### PR TITLE
Fix inventory bugs

### DIFF
--- a/src/com/base/controller/eventListeners/InventoryTooltipEventListener.java
+++ b/src/com/base/controller/eventListeners/InventoryTooltipEventListener.java
@@ -16,9 +16,11 @@ import com.base.game.combat.Attack;
 import com.base.game.combat.DamageType;
 import com.base.game.combat.Spell;
 import com.base.game.dialogue.utils.EnchantmentDialogue;
+import com.base.game.dialogue.utils.InventoryDialogue;
 import com.base.game.dialogue.utils.UtilText;
 import com.base.game.inventory.AbstractCoreItem;
 import com.base.game.inventory.InventorySlot;
+import com.base.game.inventory.ShopTransaction;
 import com.base.game.inventory.clothing.AbstractClothing;
 import com.base.game.inventory.clothing.ClothingType;
 import com.base.game.inventory.enchanting.TFEssence;
@@ -121,13 +123,19 @@ public class InventoryTooltipEventListener implements EventListener {
 				if (owner.isPlayer()) {
 					if (Main.game.getDialogueFlags().tradePartner.willBuy(item))
 						tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " offers " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
-								+ Main.game.getCurrencySymbol() + "</b> <b>" + ((int) (Main.game.getDialogueFlags().tradePartner.getBuyModifier() * item.getValue())) + "</b>" + "</div>");
+								+ Main.game.getCurrencySymbol() + "</b> <b>" + item.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier()) + "</b>" + "</div>");
 					else
 						tooltipSB.append(
 								"<div class='subTitle'>" + "<span style='color:" + Colour.TEXT_GREY.toWebHexString() + ";'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " will not buy this</span>" + "</div>");
 				} else {
-					tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " wants " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
-							+ Main.game.getCurrencySymbol() + "</b> <b>" + ((int) (Main.game.getDialogueFlags().tradePartner.getSellModifier() * item.getValue())) + "</b>" + "</div>");
+					if (InventoryDialogue.isBuyback()) {
+						tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " wants " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
+								+ Main.game.getCurrencySymbol() + "</b> <b>" + getBuybackPriceFor(item) + "</b>" + "</div>");
+					} else {
+						tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " wants " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
+								+ Main.game.getCurrencySymbol() + "</b> <b>" + item.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) + "</b>" + "</div>");
+					}
+					
 				}
 			}
 
@@ -484,12 +492,18 @@ public class InventoryTooltipEventListener implements EventListener {
 			if (owner.isPlayer()) {
 				if (Main.game.getDialogueFlags().tradePartner.willBuy(absWep))
 					tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " offers " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
-							+ Main.game.getCurrencySymbol() + "</b> <b>" + ((int) (Main.game.getDialogueFlags().tradePartner.getBuyModifier() * absWep.getValue())) + "</b>" + "</div>");
+							+ Main.game.getCurrencySymbol() + "</b> <b>" + absWep.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier()) + "</b>" + "</div>");
 				else
 					tooltipSB.append("<div class='subTitle'>" + "<span style='color:" + Colour.TEXT_GREY.toWebHexString() + ";'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " will not buy this</span>" + "</div>");
 			} else {
-				tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " wants " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
-						+ Main.game.getCurrencySymbol() + "</b> <b>" + ((int) (Main.game.getDialogueFlags().tradePartner.getSellModifier() * absWep.getValue())) + "</b>" + "</div>");
+				if (InventoryDialogue.isBuyback()) {
+					tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " wants " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
+							+ Main.game.getCurrencySymbol() + "</b> <b>" + getBuybackPriceFor(absWep) + "</b>" + "</div>");
+				} else {
+					tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " wants " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
+							+ Main.game.getCurrencySymbol() + "</b> <b>" + absWep.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) + "</b>" + "</div>");
+				}
+				
 			}
 		}
 
@@ -566,15 +580,29 @@ public class InventoryTooltipEventListener implements EventListener {
 			if (owner.isPlayer()) {
 				if (Main.game.getDialogueFlags().tradePartner.willBuy(absClothing))
 					tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " offers " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
-							+ Main.game.getCurrencySymbol() + "</b> <b>" + (absClothing.isEnchantmentKnown() ? (int) (Main.game.getDialogueFlags().tradePartner.getBuyModifier() * absClothing.getValue()) : 5) + "</b>" + "</div>");
+							+ Main.game.getCurrencySymbol() + "</b> <b>" + absClothing.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier()) + "</b>" + "</div>");
 				else
 					tooltipSB.append("<div class='subTitle'>" + "<span style='color:" + Colour.TEXT_GREY.toWebHexString() + ";'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " will not buy this</span>" + "</div>");
 			} else {
-				tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " wants " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
-						+ Main.game.getCurrencySymbol() + "</b> <b>" + (absClothing.isEnchantmentKnown() ? (int) (Main.game.getDialogueFlags().tradePartner.getSellModifier() * absClothing.getValue()) : 5) + "</b>" + "</div>");
+				if (InventoryDialogue.isBuyback()) {
+					tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " wants " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
+							+ Main.game.getCurrencySymbol() + "</b> <b>" + getBuybackPriceFor(absClothing) + "</b>" + "</div>");
+				} else {
+					tooltipSB.append("<div class='subTitle'>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " wants " + " <b style='color: " + com.base.utils.Colour.CURRENCY.toWebHexString() + ";'>"
+							+ Main.game.getCurrencySymbol() + "</b> <b>" + absClothing.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) + "</b>" + "</div>");
+				}
 			}
 		}
 
 		Main.mainController.setTooltipContent(tooltipSB.toString());
+	}
+	
+	private int getBuybackPriceFor(AbstractCoreItem item) {
+	    for (ShopTransaction s : Main.game.getPlayer().getBuybackStack()) {
+	        if (s.getAbstractItemSold() == item) {
+	            return s.getPrice();
+	        }
+	    }
+	    throw new IllegalArgumentException("That's not a buyback item");
 	}
 }

--- a/src/com/base/game/character/GameCharacter.java
+++ b/src/com/base/game/character/GameCharacter.java
@@ -2129,7 +2129,7 @@ public class GameCharacter implements Serializable {
 				addWeapon(getMainWeapon(), false);
 				s = getMainWeapon().getWeaponType().unequipText(this) + "<p style='text-align:center;'>" + addedItemToInventoryText(getMainWeapon())+"</p>";
 			}
-			inventory.unequipMainWEapon();
+			inventory.unequipMainWeapon();
 			updateInventoryListeners();
 			
 			return s;

