### PR TITLE
Linux font compatibility

### DIFF
--- a/src/com/lilithsthrone/res/css/webViewAttributes_stylesheet.css
+++ b/src/com/lilithsthrone/res/css/webViewAttributes_stylesheet.css
@@ -1,6 +1,6 @@
 html {
 	background: #1e1e20;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:11pt;
 	font-size:7vw; /*font-size:2vw;*/
 	color: #ffffff;
@@ -244,7 +244,7 @@ h6{
 	box-sizing:border-box;
 	border-radius: 5px;
 	background: #1B1B1D;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:11pt;
 	width:100%;
 	overflow-y: scroll;

--- a/src/com/lilithsthrone/res/css/webViewAttributes_stylesheet_light.css
+++ b/src/com/lilithsthrone/res/css/webViewAttributes_stylesheet_light.css
@@ -1,6 +1,6 @@
 html {
 	background: #fcfcfc;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:11pt;
 	font-size:7vw; /*font-size:2vw;*/
 	color: #262626;
@@ -244,7 +244,7 @@ h6{
 	box-sizing:border-box;
 	border-radius: 5px;
 	background: #ddd;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:11pt;
 	width:100%;
 	overflow-y: scroll;

--- a/src/com/lilithsthrone/res/css/webViewButtons_stylesheet.css
+++ b/src/com/lilithsthrone/res/css/webViewButtons_stylesheet.css
@@ -1,6 +1,6 @@
 html {
 	background: #1e1e20;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:11pt;
 	font-size:7vw; /*font-size:2vw;*/
 	color: #ffffff;

--- a/src/com/lilithsthrone/res/css/webViewButtons_stylesheet_light.css
+++ b/src/com/lilithsthrone/res/css/webViewButtons_stylesheet_light.css
@@ -1,6 +1,6 @@
 html {
 	background: #fcfcfc;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:11pt;
 	font-size:7vw; /*font-size:2vw;*/
 	color: #262626;

--- a/src/com/lilithsthrone/res/css/webViewMenu_stylesheet.css
+++ b/src/com/lilithsthrone/res/css/webViewMenu_stylesheet.css
@@ -1,6 +1,6 @@
 html {
 	background: #1e1e20;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:12pt; /*font-size:2vw;*/
 	color: #DDDDDD;
 	margin:0;

--- a/src/com/lilithsthrone/res/css/webViewMenu_stylesheet_light.css
+++ b/src/com/lilithsthrone/res/css/webViewMenu_stylesheet_light.css
@@ -1,6 +1,6 @@
 html {
 	background: #e6e6e6;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:12pt; /*font-size:2vw;*/
 	color: #262626;
 	margin:0;

--- a/src/com/lilithsthrone/res/css/webViewResponse_stylesheet.css
+++ b/src/com/lilithsthrone/res/css/webViewResponse_stylesheet.css
@@ -1,6 +1,6 @@
 html {
 	background: #1e1e20;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:17px; /*font-size:2vw;*/
 	line-height:23px;
 	color: #DDDDDD;

--- a/src/com/lilithsthrone/res/css/webViewResponse_stylesheet_light.css
+++ b/src/com/lilithsthrone/res/css/webViewResponse_stylesheet_light.css
@@ -1,6 +1,6 @@
 html {
 	background: #fcfcfc;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:17px; /*font-size:2vw;*/
 	line-height:23px;
 	color: #262626;

--- a/src/com/lilithsthrone/res/css/webViewTooltip_stylesheet.css
+++ b/src/com/lilithsthrone/res/css/webViewTooltip_stylesheet.css
@@ -1,6 +1,6 @@
 html {
 	background: #1e1e20;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:11pt;
 	color: #eeeeee;
 	padding: 0;

--- a/src/com/lilithsthrone/res/css/webViewTooltip_stylesheet_light.css
+++ b/src/com/lilithsthrone/res/css/webViewTooltip_stylesheet_light.css
@@ -1,6 +1,6 @@
 html {
 	background: #e6e6e6;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:11pt;
 	color: #262626;
 	padding: 0;

--- a/src/com/lilithsthrone/res/css/webView_stylesheet.css
+++ b/src/com/lilithsthrone/res/css/webView_stylesheet.css
@@ -1,6 +1,6 @@
 html {
 	background: #1e1e20;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:18px; /*font-size:2vw;*/
 	line-height:24px;
 	color: #DDDDDD;
@@ -166,7 +166,7 @@ td, th{
 
 input {
 	background:#333;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:18px; /*font-size:2vw;*/
 	line-height:24px;
 	color: #DDDDDD;

--- a/src/com/lilithsthrone/res/css/webView_stylesheet_light.css
+++ b/src/com/lilithsthrone/res/css/webView_stylesheet_light.css
@@ -1,6 +1,6 @@
 html {
 	background: #fcfcfc;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:18px; /*font-size:2vw;*/
 	line-height:24px;
 	color: #262626;
@@ -166,7 +166,7 @@ td, th{
 
 input {
 	background:#ccc;
-    font-family:Calibri;
+	font-family:Calibri,Carlito;
 	font-size:18px; /*font-size:2vw;*/
 	line-height:24px;
 	color: #262626;


### PR DESCRIPTION
This branch adds Carlito as an alternative font for Calibri in the CSS. This is necessary to display the interface correctly when the game is run natively on Linux. (There's no Calibri and the text becomes too large for the buttons.) Carlito is supposed to be an open-source alternative to Calibri with the same font metrics, so no sizes change.

Note: The .jar from the website has been tested and works correctly (except for the font issue) on Ubuntu 17.10, so you may want to add that info on the website. (It used to crash in an earlier version, but I don't know which of the many package updates has fixed the issue.) The following packages and their dependencies have to be installed for the fixed version: `openjfx fonts-crosextra-carlito`.