--- a/src/com/base/game/character/GameCharacter.java
+++ b/src/com/base/game/character/GameCharacter.java
@@ -2121,10 +2121,11 @@ public class GameCharacter implements Serializable {
 				for (Entry<Attribute, Integer> e : getMainWeapon().getAttributeModifiers().entrySet())
 					incrementBonusAttribute(e.getKey(), -e.getValue());
 
+			boolean mustDropToFloor = isInventoryFull() && !hasWeapon(getMainWeapon());
 			String s;
-			if (isInventoryFull() || dropToFloor) {
+			if (mustDropToFloor || dropToFloor) {
 				Main.game.getActiveWorld().getCell(location).getInventory().addWeapon(getMainWeapon());
-				s = getMainWeapon().getWeaponType().unequipText(this) + (isInventoryFull() && !dropToFloor ? inventoryFullText() : "") + droppedItemText(getMainWeapon());
+				s = getMainWeapon().getWeaponType().unequipText(this) + (mustDropToFloor && !dropToFloor ? inventoryFullText() : "") + droppedItemText(getMainWeapon());
 			} else {
 				addWeapon(getMainWeapon(), false);
 				s = getMainWeapon().getWeaponType().unequipText(this) + "<p style='text-align:center;'>" + addedItemToInventoryText(getMainWeapon())+"</p>";
@@ -2183,10 +2184,12 @@ public class GameCharacter implements Serializable {
 			if (getOffhandWeapon().getAttributeModifiers() != null)
 				for (Entry<Attribute, Integer> e : getOffhandWeapon().getAttributeModifiers().entrySet())
 					incrementBonusAttribute(e.getKey(), -e.getValue());
+			
+			boolean mustDropToFloor = isInventoryFull() && !hasWeapon(getOffhandWeapon());
 			String s;
-			if (isInventoryFull() || dropToFloor) {
+			if (mustDropToFloor || dropToFloor) {
 				Main.game.getActiveWorld().getCell(location).getInventory().addWeapon(getOffhandWeapon());
-				s = getOffhandWeapon().getWeaponType().unequipText(this) + (isInventoryFull() && !dropToFloor ? inventoryFullText() : "") + droppedItemText(getOffhandWeapon());
+				s = getOffhandWeapon().getWeaponType().unequipText(this) + (mustDropToFloor && !dropToFloor ? inventoryFullText() : "") + droppedItemText(getOffhandWeapon());
 			} else {
 				addWeapon(getOffhandWeapon(), false);
 				s = getOffhandWeapon().getWeaponType().unequipText(this) + "<p style='text-align:center;'>" + addedItemToInventoryText(getOffhandWeapon())+"</p>";
@@ -2397,9 +2400,11 @@ public class GameCharacter implements Serializable {
 			for (Entry<Attribute, Integer> e : clothing.getAttributeModifiers().entrySet()) {
 				incrementBonusAttribute(e.getKey(), -e.getValue());
 			}
+			
+			boolean fitsIntoInventory = !isInventoryFull() || hasClothing(clothing);
 
 			// Place the clothing into inventory:
-			if (!isInventoryFull())
+			if (fitsIntoInventory)
 				addClothing(clothing, false);
 			else
 				Main.game.getActiveWorld().getCell(location).getInventory().addClothing(clothing);
@@ -2409,7 +2414,7 @@ public class GameCharacter implements Serializable {
 			return "<p style='text-align:center;'>"
 				+inventory.getEquipDescription()
 				+"</br>"
-				+ (isInventoryFull()
+				+ (!fitsIntoInventory
 						? droppedItemText(clothing)
 						: addedItemToInventoryText(clothing))
 				+ "</p>";

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -1118,7 +1118,7 @@ public class InventoryDialogue {
 						
 					} else {
 						return new Response("Buy-back",
-								"Buy back the " + item.getName() + " for " + formatAsMoney(buyBackPrice) + " and add it to your inventory.", ITEM_TRADER){
+								"Buy back the " + item.getName() + " for " + formatAsMoney(buyBackPrice) + " and add it to your inventory.", INVENTORY_MENU){
 							@Override
 							public void effects(){
 								Main.game.getTextStartStringBuilder().append(buyBackItem(item, buyBackPrice, buyBackIndex));
@@ -1219,7 +1219,7 @@ public class InventoryDialogue {
 						
 					} else {
 						return new Response("Buy-back",
-								"Buy back the " + weapon.getName() + " for " + formatAsMoney(buyBackPrice) + " and add it to your inventory.", WEAPON_TRADER){
+								"Buy back the " + weapon.getName() + " for " + formatAsMoney(buyBackPrice) + " and add it to your inventory.", INVENTORY_MENU){
 							@Override
 							public void effects(){
 								Main.game.getTextStartStringBuilder().append(buyBackWeapon(weapon, buyBackPrice, buyBackIndex));
@@ -1323,7 +1323,7 @@ public class InventoryDialogue {
 						
 					} else {
 						return new Response("Buy-back",
-								"Buy back the " + clothing.getName() + " for " + formatAsMoney(buyBackPrice) + " and add it to your inventory.", CLOTHING_TRADER){
+								"Buy back the " + clothing.getName() + " for " + formatAsMoney(buyBackPrice) + " and add it to your inventory.", INVENTORY_MENU){
 							@Override
 							public void effects(){
 								Main.game.getTextStartStringBuilder().append(buyBackClothing(clothing, buyBackPrice, buyBackIndex));

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -303,7 +303,8 @@ public class InventoryDialogue {
 			inventorySB.append("</div>");
 			if (Main.game.getActiveWorld().getCell(Main.game.getPlayer().getLocation()).getPlace() != Dominion.CITY_AUNTS_HOME
 					&& Main.game.getPlayerCell().getPlace().isItemsDisappear()
-					&& Main.game.getPlayerCell().getInventory().getInventorySlotsTaken() > 0)
+					&& Main.game.getPlayerCell().getInventory().getInventorySlotsTaken() > 0
+					&& Main.game.getDialogueFlags().tradePartner == null)
 				inventorySB.append("<p style='text-align: center; height:48px;'>" + "<b style='color:" + Colour.GENERIC_BAD.toWebHexString() + ";'>These items will disappear when you leave the area.</b>" + "</p>");
 			else
 				inventorySB.append("<p style='text-align: center; height:48px;'>-</p>");

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -553,8 +553,9 @@ public class InventoryDialogue {
 						}
 						
 					} else {
+						boolean areaFull = Main.game.isPlayerTileFull() && !Main.game.getCurrentCell().getInventory().hasItem(item);
 						if(Main.game.getPlayer().getLocationPlace().isItemsDisappear()) {
-							if(Main.game.isPlayerTileFull()) {
+							if(areaFull) {
 								return new Response("Drop", "This area is full, so you can't drop your " + item.getName() + " here!", null);
 							} else {
 								return new Response("Drop", "Drop your " + item.getName() + ".", INVENTORY_MENU){
@@ -565,7 +566,7 @@ public class InventoryDialogue {
 								};
 							}
 						} else {
-							if(Main.game.isPlayerTileFull()) {
+							if(areaFull) {
 								return new Response("Store", "This area is full, so you can't store your " + item.getName() + " here!", null);
 							} else {
 								return new Response("Store", "Store the " + item.getName() + " in this area.", INVENTORY_MENU){
@@ -604,8 +605,9 @@ public class InventoryDialogue {
 						}
 						
 					} else {
+						boolean areaFull = Main.game.isPlayerTileFull() && !Main.game.getCurrentCell().getInventory().hasItem(item);
 						if(Main.game.getPlayer().getLocationPlace().isItemsDisappear()) {
-							if(Main.game.isPlayerTileFull()) {
+							if(areaFull) {
 								return new Response("Drop all", "This area is full, so you can't drop your " + item.getName() + " here!", null);
 							} else {
 								return new Response("Drop all", "Drop all of your " + item.getName() + (item.getItemType().isPlural()?"":"s")+".", INVENTORY_MENU){
@@ -620,7 +622,7 @@ public class InventoryDialogue {
 								};
 							}
 						} else {
-							if(Main.game.isPlayerTileFull()) {
+							if(areaFull) {
 								return new Response("Store all", "This area is full, so you can't store your " + item.getName() + " here!", null);
 							} else {
 								return new Response("Store all", "Store all of your " + item.getName() + (item.getItemType().isPlural()?"":"s")+" in this area.", INVENTORY_MENU){
@@ -766,8 +768,9 @@ public class InventoryDialogue {
 					}
 					
 				} else {
+					boolean areaFull = Main.game.isPlayerTileFull() && !Main.game.getCurrentCell().getInventory().hasWeapon(weapon);
 					if(Main.game.getPlayer().getLocationPlace().isItemsDisappear()) {
-						if(Main.game.isPlayerTileFull()) {
+						if(areaFull) {
 							return new Response("Drop", "This area is full, so you can't drop your " + weapon.getName() + " here!", null);
 						} else {
 							return new Response("Drop", "Drop your " + weapon.getName() + ".", INVENTORY_MENU){
@@ -779,7 +782,7 @@ public class InventoryDialogue {
 						}
 						
 					} else {
-						if(Main.game.isPlayerTileFull()) {
+						if(areaFull) {
 							return new Response("Store", "This area is full, so you can't store your " + weapon.getName() + " here!", null);
 						} else {
 							return new Response("Store", "Store your " + weapon.getName() + " in this area.", INVENTORY_MENU){
@@ -818,8 +821,9 @@ public class InventoryDialogue {
 					}
 					
 				} else {
+					boolean areaFull = Main.game.isPlayerTileFull() && !Main.game.getCurrentCell().getInventory().hasWeapon(weapon);
 					if(Main.game.getPlayer().getLocationPlace().isItemsDisappear()) {
-						if(Main.game.isPlayerTileFull()) {
+						if(areaFull) {
 							return new Response("Drop all", "This area is full, so you can't drop your " + weapon.getName() + "s here!", null);
 						} else {
 							return new Response("Drop all", "Drop all of your " + weapon.getName() + "s.", INVENTORY_MENU){
@@ -835,7 +839,7 @@ public class InventoryDialogue {
 						}
 						
 					} else {
-						if(Main.game.isPlayerTileFull()) {
+						if(areaFull) {
 							return new Response("Store all", "This area is full, so you can't store your " + weapon.getName() + "s here!", null);
 						} else {
 							return new Response("Store all", "Store all of your " + weapon.getName() + "s in this area.", INVENTORY_MENU){
@@ -938,8 +942,9 @@ public class InventoryDialogue {
 					}
 					
 				} else {
+					boolean areaFull = Main.game.isPlayerTileFull() && !Main.game.getCurrentCell().getInventory().hasClothing(clothing);
 					if(Main.game.getPlayer().getLocationPlace().isItemsDisappear()) {
-						if(Main.game.isPlayerTileFull()) {
+						if(areaFull) {
 							return new Response("Drop", "This area is full, so you can't drop your " + clothing.getName() + " here!", null);
 						} else {
 							return new Response("Drop", "Drop your " + clothing.getName() + ".", INVENTORY_MENU){
@@ -951,7 +956,7 @@ public class InventoryDialogue {
 						}
 						
 					} else {
-						if(Main.game.isPlayerTileFull()) {
+						if(areaFull) {
 							return new Response("Store", "This area is full, so you can't store your " + clothing.getName() + " here!", null);
 						} else {
 							return new Response("Store", "Store your " + clothing.getName() + " in this area.", INVENTORY_MENU){
@@ -990,8 +995,9 @@ public class InventoryDialogue {
 					}
 					
 				} else {
+					boolean areaFull = Main.game.isPlayerTileFull() && !Main.game.getCurrentCell().getInventory().hasClothing(clothing);
 					if(Main.game.getPlayer().getLocationPlace().isItemsDisappear()) {
-						if(Main.game.isPlayerTileFull()) {
+						if(areaFull) {
 							return new Response("Drop all", "This area is full, so you can't drop your " + clothing.getName() + " here!", null);
 						} else {
 							return new Response("Drop all", "Drop all of your " + clothing.getName() + "s.", INVENTORY_MENU){
@@ -1007,7 +1013,7 @@ public class InventoryDialogue {
 						}
 						
 					} else {
-						if(Main.game.isPlayerTileFull()) {
+						if(areaFull) {
 							return new Response("Store all", "This area is full, so you can't store your " + clothing.getName() + " here!", null);
 						} else {
 							return new Response("Store all", "Store all of your " + clothing.getName() + "s in this area.", INVENTORY_MENU){
@@ -1713,8 +1719,9 @@ public class InventoryDialogue {
 
 			// Drop item:
 			} else if (index == 2) {
+				boolean areaFull = Main.game.isPlayerTileFull() && !Main.game.getCurrentCell().getInventory().hasWeapon(weaponEquipped);
 				if(Main.game.getPlayer().getLocationPlace().isItemsDisappear()) {
-					if(Main.game.isPlayerTileFull()) {
+					if(areaFull) {
 						return new Response("Drop", "This area is full, so you can't drop your " + weaponEquipped.getName() + " here!", null);
 					} else {
 						return new Response("Drop", "Drop your " + weaponEquipped.getName() + ".", INVENTORY_MENU){
@@ -1731,7 +1738,7 @@ public class InventoryDialogue {
 					}
 					
 				} else {
-					if(Main.game.isPlayerTileFull()) {
+					if(areaFull) {
 						return new Response("Store", "This area is full, so you can't store your " + weaponEquipped.getName() + " here!", null);
 					} else {
 						return new Response("Store", "Store your " + weaponEquipped.getName() + " in this area.", INVENTORY_MENU){
@@ -1912,6 +1919,7 @@ public class InventoryDialogue {
 					}
 					
 				} else if (index == 2) {
+					boolean areaFull = Main.game.isPlayerTileFull() && !Main.game.getCurrentCell().getInventory().hasClothing(clothingEquipped);
 					if(Main.game.getPlayer().getLocationPlace().isItemsDisappear()) {
 						if (clothingEquipped.isSealed()) {
 							return new Response("Drop",
@@ -1919,7 +1927,7 @@ public class InventoryDialogue {
 									+ " because " + (clothingEquipped.getClothingType().isPlural() ? "they've" : "it's")
 									+ " been jinxed!</span>", null);
 							
-						} else if(Main.game.isPlayerTileFull()) {
+						} else if(areaFull) {
 							return new Response("Drop", "This area is full, so you can't drop your " + clothingEquipped.getName() + " here!", null);
 							
 						} else {
@@ -1939,7 +1947,7 @@ public class InventoryDialogue {
 									+ " because " + (clothingEquipped.getClothingType().isPlural() ? "they've" : "it's")
 									+ " been jinxed!</span>", null);
 							
-						} else if(Main.game.isPlayerTileFull()) {
+						} else if(areaFull) {
 							return new Response("Store", "This area is full, so you can't store your " + clothingEquipped.getName() + " here!", null);
 							
 						} else {

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -1692,7 +1692,7 @@ public class InventoryDialogue {
 		public Response getResponse(int index) {
 			// Unequip item:
 			if (index == 1) {
-				if (Main.game.getPlayer().isInventoryFull())
+				if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasWeapon(weaponEquipped))
 					return new Response("Unequip", "Your inventory is full, so you can't unequip the " + weaponEquipped.getName() + " into your inventory!", null);
 				else
 					return new Response("Unequip", "Unequip the " + weaponEquipped.getName() + ".", INVENTORY_MENU){
@@ -1896,7 +1896,7 @@ public class InventoryDialogue {
 								"<span style='color:" + Colour.ATTRIBUTE_CORRUPTION.toWebHexString() + ";'>You can't unequip the " + clothingEquipped.getName() + " because " + (clothingEquipped.getClothingType().isPlural() ? "they've" : "it's")
 								+ " been jinxed!</span>", null);
 						
-					} else if (Main.game.getPlayer().isInventoryFull()) {
+					} else if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasClothing(clothingEquipped)) {
 						return new Response("Unequip", "Your inventory is full, so you can't unequip the " + clothingEquipped.getName() + " into your inventory!", null);
 					} else {
 						return new Response("Unequip", "Unequip the " + clothingEquipped.getName() + " and add " + (clothingEquipped.getClothingType().isPlural() ? "them" : "it") + " to your inventory.", INVENTORY_MENU){

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -153,7 +153,7 @@ public class InventoryDialogue {
 	
 						if (itemBuyback != null) {
 							// Clothing:
-							int itemPrice = (int) (Main.game.getPlayer().getBuybackStack().get(i).getPrice());
+							int itemPrice = Main.game.getPlayer().getBuybackStack().get(i).getPrice();
 							if (itemBuyback instanceof AbstractClothing) {
 								inventorySB.append(getBuybackItemPanel(itemBuyback, "CLOTHING_BUYBACK_" + i, itemPrice));
 	
@@ -795,15 +795,13 @@ public class InventoryDialogue {
 				}
 				
 			} else if (index == 4) {
-				if(Main.game.getPlayer().hasQuest(QuestLine.SIDE_JINXED_CLOTHING)){
-					if(Main.game.getPlayer().isQuestProgressGreaterThan(QuestLine.SIDE_JINXED_CLOTHING, Quest.SIDE_JINXED_LILAYA_HELP)){
-						return new Response("Remove jinx", "Proceed to the jinxed clothing choice menu.", REMOVE_JINX){
-							@Override
-							public void effects() {
-								jinxRemovalFromFloor=false;
-							}
-						};
-					}
+				if(Main.game.getPlayer().hasQuest(QuestLine.SIDE_JINXED_CLOTHING) && Main.game.getPlayer().isQuestProgressGreaterThan(QuestLine.SIDE_JINXED_CLOTHING, Quest.SIDE_JINXED_LILAYA_HELP)){
+					return new Response("Remove jinx", "Proceed to the jinxed clothing choice menu.", REMOVE_JINX){
+						@Override
+						public void effects() {
+							jinxRemovalFromFloor = false;
+						}
+					};
 				}
 				
 				return null;
@@ -1967,7 +1965,7 @@ public class InventoryDialogue {
 
 		inventorySB.append("<div class='inventory-container'>");
 
-		if (jinxedClothing.size() > 0) {
+		if (!jinxedClothing.isEmpty()) {
 			for (int i = 0; i < jinxedClothing.size(); i++) {
 				inventorySB.append("<div class='item-background jinxed'>" + jinxedClothing.get(i).getSVGString());
 				inventorySB.append("<div class='overlay' id='JINXED_" + i + "'></div>" + "</div>");

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -414,7 +414,7 @@ public class InventoryDialogue {
 			return "<div class='inventoryImage'>" + item.getSVGString() + "</div>" + item.getDescription() + item.getExtraDescription(Main.game.getPlayer(), Main.game.getPlayer())
 					+ (Main.game.getDialogueFlags().tradePartner != null ? 
 							Main.game.getDialogueFlags().tradePartner.willBuy(item) ? 
-									"<p>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " will buy it for " + formatAsMoney((int) (item.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier())) + ".</p>" 
+									"<p>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " will buy it for " + formatAsMoney(item.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier())) + ".</p>" 
 							: Main.game.getDialogueFlags().tradePartner.getName("The") + " doesn't want to buy this."
 						: "");
 		}
@@ -524,7 +524,7 @@ public class InventoryDialogue {
 				}  else if (index == 2) {
 					if(Main.game.getDialogueFlags().tradePartner!=null) {
 						if (Main.game.getDialogueFlags().tradePartner.willBuy(item)) {
-							int sellPrice = (int) (item.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier());
+							int sellPrice = item.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier());
 							return new Response("Sell (" + formatAsMoney(sellPrice, "span") + ")", "Sell the " + item.getName() + " for " + formatAsMoney(sellPrice) + ".", INVENTORY_MENU){
 								@Override
 								public void effects(){
@@ -566,7 +566,7 @@ public class InventoryDialogue {
 				} else if (index == 3 && Main.game.getPlayer().getItemCount(item)>1) {
 					if(Main.game.getDialogueFlags().tradePartner!=null) {
 						if (Main.game.getDialogueFlags().tradePartner.willBuy(item)) {
-							int sellPrice = (int) (item.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier() * Main.game.getPlayer().getItemCount(item));
+							int sellPrice = item.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier()) * Main.game.getPlayer().getItemCount(item);
 							return new Response("Sell all (" + formatAsMoney(sellPrice, "span") + ")",
 									"Sell all of your " + item.getName() + (item.getItemType().isPlural()?"":"s")+" for " + formatAsMoney(sellPrice) + ".", INVENTORY_MENU){
 								@Override
@@ -714,7 +714,7 @@ public class InventoryDialogue {
 			return "<div class='inventoryImage'>" + weapon.getSVGString() + "</div>" + weapon.getDescription()
 					+ (Main.game.getDialogueFlags().tradePartner != null ? 
 							Main.game.getDialogueFlags().tradePartner.willBuy(weapon) ? 
-									"<p>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " will buy it for " + formatAsMoney((int) (weapon.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier())) + ".</p>" 
+									"<p>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " will buy it for " + formatAsMoney(weapon.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier())) + ".</p>" 
 							: Main.game.getDialogueFlags().tradePartner.getName("The") + " doesn't want to buy this."
 						: "");
 		}
@@ -738,7 +738,7 @@ public class InventoryDialogue {
 			} else if (index == 2) {
 				if(Main.game.getDialogueFlags().tradePartner!=null) {
 					if (Main.game.getDialogueFlags().tradePartner.willBuy(weapon)) {
-						int sellPrice = (int) (weapon.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier());
+						int sellPrice = weapon.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier());
 						return new Response("Sell (" + formatAsMoney(sellPrice, "span") + ")",
 								"Sell the " + weapon.getName() + " for " + formatAsMoney(sellPrice) + ".", INVENTORY_MENU){
 							@Override
@@ -782,7 +782,7 @@ public class InventoryDialogue {
 			} else if (index == 3 && Main.game.getPlayer().getWeaponCount(weapon)>1) {
 				if(Main.game.getDialogueFlags().tradePartner!=null) {
 					if (Main.game.getDialogueFlags().tradePartner.willBuy(weapon)) {
-						int sellPrice = (int) (weapon.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier() * Main.game.getPlayer().getWeaponCount(weapon));
+						int sellPrice = weapon.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier()) * Main.game.getPlayer().getWeaponCount(weapon);
 						return new Response("Sell all (" + formatAsMoney(sellPrice, "span") + ")",
 								"Sell all of your " + weapon.getName() +"s for " + formatAsMoney(sellPrice) + ".", INVENTORY_MENU){
 							@Override
@@ -891,7 +891,7 @@ public class InventoryDialogue {
 			return "<div class='inventoryImage'>" + clothing.getSVGString() + "</div>" + clothing.getDescription() + clothing.clothingExtraInformation(null)
 					+ (Main.game.getDialogueFlags().tradePartner != null ? 
 							Main.game.getDialogueFlags().tradePartner.willBuy(clothing) ? 
-									"<p>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " will buy it for " + formatAsMoney((int) (clothing.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier())) + ".</p>" 
+									"<p>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " will buy it for " + formatAsMoney(clothing.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier())) + ".</p>" 
 							: Main.game.getDialogueFlags().tradePartner.getName("The") + " doesn't want to buy this."
 						: "");
 		}
@@ -912,7 +912,7 @@ public class InventoryDialogue {
 			} else if (index == 2) {
 				if(Main.game.getDialogueFlags().tradePartner!=null) {
 					if (Main.game.getDialogueFlags().tradePartner.willBuy(clothing)) {
-						int itemPrice = (int) (clothing.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier());
+						int itemPrice = clothing.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier());
 						return new Response("Sell (" + formatAsMoney(itemPrice, "span") + ")",
 								"Sell your " + clothing.getName() + " for " + formatAsMoney(itemPrice) + ".", INVENTORY_MENU){
 							@Override
@@ -956,7 +956,7 @@ public class InventoryDialogue {
 			} else if (index == 3 && Main.game.getPlayer().getClothingCount(clothing)>1) {
 				if(Main.game.getDialogueFlags().tradePartner!=null) {
 					if (Main.game.getDialogueFlags().tradePartner.willBuy(clothing)) {
-						int itemPrice = (int) (clothing.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier() * Main.game.getPlayer().getClothingCount(clothing));
+						int itemPrice = clothing.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier()) * Main.game.getPlayer().getClothingCount(clothing);
 						return new Response("Sell all (" + formatAsMoney(itemPrice, "span") + ")",
 								"Sell all of your " + clothing.getName() +" for " + formatAsMoney(itemPrice) + ".", INVENTORY_MENU){
 							@Override
@@ -1094,7 +1094,7 @@ public class InventoryDialogue {
 
 		@Override
 		public String getContent() {
-			int itemPrice = buyback ? buyBackPrice : (int) (item.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier());
+			int itemPrice = buyback ? buyBackPrice : item.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
 			return "<div class='inventoryImage'>" + item.getSVGString() + "</div>" + "<p>" + item.getDescription() + "</p>" + item.getExtraDescription(Main.game.getPlayer(), Main.game.getPlayer()) + "<p>" + Main.game.getDialogueFlags().tradePartner.getName("The")
 					+ " will sell it to you for " + formatAsMoney(itemPrice) + "." + "</p>";
 		}
@@ -1121,7 +1121,7 @@ public class InventoryDialogue {
 					}
 					
 				} else {
-					int itemPrice = (int) (item.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier());
+					int itemPrice = item.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
 					if (Main.game.getPlayer().isInventoryFull()) {
 						return new Response("Buy", "Your inventory is full, so you can't buy the " + item.getName() + "!", null);
 						
@@ -1141,7 +1141,7 @@ public class InventoryDialogue {
 				
 			} else if (index == 2 && Main.game.getDialogueFlags().tradePartner.getItemCount(item)>1) {
 				if (!buyback) {
-					int totalPrice = (int) ((item.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier()) * Main.game.getDialogueFlags().tradePartner.getItemCount(item));
+					int totalPrice = item.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) * Main.game.getDialogueFlags().tradePartner.getItemCount(item);
 					if (Main.game.getPlayer().isInventoryFull()) {
 						return new Response("Buy all", "Your inventory is full, so you can't buy the " + item.getName() + "!", null);
 						
@@ -1195,7 +1195,7 @@ public class InventoryDialogue {
 
 		@Override
 		public String getContent() {
-			int itemPrice = buyback ? buyBackPrice : (int) (weapon.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier());
+			int itemPrice = buyback ? buyBackPrice : weapon.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
 			return "<div class='inventoryImage'>" + weapon.getSVGString() + "</div>" + weapon.getDescription() + "<p>" + Main.game.getDialogueFlags().tradePartner.getName("The") + " will sell it to you for " 
 					+ formatAsMoney(itemPrice) + ".</p>";
 		}
@@ -1222,7 +1222,7 @@ public class InventoryDialogue {
 					}
 					
 				} else {
-					int itemPrice = (int) (weapon.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier());
+					int itemPrice = weapon.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
 					if (Main.game.getPlayer().isInventoryFull()) {
 						return new Response("Buy", "Your inventory is full, so you can't buy the " + weapon.getName() + "!", null);
 						
@@ -1242,7 +1242,7 @@ public class InventoryDialogue {
 				
 			} else if (index == 2 && Main.game.getDialogueFlags().tradePartner.getWeaponCount(weapon)>1) {
 				if (!buyback) {
-					int totalPrice = (int) ((weapon.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier()) * Main.game.getDialogueFlags().tradePartner.getWeaponCount(weapon));
+					int totalPrice = weapon.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) * Main.game.getDialogueFlags().tradePartner.getWeaponCount(weapon);
 					if (Main.game.getPlayer().isInventoryFull()) {
 						return new Response("Buy all", "Your inventory is full, so you can't buy the " + weapon.getName() + "!", null);
 						
@@ -1299,7 +1299,7 @@ public class InventoryDialogue {
 
 		@Override
 		public String getContent() {
-			int itemPrice = buyback ? buyBackPrice : (int) (clothing.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier());
+			int itemPrice = buyback ? buyBackPrice : clothing.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
 			return "<div class='inventoryImage'>" + clothing.getSVGString() + "</div>" + clothing.getDescription() + clothing.clothingExtraInformation(null) + "<p>" + Main.game.getDialogueFlags().tradePartner.getName("The")
 					+ " will sell it to you for " + formatAsMoney(itemPrice) + ".</p>";
 		}
@@ -1326,7 +1326,7 @@ public class InventoryDialogue {
 					}
 					
 				} else {
-					int itemPrice = (int) (clothing.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier());
+					int itemPrice = clothing.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
 					if (Main.game.getPlayer().isInventoryFull()) {
 						return new Response("Buy", "Your inventory is full, so you can't buy the " + clothing.getName() + "!", null);
 						
@@ -1346,7 +1346,7 @@ public class InventoryDialogue {
 				
 			} else if (index == 2 && Main.game.getDialogueFlags().tradePartner.getClothingCount(clothing)>1) {
 				if (!buyback) {
-					int totalPrice = (int) ((clothing.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier()) * Main.game.getDialogueFlags().tradePartner.getClothingCount(clothing));
+					int totalPrice = clothing.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) * Main.game.getDialogueFlags().tradePartner.getClothingCount(clothing);
 					if (Main.game.getPlayer().isInventoryFull()) {
 						return new Response("Buy all", "Your inventory is full, so you can't buy the " + clothing.getName() + "!", null);
 						
@@ -2334,7 +2334,7 @@ public class InventoryDialogue {
 
 	// Items:
 	public static String buyItem(AbstractItem item) {
-		int itemPrice = (int) (item.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier());
+		int itemPrice = item.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
 		if (Main.game.getPlayer().getMoney() < itemPrice)
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
@@ -2356,7 +2356,7 @@ public class InventoryDialogue {
 	
 	public static String buyAllItems(AbstractItem item) {
 		int itemCount = Main.game.getDialogueFlags().tradePartner.getItemCount(item);
-		int totalPrice = (int) (item.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier() * itemCount);
+		int totalPrice = item.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) * itemCount;
 		if (Main.game.getPlayer().getMoney() < totalPrice)
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
@@ -2409,7 +2409,7 @@ public class InventoryDialogue {
 	}
 
 	public static String sellItem(AbstractItem item) {
-		int itemPrice = (int) (item.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier());
+		int itemPrice = item.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier());
 		Main.game.getPlayer().getBuybackStack().push(new ShopTransaction(item, itemPrice));
 		Main.game.getPlayer().removeItem(item);
 		Main.game.getPlayer().incrementMoney(itemPrice);
@@ -2424,7 +2424,7 @@ public class InventoryDialogue {
 
 	// Clothing:
 	public static String buyClothing(AbstractClothing clothing) {
-		int itemPrice = (int) (clothing.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier());
+		int itemPrice = clothing.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
 		if (Main.game.getPlayer().getMoney() < itemPrice) {
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
@@ -2448,7 +2448,7 @@ public class InventoryDialogue {
 	
 	public static String buyAllClothing(AbstractClothing clothing) {
 		int clothingCount = Main.game.getDialogueFlags().tradePartner.getClothingCount(clothing);
-		int totalPrice = (int) (clothing.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier() * clothingCount);
+		int totalPrice = clothing.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) * clothingCount;
 		if (Main.game.getPlayer().getMoney() < totalPrice) {
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
@@ -2509,7 +2509,7 @@ public class InventoryDialogue {
 	}
 
 	public static String sellClothing(AbstractClothing clothing) {
-		int itemPrice = (int) (clothing.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier());
+		int itemPrice = clothing.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier());
 		Main.game.getPlayer().getBuybackStack().push(new ShopTransaction(clothing, itemPrice));
 		Main.game.getPlayer().removeClothing(clothing);
 		Main.game.getPlayer().incrementMoney(itemPrice);
@@ -2524,7 +2524,7 @@ public class InventoryDialogue {
 
 	// Weapons:
 	public static String buyWeapon(AbstractWeapon weapon) {
-		int itemPrice = (int) (weapon.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier());
+		int itemPrice = weapon.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
 		if (Main.game.getPlayer().getMoney() < itemPrice)
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
@@ -2546,7 +2546,7 @@ public class InventoryDialogue {
 	
 	public static String buyAllWeapons(AbstractWeapon weapon) {
 		int weaponCount = Main.game.getDialogueFlags().tradePartner.getWeaponCount(weapon);
-		int totalPrice = (int) (weapon.getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier() * weaponCount);
+		int totalPrice = weapon.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) * weaponCount;
 		if (Main.game.getPlayer().getMoney() < totalPrice)
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
@@ -2599,7 +2599,7 @@ public class InventoryDialogue {
 	}
 
 	public static String sellWeapon(AbstractWeapon weapon) {
-		int itemPrice = (int) (weapon.getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier());
+		int itemPrice = weapon.getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier());
 		Main.game.getPlayer().getBuybackStack().push(new ShopTransaction(weapon, itemPrice));
 		Main.game.getPlayer().removeWeapon(weapon);
 		Main.game.getPlayer().incrementMoney(itemPrice);

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -1045,11 +1045,14 @@ public class InventoryDialogue {
 								"Have the " + clothing.getName() + " identified for " + formatAsMoney(IDENTIFICATION_PRICE, "span") + ".", INVENTORY_MENU){
 						@Override
 						public void effects(){
+							Main.game.getPlayer().removeClothing(clothing);
 							Main.game.getTextStartStringBuilder().append(
 									"<p style='text-align:center;'>" + "You hand over " + formatAsMoney(IDENTIFICATION_PRICE) + " to "
 											+Main.game.getDialogueFlags().tradePartner.getName("the")+", who promptly identifies your "+clothing.getName()+"."
 									+ "</p>"
 									+clothing.setEnchantmentKnown(true));
+							
+							Main.game.getPlayer().addClothing(clothing, false);
 							Main.game.getPlayer().incrementMoney(-IDENTIFICATION_PRICE);
 						}
 					};

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -1103,9 +1103,10 @@ public class InventoryDialogue {
 		@Override
 		public Response getResponse(int index) {
 			// Use item:
+			boolean noSlotForItem = Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasItem(item);
 			if (index == 1) {
 				if (buyback) {
-					if (Main.game.getPlayer().isInventoryFull()) {
+					if (noSlotForItem) {
 						return new Response("Buy-back", "Your inventory is full, so you can't buy back the " + item.getName() + "!", null);
 						
 					} else if (Main.game.getPlayer().getMoney() < buyBackPrice) {
@@ -1123,7 +1124,7 @@ public class InventoryDialogue {
 					
 				} else {
 					int itemPrice = item.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
-					if (Main.game.getPlayer().isInventoryFull()) {
+					if (noSlotForItem) {
 						return new Response("Buy", "Your inventory is full, so you can't buy the " + item.getName() + "!", null);
 						
 					} else if (Main.game.getPlayer().getMoney() < itemPrice) {
@@ -1143,7 +1144,7 @@ public class InventoryDialogue {
 			} else if (index == 2 && Main.game.getDialogueFlags().tradePartner.getItemCount(item)>1) {
 				if (!buyback) {
 					int totalPrice = item.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) * Main.game.getDialogueFlags().tradePartner.getItemCount(item);
-					if (Main.game.getPlayer().isInventoryFull()) {
+					if (noSlotForItem) {
 						return new Response("Buy all", "Your inventory is full, so you can't buy the " + item.getName() + "!", null);
 						
 					} else if (Main.game.getPlayer().getMoney() < totalPrice) {
@@ -1204,9 +1205,10 @@ public class InventoryDialogue {
 		@Override
 		public Response getResponse(int index) {
 			// Use item:
+			boolean noSlotForItem = Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasWeapon(weapon);
 			if (index == 1) {
 				if (buyback) {
-					if (Main.game.getPlayer().isInventoryFull()) {
+					if (noSlotForItem) {
 						return new Response("Buy-back", "Your inventory is full, so you can't buy back the " + weapon.getName() + "!", null);
 						
 					} else if (Main.game.getPlayer().getMoney() < buyBackPrice) {
@@ -1224,7 +1226,7 @@ public class InventoryDialogue {
 					
 				} else {
 					int itemPrice = weapon.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
-					if (Main.game.getPlayer().isInventoryFull()) {
+					if (noSlotForItem) {
 						return new Response("Buy", "Your inventory is full, so you can't buy the " + weapon.getName() + "!", null);
 						
 					} else if (Main.game.getPlayer().getMoney() < itemPrice) {
@@ -1244,7 +1246,7 @@ public class InventoryDialogue {
 			} else if (index == 2 && Main.game.getDialogueFlags().tradePartner.getWeaponCount(weapon)>1) {
 				if (!buyback) {
 					int totalPrice = weapon.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) * Main.game.getDialogueFlags().tradePartner.getWeaponCount(weapon);
-					if (Main.game.getPlayer().isInventoryFull()) {
+					if (noSlotForItem) {
 						return new Response("Buy all", "Your inventory is full, so you can't buy the " + weapon.getName() + "!", null);
 						
 					} else if (Main.game.getPlayer().getMoney() < totalPrice) {
@@ -1308,9 +1310,10 @@ public class InventoryDialogue {
 		@Override
 		public Response getResponse(int index) {
 			// Use item:
+			boolean noSlotForItem = Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasClothing(clothing);
 			if (index == 1) {
 				if (buyback) {
-					if (Main.game.getPlayer().isInventoryFull()) {
+					if (noSlotForItem) {
 						return new Response("Buy-back", "Your inventory is full, so you can't buy back the " + clothing.getName() + "!", null);
 						
 					} else if (Main.game.getPlayer().getMoney() < buyBackPrice) {
@@ -1328,7 +1331,7 @@ public class InventoryDialogue {
 					
 				} else {
 					int itemPrice = clothing.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier());
-					if (Main.game.getPlayer().isInventoryFull()) {
+					if (noSlotForItem) {
 						return new Response("Buy", "Your inventory is full, so you can't buy the " + clothing.getName() + "!", null);
 						
 					} else if (Main.game.getPlayer().getMoney() < itemPrice) {
@@ -1348,7 +1351,7 @@ public class InventoryDialogue {
 			} else if (index == 2 && Main.game.getDialogueFlags().tradePartner.getClothingCount(clothing)>1) {
 				if (!buyback) {
 					int totalPrice = clothing.getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()) * Main.game.getDialogueFlags().tradePartner.getClothingCount(clothing);
-					if (Main.game.getPlayer().isInventoryFull()) {
+					if (noSlotForItem) {
 						return new Response("Buy all", "Your inventory is full, so you can't buy the " + clothing.getName() + "!", null);
 						
 					} else if (Main.game.getPlayer().getMoney() < totalPrice) {
@@ -2339,7 +2342,7 @@ public class InventoryDialogue {
 		if (Main.game.getPlayer().getMoney() < itemPrice)
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
-		else if (Main.game.getPlayer().isInventoryFull())
+		else if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasItem(item))
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>Your inventory is full, so you can't buy this!</p>";
 
 		else {
@@ -2361,7 +2364,7 @@ public class InventoryDialogue {
 		if (Main.game.getPlayer().getMoney() < totalPrice)
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
-		else if (Main.game.getPlayer().isInventoryFull())
+		else if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasItem(item))
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>Your inventory is full, so you can't buy this!</p>";
 
 		else {
@@ -2394,7 +2397,7 @@ public class InventoryDialogue {
 		if (Main.game.getPlayer().getMoney() < price)
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
-		else if (Main.game.getPlayer().isInventoryFull())
+		else if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasItem(item))
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>Your inventory is full, so you can't buy this!</p>";
 
 		else {
@@ -2429,7 +2432,7 @@ public class InventoryDialogue {
 		if (Main.game.getPlayer().getMoney() < itemPrice) {
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
-		} else if (Main.game.getPlayer().isInventoryFull()) {
+		} else if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasClothing(clothing)) {
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>Your inventory is full, so you can't buy this!</p>";
 
 		} else {
@@ -2453,7 +2456,7 @@ public class InventoryDialogue {
 		if (Main.game.getPlayer().getMoney() < totalPrice) {
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
-		} else if (Main.game.getPlayer().isInventoryFull()) {
+		} else if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasClothing(clothing)) {
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>Your inventory is full, so you can't buy this!</p>";
 
 		} else {
@@ -2494,7 +2497,7 @@ public class InventoryDialogue {
 		if (Main.game.getPlayer().getMoney() < price)
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
-		else if (Main.game.getPlayer().isInventoryFull())
+		else if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasClothing(clothing))
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>Your inventory is full, so you can't buy this!</p>";
 
 		else {
@@ -2529,7 +2532,7 @@ public class InventoryDialogue {
 		if (Main.game.getPlayer().getMoney() < itemPrice)
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
-		else if (Main.game.getPlayer().isInventoryFull())
+		else if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasWeapon(weapon))
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>Your inventory is full, so you can't buy this!</p>";
 
 		else {
@@ -2551,7 +2554,7 @@ public class InventoryDialogue {
 		if (Main.game.getPlayer().getMoney() < totalPrice)
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
-		else if (Main.game.getPlayer().isInventoryFull())
+		else if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasWeapon(weapon))
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>Your inventory is full, so you can't buy this!</p>";
 
 		else {
@@ -2584,7 +2587,7 @@ public class InventoryDialogue {
 		if (Main.game.getPlayer().getMoney() < price)
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>You don't have enough money to buy this!</p>";
 
-		else if (Main.game.getPlayer().isInventoryFull())
+		else if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasWeapon(weapon))
 			return "<p style='colour:" + Colour.GENERIC_BAD.toWebHexString() + ";'>Your inventory is full, so you can't buy this!</p>";
 
 		else {

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -19,7 +19,6 @@ import com.base.game.dialogue.responses.Response;
 import com.base.game.dialogue.responses.ResponseEffectsOnly;
 import com.base.game.inventory.AbstractCoreItem;
 import com.base.game.inventory.InventorySlot;
-import com.base.game.inventory.Rarity;
 import com.base.game.inventory.ShopTransaction;
 import com.base.game.inventory.clothing.AbstractClothing;
 import com.base.game.inventory.enchanting.TFEssence;
@@ -71,7 +70,7 @@ public class InventoryDialogue {
 		if (Main.game.getPlayer().getWeaponCount() > 0) {
 			for (Entry<AbstractWeapon, Integer> entry : Main.game.getPlayer().getMapOfDuplicateWeapons().entrySet()) {
 				inventorySB.append("<div class='item-background "
-						+ getClassFromRarity(entry.getKey().getRarity()) + "'>" + entry.getKey().getSVGString()
+						+ entry.getKey().getDisplayRarity() + "'>" + entry.getKey().getSVGString()
 						+ "<div class='overlay"
 						+ (Main.game.getDialogueFlags().tradePartner!=null 
 							? (Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? "" : " dark")
@@ -89,14 +88,7 @@ public class InventoryDialogue {
 		// Clothing:
 		if (Main.game.getPlayer().getClothingCount() > 0) {
 			for (Entry<AbstractClothing, Integer> entry : Main.game.getPlayer().getMapOfDuplicateClothing().entrySet()) {
-				inventorySB.append("<div class='item-background ");
-				
-				if (entry.getKey().isEnchantmentKnown()) {
-					inventorySB.append(getClassFromRarity(entry.getKey().getRarity()));
-				} else {
-					inventorySB.append("unknown");
-				}
-				inventorySB.append("'>");
+				inventorySB.append("<div class='item-background " + entry.getKey().getDisplayRarity() + "'>");
 
 				inventorySB.append(entry.getKey().getSVGString() + "<div class='overlay"
 							+ (Main.game.getDialogueFlags().tradePartner!=null
@@ -118,7 +110,7 @@ public class InventoryDialogue {
 		if (Main.game.getPlayer().getItemCount() > 0) {
 			for (Entry<AbstractItem, Integer> entry : Main.game.getPlayer().getMapOfDuplicateItems().entrySet()) {
 				inventorySB.append("<div class='item-background "
-						+ getClassFromRarity(entry.getKey().getRarity()) + "'>" + entry.getKey().getSVGString()
+						+ entry.getKey().getDisplayRarity() + "'>" + entry.getKey().getSVGString()
 						+ "<div class='overlay"
 						+ (Main.game.getDialogueFlags().tradePartner!=null
 										? (Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? ""
@@ -145,7 +137,7 @@ public class InventoryDialogue {
 		for(TFEssence essence : TFEssence.values()) {
 			inventorySB.append(
 					"<div style='width:28px; display:inline-block; margin:0 4px 0 4px;'>"
-						+ "<div class='item-inline " + getClassFromRarity(essence.getRarity()) + "'>"
+						+ "<div class='item-inline " + essence.getRarity().getName() + "'>"
 							+ essence.getSVGString()
 							+ "<div class='overlay no-pointer' id='ESSENCE_"+essence.hashCode()+"'></div>"
 						+ "</div>"
@@ -234,7 +226,7 @@ public class InventoryDialogue {
 					// Weapons:
 					if (Main.game.getDialogueFlags().tradePartner.getWeaponCount() > 0) {
 						for (Entry<AbstractWeapon, Integer> entry : Main.game.getDialogueFlags().tradePartner.getMapOfDuplicateWeapons().entrySet()) {
-							inventorySB.append("<div class='item-background " + getClassFromRarity(entry.getKey().getRarity()) + "'>" + entry.getKey().getSVGString());
+							inventorySB.append("<div class='item-background " + entry.getKey().getDisplayRarity() + "'>" + entry.getKey().getSVGString());
 							inventorySB.append("<div class='overlay' id='WEAPON_TRADER_" + entry.getKey().hashCode() + "'>"
 									+ getItemCountDiv(entry.getValue())
 									+ getItemPriceDiv((int) (entry.getKey().getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier()))
@@ -245,7 +237,7 @@ public class InventoryDialogue {
 					// Clothing:
 					if (Main.game.getDialogueFlags().tradePartner.getClothingCount() > 0) {
 						for (Entry<AbstractClothing, Integer> entry : Main.game.getDialogueFlags().tradePartner.getMapOfDuplicateClothing().entrySet()) {
-							inventorySB.append("<div class='item-background " + (entry.getKey().isEnchantmentKnown() ? getClassFromRarity(entry.getKey().getRarity()) : "unknown") + "'>"
+							inventorySB.append("<div class='item-background " + entry.getKey().getDisplayRarity() + "'>"
 									+ entry.getKey().getSVGString() + "<div class='overlay' id='CLOTHING_TRADER_" + entry.getKey().hashCode() + "'>"
 											+ getItemCountDiv(entry.getValue())
 											+ getItemPriceDiv(!entry.getKey().getAttributeModifiers().isEmpty() && !entry.getKey().isEnchantmentKnown() ? 5
@@ -256,7 +248,7 @@ public class InventoryDialogue {
 					// Items:
 					if (Main.game.getDialogueFlags().tradePartner.getItemCount() > 0) {
 						for (Entry<AbstractItem, Integer> entry : Main.game.getDialogueFlags().tradePartner.getMapOfDuplicateItems().entrySet()) {
-							inventorySB.append("<div class='item-background " + getClassFromRarity(entry.getKey().getRarity()) + "'>" + entry.getKey().getSVGString()
+							inventorySB.append("<div class='item-background " + entry.getKey().getDisplayRarity() + "'>" + entry.getKey().getSVGString()
 											+ "<div class='overlay' id='ITEM_TRADER_" + entry.getKey().hashCode() + "'>"
 													+ getItemCountDiv(entry.getValue())
 													+ getItemPriceDiv((int) (entry.getKey().getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier()))
@@ -275,7 +267,7 @@ public class InventoryDialogue {
 				// Weapons:
 				if (Main.game.getPlayerCell().getInventory().getWeaponCount() > 0) {
 					for (Entry<AbstractWeapon, Integer> entry : Main.game.getPlayerCell().getInventory().getMapOfDuplicateWeapons().entrySet()) {
-						inventorySB.append("<div class='item-background " + getClassFromRarity(entry.getKey().getRarity()) + "'>"
+						inventorySB.append("<div class='item-background " + entry.getKey().getDisplayRarity() + "'>"
 								+ entry.getKey().getSVGString() + "<div class='overlay' id='WEAPON_FLOOR_" + entry.getKey().hashCode() + "'>"
 										+ getItemCountDiv(entry.getValue())
 										+ "</div>"
@@ -285,14 +277,7 @@ public class InventoryDialogue {
 				// Clothing:
 				if (Main.game.getPlayerCell().getInventory().getClothingCount() > 0) {
 					for (Entry<AbstractClothing, Integer> entry : Main.game.getPlayerCell().getInventory().getMapOfDuplicateClothing().entrySet()) {
-						inventorySB.append("<div class='item-background ");
-						
-						if (entry.getKey().isEnchantmentKnown()) {
-							inventorySB.append(getClassFromRarity(entry.getKey().getRarity()));
-						} else {
-							inventorySB.append("unknown");
-						}
-						inventorySB.append("'>");
+						inventorySB.append("<div class='item-background " + entry.getKey().getDisplayRarity() + "'>");
 	
 						inventorySB.append(entry.getKey().getSVGString() + "<div class='overlay' id='CLOTHING_FLOOR_" + entry.getKey().hashCode() + "'>"
 								+ getItemCountDiv(entry.getValue())
@@ -303,7 +288,7 @@ public class InventoryDialogue {
 				// Items:
 				if (Main.game.getPlayerCell().getInventory().getItemCount() > 0) {
 					for (Entry<AbstractItem, Integer> entry : Main.game.getPlayerCell().getInventory().getMapOfDuplicateItems().entrySet()) {
-						inventorySB.append("<div class='item-background " + getClassFromRarity(entry.getKey().getRarity()) + "'>"
+						inventorySB.append("<div class='item-background " + entry.getKey().getDisplayRarity() + "'>"
 								+ entry.getKey().getSVGString()
 								+ "<div class='overlay' id='ITEM_FLOOR_" + entry.getKey().hashCode() + "'>"
 										+ getItemCountDiv(entry.getValue())
@@ -2312,7 +2297,7 @@ public class InventoryDialogue {
 	}
 	
 	private static String getBuybackItemPanel(AbstractCoreItem itemBuyback, String id, int price) {
-		return "<div class='item-background " + getClassFromRarity(itemBuyback.getRarity()) + "'>"
+		return "<div class='item-background " + itemBuyback.getDisplayRarity() + "'>"
 				+ itemBuyback.getSVGString()
 				+ "<div class='overlay' id='" + id + "'>"
 					+ getItemPriceDiv(price)
@@ -2331,13 +2316,6 @@ public class InventoryDialogue {
 		return "<div class='item-price'>"
 				+ formatAsItemPrice(price)
 			+ "</div>";
-	}
-	
-	private static String getClassFromRarity(Rarity rarity) {
-		if (rarity != null) {
-			return rarity.getName();
-		}
-		return "unknown";
 	}
 	
 	private static String formatAsMoney(int money) {

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -1548,7 +1548,7 @@ public class InventoryDialogue {
 
 			} else if (index == 3 && Main.game.getPlayerCell().getInventory().getWeaponCount(weaponFloor)>1) {
 				
-				if (Main.game.getPlayer().isInventoryFull())
+				if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasWeapon(weaponFloor))
 					return new Response("Take all", "Your inventory is full, so you can't take the " + weaponFloor.getName() + "!", null);
 				else
 					return new Response("Take all", "Take the " + weaponFloor.getName() + ".", INVENTORY_MENU){
@@ -1637,7 +1637,7 @@ public class InventoryDialogue {
 				
 			} else if (index == 3 && Main.game.getPlayerCell().getInventory().getClothingCount(clothingFloor)>1) {
 				
-				if (Main.game.getPlayer().isInventoryFull())
+				if (Main.game.getPlayer().isInventoryFull() && !Main.game.getPlayer().hasClothing(clothingFloor))
 					return new Response("Take all", "Your inventory is full, so you can't take the " + clothingFloor.getName() + "!", null);
 				else
 					return new Response("Take all", "Take the " + clothingFloor.getName() + ".", INVENTORY_MENU){

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -2,6 +2,7 @@ package com.base.game.dialogue.utils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
@@ -68,62 +69,15 @@ public class InventoryDialogue {
 
 		// Weapons:
 		if (Main.game.getPlayer().getWeaponCount() > 0) {
-			for (Entry<AbstractWeapon, Integer> entry : Main.game.getPlayer().getMapOfDuplicateWeapons().entrySet()) {
-				inventorySB.append("<div class='item-background "
-						+ entry.getKey().getDisplayRarity() + "'>" + entry.getKey().getSVGString()
-						+ "<div class='overlay"
-						+ (Main.game.getDialogueFlags().tradePartner!=null 
-							? (Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? "" : " dark")
-							: (Main.game.isInSex() || Main.game.isInCombat()?" disabled":""))
-						+ "' id='WEAPON_" + entry.getKey().hashCode() + "'>"
-						+ getItemCountDiv(entry.getValue())
-						+ (Main.game.getDialogueFlags().tradePartner != null ? 
-								(Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? 
-										getItemPriceDiv(entry.getKey().getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier())) 
-										: "") 
-								: "")
-						+ "</div>" + "</div>");
-			}
+			appendDivsForItemsToInventory(Main.game.getPlayer().getMapOfDuplicateWeapons(), "WEAPON_");
 		}
 		// Clothing:
 		if (Main.game.getPlayer().getClothingCount() > 0) {
-			for (Entry<AbstractClothing, Integer> entry : Main.game.getPlayer().getMapOfDuplicateClothing().entrySet()) {
-				inventorySB.append("<div class='item-background " + entry.getKey().getDisplayRarity() + "'>");
-
-				inventorySB.append(entry.getKey().getSVGString() + "<div class='overlay"
-							+ (Main.game.getDialogueFlags().tradePartner!=null
-								? (Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? "" : " dark")
-								: (Main.game.isInSex() || Main.game.isInCombat()?" disabled":""))
-							+ "' id='CLOTHING_" + entry.getKey().hashCode() + "'>"
-							+ getItemCountDiv(entry.getValue())
-							+ (Main.game.getDialogueFlags().tradePartner != null ? 
-									(Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? 
-											getItemPriceDiv(entry.getKey().getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier())) 
-											: "") 
-									: "")
-							+ "</div>"
-						+ "</div>");
-			}
+			appendDivsForItemsToInventory(Main.game.getPlayer().getMapOfDuplicateClothing(), "CLOTHING_");
 		}
 		// Items:
 		if (Main.game.getPlayer().getItemCount() > 0) {
-			for (Entry<AbstractItem, Integer> entry : Main.game.getPlayer().getMapOfDuplicateItems().entrySet()) {
-				inventorySB.append("<div class='item-background "
-						+ entry.getKey().getDisplayRarity() + "'>" + entry.getKey().getSVGString()
-						+ "<div class='overlay"
-						+ (Main.game.getDialogueFlags().tradePartner!=null
-										? (Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? ""
-												: " dark")
-										: ((Main.game.isInSex() && !entry.getKey().getItemType().isAbleToBeUsedInSex()) || (Main.game.isInCombat() && !entry.getKey().getItemType().isAbleToBeUsedInCombat())?" disabled":""))
-						+ "' id='ITEM_" + entry.getKey().hashCode() + "'>"
-						+ getItemCountDiv(entry.getValue())
-						+ (Main.game.getDialogueFlags().tradePartner != null ? 
-								(Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? 
-										getItemPriceDiv(entry.getKey().getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier()))
-										: "") 
-								: "")
-						+ "</div>" + "</div>");
-			}
+			appendDivsForItemsToInventory(Main.game.getPlayer().getMapOfDuplicateItems(), "ITEM_");
 		}
 		// Fill space:
 		for (int i = Main.game.getPlayer().getMaximumInventorySpace(); i > Main.game.getPlayer().getInventorySlotsTaken(); i--) {
@@ -2298,6 +2252,25 @@ public class InventoryDialogue {
 					Main.game.getDialogueFlags().quickTrade = !Main.game.getDialogueFlags().quickTrade;
 				}
 			};
+		}
+	}
+	
+	private static void appendDivsForItemsToInventory(Map<? extends AbstractCoreItem, Integer> map, String idPrefix) {
+		for (Entry<? extends AbstractCoreItem, Integer> entry : map.entrySet()) {
+			inventorySB.append("<div class='item-background "
+					+ entry.getKey().getDisplayRarity() + "'>" + entry.getKey().getSVGString()
+					+ "<div class='overlay"
+					+ (Main.game.getDialogueFlags().tradePartner!=null 
+						? (Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? "" : " dark")
+						: (Main.game.isInSex() || Main.game.isInCombat()?" disabled":""))
+					+ "' id='" + idPrefix + entry.getKey().hashCode() + "'>"
+					+ getItemCountDiv(entry.getValue())
+					+ (Main.game.getDialogueFlags().tradePartner != null ? 
+							(Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? 
+									getItemPriceDiv(entry.getKey().getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier())) 
+									: "") 
+							: "")
+					+ "</div>" + "</div>");
 		}
 	}
 	

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -370,22 +370,24 @@ public class InventoryDialogue {
 					return new Response("Take all", "Pick up everything on the ground.", INVENTORY_MENU){
 						@Override
 						public void effects(){
+							//TODO if this starts printing it will complain about the player's inventory being full
+							//TODO optimize (what if someone stores a thousand panties somewhere?)
 							int i = Main.game.getPlayerCell().getInventory().getItemsInInventory().size();
-							while(i>0 && !Main.game.getPlayer().isInventoryFull()) {
+							while(i > 0) {
 								Main.game.getPlayer().addItem(Main.game.getPlayerCell().getInventory().getItemsInInventory().get(i-1), true);
-								i = Main.game.getPlayerCell().getInventory().getItemsInInventory().size();
+								i--;
 							}
 							
 							i = Main.game.getPlayerCell().getInventory().getClothingInInventory().size();
-							while(i>0 && !Main.game.getPlayer().isInventoryFull()) {
+							while(i > 0) {
 								Main.game.getPlayer().addClothing(Main.game.getPlayerCell().getInventory().getClothingInInventory().get(i-1), true);
-								i = Main.game.getPlayerCell().getInventory().getClothingInInventory().size();
+								i--;
 							}
 							
 							i = Main.game.getPlayerCell().getInventory().getWeaponsInInventory().size();
-							while(i>0 && !Main.game.getPlayer().isInventoryFull()) {
+							while(i > 0) {
 								Main.game.getPlayer().addWeapon(Main.game.getPlayerCell().getInventory().getWeaponsInInventory().get(i-1), true);
-								i = Main.game.getPlayerCell().getInventory().getWeaponsInInventory().size();
+								i--;
 							}
 						}
 					};

--- a/src/com/base/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/base/game/dialogue/utils/InventoryDialogue.java
@@ -79,7 +79,7 @@ public class InventoryDialogue {
 						+ getItemCountDiv(entry.getValue())
 						+ (Main.game.getDialogueFlags().tradePartner != null ? 
 								(Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? 
-										getItemPriceDiv((int) (entry.getKey().getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier())) 
+										getItemPriceDiv(entry.getKey().getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier())) 
 										: "") 
 								: "")
 						+ "</div>" + "</div>");
@@ -98,8 +98,7 @@ public class InventoryDialogue {
 							+ getItemCountDiv(entry.getValue())
 							+ (Main.game.getDialogueFlags().tradePartner != null ? 
 									(Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? 
-											getItemPriceDiv(!entry.getKey().getAttributeModifiers().isEmpty() && !entry.getKey().isEnchantmentKnown() ? 5
-															:(int) (entry.getKey().getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier())) 
+											getItemPriceDiv(entry.getKey().getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier())) 
 											: "") 
 									: "")
 							+ "</div>"
@@ -120,7 +119,7 @@ public class InventoryDialogue {
 						+ getItemCountDiv(entry.getValue())
 						+ (Main.game.getDialogueFlags().tradePartner != null ? 
 								(Main.game.getDialogueFlags().tradePartner.willBuy(entry.getKey()) ? 
-										getItemPriceDiv((int) (entry.getKey().getValue() * Main.game.getDialogueFlags().tradePartner.getBuyModifier())) 
+										getItemPriceDiv(entry.getKey().getPrice(Main.game.getDialogueFlags().tradePartner.getBuyModifier()))
 										: "") 
 								: "")
 						+ "</div>" + "</div>");
@@ -229,7 +228,7 @@ public class InventoryDialogue {
 							inventorySB.append("<div class='item-background " + entry.getKey().getDisplayRarity() + "'>" + entry.getKey().getSVGString());
 							inventorySB.append("<div class='overlay' id='WEAPON_TRADER_" + entry.getKey().hashCode() + "'>"
 									+ getItemCountDiv(entry.getValue())
-									+ getItemPriceDiv((int) (entry.getKey().getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier()))
+									+ getItemPriceDiv(entry.getKey().getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()))
 									+ "</div>" + "</div>");
 						}
 					}
@@ -240,8 +239,7 @@ public class InventoryDialogue {
 							inventorySB.append("<div class='item-background " + entry.getKey().getDisplayRarity() + "'>"
 									+ entry.getKey().getSVGString() + "<div class='overlay' id='CLOTHING_TRADER_" + entry.getKey().hashCode() + "'>"
 											+ getItemCountDiv(entry.getValue())
-											+ getItemPriceDiv(!entry.getKey().getAttributeModifiers().isEmpty() && !entry.getKey().isEnchantmentKnown() ? 5
-													:(int) (entry.getKey().getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier()))
+											+ getItemPriceDiv(entry.getKey().getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()))
 									+ "</div>" + "</div>");
 						}
 					}
@@ -251,7 +249,7 @@ public class InventoryDialogue {
 							inventorySB.append("<div class='item-background " + entry.getKey().getDisplayRarity() + "'>" + entry.getKey().getSVGString()
 											+ "<div class='overlay' id='ITEM_TRADER_" + entry.getKey().hashCode() + "'>"
 													+ getItemCountDiv(entry.getValue())
-													+ getItemPriceDiv((int) (entry.getKey().getValue() * Main.game.getDialogueFlags().tradePartner.getSellModifier()))
+													+ getItemPriceDiv(entry.getKey().getPrice(Main.game.getDialogueFlags().tradePartner.getSellModifier()))
 											+ "</div>" + "</div>");
 						}
 					}

--- a/src/com/base/game/inventory/AbstractCoreItem.java
+++ b/src/com/base/game/inventory/AbstractCoreItem.java
@@ -132,6 +132,13 @@ public abstract class AbstractCoreItem implements Serializable {
 	public Rarity getRarity() {
 		return rarity;
 	}
+	
+	/**
+	 * @return the name of a css class to use as a displayed rarity in inventory screens
+	 */
+	public String getDisplayRarity() {
+		return rarity.getName();
+	}
 
 	public Colour getColour() {
 		return colourShade;

--- a/src/com/base/game/inventory/AbstractCoreItem.java
+++ b/src/com/base/game/inventory/AbstractCoreItem.java
@@ -128,6 +128,10 @@ public abstract class AbstractCoreItem implements Serializable {
 	public abstract String getDescription();
 
 	public abstract int getValue();
+	
+	public int getPrice(float modifier) {
+		return (int) (getValue() * modifier);
+	}
 
 	public Rarity getRarity() {
 		return rarity;

--- a/src/com/base/game/inventory/CharacterInventory.java
+++ b/src/com/base/game/inventory/CharacterInventory.java
@@ -818,7 +818,7 @@ public class CharacterInventory implements Serializable {
 
 				// Remove the old clothing in this slot using the owner's accessor method:
 				if (getClothingInSlot(newClothing.getClothingType().getSlot()) != null) {
-					if (!characterClothingOwner.isInventoryFull())
+					if (!characterClothingOwner.isInventoryFull() || characterClothingOwner.hasClothing(getClothingInSlot(newClothing.getClothingType().getSlot())))
 						equipTextSB.append("</br>" + characterClothingOwner.addedItemToInventoryText(getClothingInSlot(newClothing.getClothingType().getSlot())));
 					else
 						equipTextSB.append("</br>" + characterClothingOwner.droppedItemText(getClothingInSlot(newClothing.getClothingType().getSlot())));

--- a/src/com/base/game/inventory/CharacterInventory.java
+++ b/src/com/base/game/inventory/CharacterInventory.java
@@ -568,7 +568,7 @@ public class CharacterInventory implements Serializable {
 		if (tempSB.length() != 0)
 			tempSB.append("</br></br>");
 		tempSB.append("</br><span style='color:" + Colour.GENERIC_BAD.toWebHexString() + ";'>"+description+"</span>");
-		if (isInventoryFull()) {
+		if (isInventoryFull() && !hasClothing(c)) {
 			Main.game.getActiveWorld().getCell(character.getLocation()).getInventory().addClothing(c);
 			tempSB.append("</br>" + character.droppedItemText(c));
 		} else {

--- a/src/com/base/game/inventory/CharacterInventory.java
+++ b/src/com/base/game/inventory/CharacterInventory.java
@@ -374,7 +374,7 @@ public class CharacterInventory implements Serializable {
 	public void equipMainWeapon(AbstractWeapon weapon) {
 		mainWeapon = weapon;
 	}
-	public void unequipMainWEapon() {
+	public void unequipMainWeapon() {
 		mainWeapon = null;
 	}
 	

--- a/src/com/base/game/inventory/CharacterInventory.java
+++ b/src/com/base/game/inventory/CharacterInventory.java
@@ -806,7 +806,7 @@ public class CharacterInventory implements Serializable {
 
 				// Remove all clothing that is incompatible with newClothing using the owner's accessor method.
 				for (AbstractClothing c : incompatibleRemovableClothing) {
-					if (!characterClothingOwner.isInventoryFull())
+					if (!characterClothingOwner.isInventoryFull() || characterClothingOwner.hasClothing(c))
 						equipTextSB.append("</br>" + characterClothingOwner.addedItemToInventoryText(c));
 					else
 						equipTextSB.append("</br>" + characterClothingOwner.droppedItemText(c));

--- a/src/com/base/game/inventory/CharacterInventory.java
+++ b/src/com/base/game/inventory/CharacterInventory.java
@@ -230,13 +230,17 @@ public class CharacterInventory implements Serializable {
 	 * @return true if added, false if inventory was full.
 	 */
 	public boolean addItem(AbstractItem item) {
-		if (!isInventoryFull() || hasItem(item)){
+		if (canAddItem(item)) {
 			itemsInInventory.add(item);
 			recalculateMapOfDuplicateItems();
 			return true;
 		}
 		
 		return false;
+	}
+	
+	public boolean canAddItem(AbstractItem item) {
+		return !isInventoryFull() || hasItem(item);
 	}
 	
 	public boolean removeItem(AbstractItem item) {
@@ -327,13 +331,17 @@ public class CharacterInventory implements Serializable {
 	 * @return true if added, false if inventory was full.
 	 */
 	public boolean addWeapon(AbstractWeapon weapon) {
-		if (!isInventoryFull() || hasWeapon(weapon)){
+		if (canAddWeapon(weapon)) {
 			weaponsInInventory.add(weapon);
 			recalculateMapOfDuplicateWeapons();
 			return true;
 		}
 		
 		return false;
+	}
+	
+	public boolean canAddWeapon(AbstractWeapon weapon) {
+		return !isInventoryFull() || hasWeapon(weapon);
 	}
 	
 	public boolean removeWeapon(AbstractWeapon weapon) {
@@ -443,12 +451,16 @@ public class CharacterInventory implements Serializable {
 	 */
 	
 	public boolean addClothing(AbstractClothing clothing) {
-		if (!isInventoryFull() || hasClothing(clothing)) {
+		if (canAddClothing(clothing)) {
 			clothingInInventory.add(clothing);
 			recalculateMapOfDuplicateClothing();
 			return true;
 		} else
 			return false;
+	}
+	
+	public boolean canAddClothing(AbstractClothing clothing) {
+		return !isInventoryFull() || hasClothing(clothing);
 	}
 	
 	public boolean hasClothing(AbstractClothing clothing) {

--- a/src/com/base/game/inventory/CharacterInventory.java
+++ b/src/com/base/game/inventory/CharacterInventory.java
@@ -810,7 +810,10 @@ public class CharacterInventory implements Serializable {
 						equipTextSB.append("</br>" + characterClothingOwner.addedItemToInventoryText(c));
 					else
 						equipTextSB.append("</br>" + characterClothingOwner.droppedItemText(c));
+					String oldEquipText = equipTextSB.toString();// this is a hack to fix the string builder being overwritten
 					characterClothingOwner.unequipClothingIntoInventory(c, true, characterClothingEquipper);
+					equipTextSB.setLength(0);
+					equipTextSB.append(oldEquipText);
 				}
 
 				// Clear the new clothing's displacement list as a precaution:

--- a/src/com/base/game/inventory/CharacterInventory.java
+++ b/src/com/base/game/inventory/CharacterInventory.java
@@ -822,7 +822,10 @@ public class CharacterInventory implements Serializable {
 						equipTextSB.append("</br>" + characterClothingOwner.addedItemToInventoryText(getClothingInSlot(newClothing.getClothingType().getSlot())));
 					else
 						equipTextSB.append("</br>" + characterClothingOwner.droppedItemText(getClothingInSlot(newClothing.getClothingType().getSlot())));
+					String oldEquipText = equipTextSB.toString();// this is a hack to fix the string builder being overwritten
 					characterClothingOwner.unequipClothingIntoInventory(getClothingInSlot(newClothing.getClothingType().getSlot()), true, characterClothingEquipper);
+					equipTextSB.setLength(0);
+					equipTextSB.append(oldEquipText);
 				}
 
 				// Actually equip the newClothing:

--- a/src/com/base/game/inventory/clothing/AbstractClothing.java
+++ b/src/com/base/game/inventory/clothing/AbstractClothing.java
@@ -581,6 +581,7 @@ public abstract class AbstractClothing extends AbstractCoreItem implements Seria
 	public void removeBadEnchantment() {
 		this.badEnchantment = false;
 		this.rarity = Rarity.COMMON;
+		this.coreEnchantment = null;
 	}
 
 	public boolean isSealed() {

--- a/src/com/base/game/inventory/clothing/AbstractClothing.java
+++ b/src/com/base/game/inventory/clothing/AbstractClothing.java
@@ -280,6 +280,14 @@ public abstract class AbstractClothing extends AbstractCoreItem implements Seria
 
 		return runningTotal;
 	}
+	
+	@Override
+	public int getPrice(float modifier) {
+		if (!enchantmentKnown) {
+			return 5;
+		}
+		return super.getPrice(modifier);
+	}
 
 	/**
 	 * @param withDeterminer

--- a/src/com/base/game/inventory/clothing/AbstractClothing.java
+++ b/src/com/base/game/inventory/clothing/AbstractClothing.java
@@ -158,6 +158,17 @@ public abstract class AbstractClothing extends AbstractCoreItem implements Seria
 		result = 31 * result + displacedList.hashCode();
 		return result;
 	}
+	
+	/**
+	 * @return the name of a css class to use as a displayed rarity in inventory screens
+	 */
+	@Override
+	public String getDisplayRarity() {
+		if (!enchantmentKnown) {
+			return "unknown";
+		}
+		return super.getDisplayRarity();
+	}
 
 	private StringBuilder descriptionSB;
 


### PR DESCRIPTION
this still needs extensive testing to make sure it really doesn't add any more bugs.

Bugs fixed:
- Take all from floor doesn't handle stackables well if your inventory is full
- Take all weapon doesn't work if inv is full?
- Jinxed items don't stack when unjinxed
- You can't store stackables if the area is full
- Unidentified items will show their state in the buyback menu
- Jinxed items can't be selected if you're carrying a dye brush and just identified them
- Unidentified items will sell for their real value and not the fixed value you get for an unidentified item
- That includes the "vendor will buy for x" text (not overlay) and the button
- "These items will disappear when you leave the area" when trading on a tile with dropped stuff
- Can't buy/buyback a stackable with full inventory? Check item/weapon/clothing!
- Can't unequip weapons/clothing even although they would stack if you have a full inventory
- Unequipping clothing (weapons too?) causing your inventory to be full claims it gets dropped when it doesn't
- Equipping clothing (weapons too?) when you're already wearing something with a full inventory will drop that already worn item to the ground, even if it was stackable in your inventory
- Displaced clothing is dropped even if it could be stacked with a full inventory
- Equipping an item may reset the string builder halfway through causing some warnings not to display
- Sell All has improper rounding as it rounds after all items instead of each item individually
-- Same goes for buy all

- getting transformed with full inventory will drop your clothing even although it fits in inventory as stackable

- Improvement: Deduplicate printing items now that weapon/clothing/item is similar

- The overlay display "Vendor wants x" in the buyback shows the wrong price

Known bugs that are not fixed:
- The overlay display properly stretches for an item that blocks your clothing, but it doesn't properly stretch for item effects that are large - talked with @Innoxia about this and apparently fixing this is hell.
-- Proficiency "spell cost reduction"
-- Seduction "willpower damage"

- Sell All "Sell all of your tiara for x" improper pluralizing (this does work for items?)
-- Buy All "Buy all of the opaque demonstone" also has improper pluralizing
-- Drink All too
-- Store All too
-- Take All too

- Text misaligned when unequip drop warning is saved
- Possible bug with identifying working with stacks instead of single items (confirming that there is a bug here would be real nice because then I could fix it)

Known possible inventory related improvements which I haven't applied yet because... ehhh lemme know if you want these:
- The bottom border of the item overlay with effects grows as the effects list goes on, this could get normalized
- Buy back says "Vendor will sell it to you for $ x.", could be "Vendor will let you buy it back for $ x."
- Dyeing items prints the text below the shop dialogue, when buying and selling items prints the text under the shop dialogue

Known issues related to inventory that I'm not gonna fix:
- Pluralization bugs
-- "You hand over all of your A dye-brush to Ralph in exchange for ¤ 287." Yeahhh that's item names and pluralization hell