### PR TITLE
Forced TF Gender Tendency Setting

### DIFF
--- a/src/com/lilithsthrone/controller/MainController.java
+++ b/src/com/lilithsthrone/controller/MainController.java
@@ -35,6 +35,7 @@ import com.lilithsthrone.controller.eventListeners.buttons.ButtonMoveSouthEventL
 import com.lilithsthrone.controller.eventListeners.buttons.ButtonMoveWestEventListener;
 import com.lilithsthrone.controller.eventListeners.buttons.ButtonZoomEventListener;
 import com.lilithsthrone.controller.eventListeners.information.CopyInfoEventListener;
+import com.lilithsthrone.game.ForcedTFTendency;
 import com.lilithsthrone.game.Game;
 import com.lilithsthrone.game.KeyCodeWithModifiers;
 import com.lilithsthrone.game.KeyboardAction;
@@ -4388,6 +4389,83 @@ public class MainController implements Initializable {
 						Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
 					}, false);
 				}
+			}
+			
+			id = "FORCED_TF_TENDENCY_"+ForcedTFTendency.NEUTRAL;
+			if (((EventTarget) document.getElementById(id)) != null) {
+				((EventTarget) document.getElementById(id)).addEventListener("click", e -> {
+					Main.getProperties().forcedTFTendency = ForcedTFTendency.NEUTRAL;
+					Main.saveProperties();
+					Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+				}, false);
+				
+				addEventListener(document, id, "mousemove", moveTooltipListener, false);
+				addEventListener(document, id, "mouseleave", hideTooltipListener, false);
+				TooltipInformationEventListener el = new TooltipInformationEventListener().setInformation(ForcedTFTendency.NEUTRAL.getName(),
+						ForcedTFTendency.NEUTRAL.getDescription());
+				addEventListener(document, id, "mouseenter", el, false);
+			}
+			
+			
+			
+			id = "FORCED_TF_TENDENCY_"+ForcedTFTendency.FEMININE;
+			if (((EventTarget) document.getElementById(id)) != null) {
+				((EventTarget) document.getElementById(id)).addEventListener("click", e -> {
+					Main.getProperties().forcedTFTendency = ForcedTFTendency.FEMININE;
+					Main.saveProperties();
+					Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+				}, false);
+				
+				addEventListener(document, id, "mousemove", moveTooltipListener, false);
+				addEventListener(document, id, "mouseleave", hideTooltipListener, false);
+				TooltipInformationEventListener el = new TooltipInformationEventListener().setInformation(ForcedTFTendency.FEMININE.getName(),
+						ForcedTFTendency.FEMININE.getDescription());
+				addEventListener(document, id, "mouseenter", el, false);
+			}
+			
+			id = "FORCED_TF_TENDENCY_"+ForcedTFTendency.FEMININE_HEAVY;
+			if (((EventTarget) document.getElementById(id)) != null) {
+				((EventTarget) document.getElementById(id)).addEventListener("click", e -> {
+					Main.getProperties().forcedTFTendency = ForcedTFTendency.FEMININE_HEAVY;
+					Main.saveProperties();
+					Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+				}, false);
+				
+				addEventListener(document, id, "mousemove", moveTooltipListener, false);
+				addEventListener(document, id, "mouseleave", hideTooltipListener, false);
+				TooltipInformationEventListener el = new TooltipInformationEventListener().setInformation(ForcedTFTendency.FEMININE_HEAVY.getName(),
+						ForcedTFTendency.FEMININE_HEAVY.getDescription());
+				addEventListener(document, id, "mouseenter", el, false);
+			}
+			
+			id = "FORCED_TF_TENDENCY_"+ForcedTFTendency.MASCULINE;
+			if (((EventTarget) document.getElementById(id)) != null) {
+				((EventTarget) document.getElementById(id)).addEventListener("click", e -> {
+					Main.getProperties().forcedTFTendency = ForcedTFTendency.MASCULINE;
+					Main.saveProperties();
+					Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+				}, false);
+				
+				addEventListener(document, id, "mousemove", moveTooltipListener, false);
+				addEventListener(document, id, "mouseleave", hideTooltipListener, false);
+				TooltipInformationEventListener el = new TooltipInformationEventListener().setInformation(ForcedTFTendency.MASCULINE.getName(),
+						ForcedTFTendency.MASCULINE.getDescription());
+				addEventListener(document, id, "mouseenter", el, false);
+			}
+			
+			id = "FORCED_TF_TENDENCY_"+ForcedTFTendency.MASCULINE_HEAVY;
+			if (((EventTarget) document.getElementById(id)) != null) {
+				((EventTarget) document.getElementById(id)).addEventListener("click", e -> {
+					Main.getProperties().forcedTFTendency = ForcedTFTendency.MASCULINE_HEAVY;
+					Main.saveProperties();
+					Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+				}, false);
+				
+				addEventListener(document, id, "mousemove", moveTooltipListener, false);
+				addEventListener(document, id, "mouseleave", hideTooltipListener, false);
+				TooltipInformationEventListener el = new TooltipInformationEventListener().setInformation(ForcedTFTendency.MASCULINE_HEAVY.getName(),
+						ForcedTFTendency.MASCULINE_HEAVY.getDescription());
+				addEventListener(document, id, "mouseenter", el, false);
 			}
 		}
 		

--- a/src/com/lilithsthrone/game/ForcedTFTendency.java
+++ b/src/com/lilithsthrone/game/ForcedTFTendency.java
@@ -1,0 +1,48 @@
+package com.lilithsthrone.game;
+
+import com.lilithsthrone.utils.Colour;
+
+/**
+ * @since 0.1.95
+ * @version 0.1.95
+ * @author FeiFongWong
+ */
+public enum ForcedTFTendency {
+	
+	FEMININE_HEAVY("Feminine (Heavy)", "There is a strong chance that forced transformations will make you more feminine regardless of NPC tastes.", Colour.FEMININE),
+	
+	FEMININE("Feminine", "While NPC tastes still matter, forced transformations will often make you more feminine.", Colour.FEMININE),
+	
+	NEUTRAL("Neutral", "Gender effects of forced trasformations will be determined solely by the tastes and whims of the controlling NPC.", Colour.ANDROGYNOUS),
+	
+	MASCULINE("Masculine", "While NPC tastes still matter, forced transformations will often make you more masculine.", Colour.MASCULINE),
+	
+	MASCULINE_HEAVY("Masculine (Heavy)", "There is a strong chance that forced transformations will make you more masculine regardless of NPC tastes.", Colour.MASCULINE);
+
+
+	private String name;
+	private String description;
+	private Colour colour;
+
+	
+	private ForcedTFTendency(String name, String description, Colour colour) {
+		this.name = name;
+		this.description = description;
+		this.colour = colour;
+
+	}
+
+	public String getName() {
+		return name;
+	}
+	
+	public String getDescription() {
+		return description;
+	}
+
+	public Colour getColour() {
+		return colour;
+	}
+
+
+}

--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -27,6 +27,7 @@ import com.lilithsthrone.game.character.gender.Gender;
 import com.lilithsthrone.game.character.gender.GenderNames;
 import com.lilithsthrone.game.character.gender.GenderPronoun;
 import com.lilithsthrone.game.character.race.FurryPreference;
+import com.lilithsthrone.game.ForcedTFTendency;
 import com.lilithsthrone.game.character.race.Race;
 import com.lilithsthrone.game.dialogue.eventLog.EventLogEntryEncyclopediaUnlock;
 import com.lilithsthrone.game.inventory.clothing.AbstractClothingType;
@@ -77,7 +78,9 @@ public class Properties implements Serializable {
 
 	public Map<Race, FurryPreference> raceFemininePreferencesMap, raceMasculinePreferencesMap;
 	
+	// Transformation Settings
 	public FurryPreference forcedTFPreference;
+	public ForcedTFTendency forcedTFTendency;
 	
 	// Discoveries:
 	private Set<AbstractItemType> itemsDiscovered;
@@ -118,6 +121,7 @@ public class Properties implements Serializable {
 		}
 		
 		forcedTFPreference = FurryPreference.NORMAL;
+		forcedTFTendency = ForcedTFTendency.NEUTRAL;
 		
 		raceFemininePreferencesMap = new EnumMap<>(Race.class);
 		raceMasculinePreferencesMap = new EnumMap<>(Race.class);
@@ -297,8 +301,9 @@ public class Properties implements Serializable {
 				element.setAttributeNode(value);
 			}
 			
-			// Forced TF preference:
+			// Forced TF settings:
 			createXMLElementWithValue(doc, settings, "forcedTFPreference", String.valueOf(forcedTFPreference));
+			createXMLElementWithValue(doc, settings, "forcedTFTendency", String.valueOf(forcedTFTendency));
 			
 			// Race preferences:
 			Element racePreferences = doc.createElement("furryPreferences");
@@ -492,6 +497,9 @@ public class Properties implements Serializable {
 				// Forced TF preference:
 				if(element.getElementsByTagName("forcedTFPreference").item(0)!=null) {
 					forcedTFPreference = FurryPreference.valueOf(((Element)element.getElementsByTagName("forcedTFPreference").item(0)).getAttribute("value"));
+				}
+				if(element.getElementsByTagName("forcedTFTendency").item(0)!=null) {
+					forcedTFTendency = ForcedTFTendency.valueOf(((Element)element.getElementsByTagName("forcedTFTendency").item(0)).getAttribute("value"));
 				}
 				
 				// Keys:

--- a/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
@@ -10,6 +10,7 @@ import java.text.SimpleDateFormat;
 import java.util.Comparator;
 
 import com.lilithsthrone.game.DifficultyLevel;
+import com.lilithsthrone.game.ForcedTFTendency;
 import com.lilithsthrone.game.Game;
 import com.lilithsthrone.game.KeyboardAction;
 import com.lilithsthrone.game.character.CharacterUtils;
@@ -1431,59 +1432,113 @@ public class OptionsDialogue {
 						"This enables body hair descriptions and content for armpits and assholes.",
 						Main.getProperties().bodyHairContent)
 					
-					+"<div class='cosmetics-inner-container'>"
-						+ "<h5 style='text-align:center; color:"+Colour.BASE_GREEN.toWebHexString()+";'>"
-							+ "Forced TF"
-						+"</h5>"
-						+ "<p style='text-align:center;'>"
-							+ "This sets the amount of NPCs spawning with the '"+Fetish.FETISH_TRANSFORMATION_GIVING.getName(null)+"' fetish, which causes them to try and forcibly transform you after beating you in combat."
-						+ "</p>"
-						+(Main.getProperties().forcedTFPercentage==forcedTFsettings[0]
-							?"<div class='cosmetics-button active'>"
-									+ "[style.boldGood("+forcedTFsettings[0]+"%)]"
-									+ "</div>"
-							:"<div id='FORCED_TF_"+forcedTFsettings[0]+"' class='cosmetics-button'>"
-									+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+forcedTFsettings[0]+"%</span>"
-									+ "</div>")
-						+(Main.getProperties().forcedTFPercentage==forcedTFsettings[1]
-								?"<div class='cosmetics-button active'>"
-										+ "[style.boldGood("+forcedTFsettings[1]+"%)]"
-										+ "</div>"
-								:"<div id='FORCED_TF_"+forcedTFsettings[1]+"' class='cosmetics-button'>"
-										+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+forcedTFsettings[1]+"%</span>"
-										+ "</div>")
-						+(Main.getProperties().forcedTFPercentage==forcedTFsettings[2]
-								?"<div class='cosmetics-button active'>"
-										+ "[style.boldGood("+forcedTFsettings[2]+"%)]"
-										+ "</div>"
-								:"<div id='FORCED_TF_"+forcedTFsettings[2]+"' class='cosmetics-button'>"
-										+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+forcedTFsettings[2]+"%</span>"
-										+ "</div>")
-						+(Main.getProperties().forcedTFPercentage==forcedTFsettings[3]
-								?"<div class='cosmetics-button active'>"
-										+ "[style.boldGood("+forcedTFsettings[3]+"%)]"
-										+ "</div>"
-								:"<div id='FORCED_TF_"+forcedTFsettings[3]+"' class='cosmetics-button'>"
-										+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+forcedTFsettings[3]+"%</span>"
-										+ "</div>")
-						+(Main.getProperties().forcedTFPercentage==forcedTFsettings[4]
-								?"<div class='cosmetics-button active'>"
-										+ "[style.boldGood("+forcedTFsettings[4]+"%)]"
-										+ "</div>"
-								:"<div id='FORCED_TF_"+forcedTFsettings[4]+"' class='cosmetics-button'>"
-										+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+forcedTFsettings[4]+"%</span>"
-										+ "</div>")
-					+ "</div>"
+					+getContentPreferenceDiv(
+							"FURRY_TAIL_PENETRATION",
+							Colour.BASE_MAGENTA,
+							"Furry tail penetrations",
+							"This enables furry tails to engage in penetrative actions in sex.",
+							Main.getProperties().furryTailPenetrationContent)
+					
+					
 				+"</div>"
+					
+					
 				
 				
 				+ "<div class='container-full-width' style='background:transparent; padding:0; margin-bottom:0; margin-top:0;'>"
-					+getContentPreferenceDiv(
-						"FURRY_TAIL_PENETRATION",
-						Colour.BASE_MAGENTA,
-						"Furry tail penetrations",
-						"This enables furry tails to engage in penetrative actions in sex.",
-						Main.getProperties().furryTailPenetrationContent)
+					+"<div class='cosmetics-inner-container'>"
+					+ "<h5 style='text-align:center; color:"+Colour.BASE_GREEN.toWebHexString()+";'>"
+					+ "Forced TF"
+					+"</h5>"
+					+ "<p style='text-align:center;'>"
+					+ "This sets the amount of NPCs spawning with the '"+Fetish.FETISH_TRANSFORMATION_GIVING.getName(null)+"' fetish, which causes them to try and forcibly transform you after beating you in combat."
+					+ "</p>"
+					+(Main.getProperties().forcedTFPercentage==forcedTFsettings[0]
+							?"<div class='cosmetics-button active'>"
+							+ "[style.boldGood("+forcedTFsettings[0]+"%)]"
+							+ "</div>"
+							:"<div id='FORCED_TF_"+forcedTFsettings[0]+"' class='cosmetics-button'>"
+							+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+forcedTFsettings[0]+"%</span>"
+							+ "</div>")
+					+(Main.getProperties().forcedTFPercentage==forcedTFsettings[1]
+							?"<div class='cosmetics-button active'>"
+							+ "[style.boldGood("+forcedTFsettings[1]+"%)]"
+							+ "</div>"
+							:"<div id='FORCED_TF_"+forcedTFsettings[1]+"' class='cosmetics-button'>"
+							+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+forcedTFsettings[1]+"%</span>"
+							+ "</div>")
+					+(Main.getProperties().forcedTFPercentage==forcedTFsettings[2]
+							?"<div class='cosmetics-button active'>"
+							+ "[style.boldGood("+forcedTFsettings[2]+"%)]"
+							+ "</div>"
+							:"<div id='FORCED_TF_"+forcedTFsettings[2]+"' class='cosmetics-button'>"
+							+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+forcedTFsettings[2]+"%</span>"
+							+ "</div>")
+					+(Main.getProperties().forcedTFPercentage==forcedTFsettings[3]
+							?"<div class='cosmetics-button active'>"
+							+ "[style.boldGood("+forcedTFsettings[3]+"%)]"
+							+ "</div>"
+							:"<div id='FORCED_TF_"+forcedTFsettings[3]+"' class='cosmetics-button'>"
+							+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+forcedTFsettings[3]+"%</span>"
+							+ "</div>")
+					+(Main.getProperties().forcedTFPercentage==forcedTFsettings[4]
+							?"<div class='cosmetics-button active'>"
+							+ "[style.boldGood("+forcedTFsettings[4]+"%)]"
+							+ "</div>"
+							:"<div id='FORCED_TF_"+forcedTFsettings[4]+"' class='cosmetics-button'>"
+							+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+forcedTFsettings[4]+"%</span>"
+							+ "</div>")
+					+ "</div>"
+					
+					+"<div class='cosmetics-inner-container'>"
+					+ "<h5 style='text-align:center; color:"+Colour.BASE_GREEN.toWebHexString()+";'>"
+						+ "Forced TF Gender Tendency"
+					+"</h5>"
+					+ "<p style='text-align:center;'>"
+						+ "This allows you to override NPC tastes when a forced transformation will alter your gender presentation."
+					+ "</p>"
+					+(Main.getProperties().forcedTFTendency==ForcedTFTendency.NEUTRAL
+					?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.NEUTRAL+\"' class='cosmetics-button active'>"
+							+ "[style.boldGood("+ForcedTFTendency.NEUTRAL.getName()+")]"
+							+ "</div>"
+					:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.NEUTRAL+"' class='cosmetics-button'>"
+							+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+ForcedTFTendency.NEUTRAL.getName()+"</span>"
+							+ "</div>")	
+							+ ("<br>")	
+					+(Main.getProperties().forcedTFTendency==ForcedTFTendency.FEMININE
+						?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.FEMININE+\"' class='cosmetics-button active'>"
+								+ "[style.boldGood("+ForcedTFTendency.FEMININE.getName()+")]"
+								+ "</div>"
+						:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.FEMININE+"' class='cosmetics-button'>"
+								+ "<span style='color:"+Colour.FEMININE.getShades()[0]+";'>"+ForcedTFTendency.FEMININE.getName()+"</span>"
+								+ "</div>")
+					+(Main.getProperties().forcedTFTendency==ForcedTFTendency.FEMININE_HEAVY
+							?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.FEMININE_HEAVY+\"' class='cosmetics-button active'>"
+									+ "[style.boldGood("+ForcedTFTendency.FEMININE_HEAVY.getName()+")]"
+									+ "</div>"
+							:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.FEMININE_HEAVY+"' class='cosmetics-button'>"
+									+ "<span style='color:"+Colour.FEMININE.getShades()[0]+";'>"+ForcedTFTendency.FEMININE_HEAVY.getName()+"</span>"
+									+ "</div>")
+					
+					+(Main.getProperties().forcedTFTendency==ForcedTFTendency.MASCULINE
+							?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.MASCULINE+\"' class='cosmetics-button active'>"
+									+ "[style.boldGood("+ForcedTFTendency.MASCULINE.getName()+")]"
+									+ "</div>"
+							:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.MASCULINE+"' class='cosmetics-button'>"
+									+ "<span style='color:"+Colour.MASCULINE.getShades()[0]+";'>"+ForcedTFTendency.MASCULINE.getName()+"</span>"
+									+ "</div>")
+					+(Main.getProperties().forcedTFTendency==ForcedTFTendency.MASCULINE_HEAVY
+							?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.MASCULINE_HEAVY+\"' class='cosmetics-button active'>"
+									+ "[style.boldGood("+ForcedTFTendency.MASCULINE_HEAVY.getName()+")]"
+									+ "</div>"
+							:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.MASCULINE_HEAVY+"' class='cosmetics-button'>"
+									+ "<span style='color:"+Colour.MASCULINE.getShades()[0]+";'>"+ForcedTFTendency.MASCULINE_HEAVY.getName()+"</span>"
+									+ "</div>")
+					+ "</div>" 
+				
+					
+					
+					
 				+"</div>");
 			
 			return UtilText.nodeContentSB.toString();

--- a/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
@@ -1483,50 +1483,54 @@ public class OptionsDialogue {
 					+ "</div>"
 					
 					+"<div class='cosmetics-inner-container'>"
-					+ "<h5 style='text-align:center; color:"+Colour.BASE_GREEN.toWebHexString()+";'>"
+						+ "<h5 style='text-align:center; color:"+Colour.BASE_GREEN.toWebHexString()+";'>"
 						+ "Forced TF Gender Tendency"
-					+"</h5>"
-					+ "<p style='text-align:center;'>"
+						+"</h5>"
+						+ "<p style='text-align:center;'>"
 						+ "This allows you to override NPC tastes when a forced transformation will alter your gender presentation."
-					+ "</p>"
+						+ "</p>"
 					+(Main.getProperties().forcedTFTendency==ForcedTFTendency.NEUTRAL
-					?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.NEUTRAL+\"' class='cosmetics-button active'>"
-							+ "[style.boldGood("+ForcedTFTendency.NEUTRAL.getName()+")]"
-							+ "</div>"
-					:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.NEUTRAL+"' class='cosmetics-button'>"
-							+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+ForcedTFTendency.NEUTRAL.getName()+"</span>"
-							+ "</div>")	
-							+ ("<br>")	
+						?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.NEUTRAL+\"' class='cosmetics-button active'>"
+						+ "[style.boldGood("+ForcedTFTendency.NEUTRAL.getName()+")]"
+						+ "</div>"
+						:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.NEUTRAL+"' class='cosmetics-button'>"
+						+ "<span style='color:"+Colour.GENERIC_BAD.getShades()[0]+";'>"+ForcedTFTendency.NEUTRAL.getName()+"</span>"
+						+ "</div>")	
+						+ ("<br>")	
 					+(Main.getProperties().forcedTFTendency==ForcedTFTendency.FEMININE
 						?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.FEMININE+\"' class='cosmetics-button active'>"
-								+ "[style.boldGood("+ForcedTFTendency.FEMININE.getName()+")]"
-								+ "</div>"
+						+ "[style.boldGood("+ForcedTFTendency.FEMININE.getName()+")]"
+						+ "</div>"
 						:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.FEMININE+"' class='cosmetics-button'>"
-								+ "<span style='color:"+Colour.FEMININE.getShades()[0]+";'>"+ForcedTFTendency.FEMININE.getName()+"</span>"
-								+ "</div>")
+						+ "<span style='color:"+Colour.FEMININE.getShades()[0]+";'>"+ForcedTFTendency.FEMININE.getName()+"</span>"
+						+ "</div>")
 					+(Main.getProperties().forcedTFTendency==ForcedTFTendency.FEMININE_HEAVY
-							?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.FEMININE_HEAVY+\"' class='cosmetics-button active'>"
-									+ "[style.boldGood("+ForcedTFTendency.FEMININE_HEAVY.getName()+")]"
-									+ "</div>"
-							:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.FEMININE_HEAVY+"' class='cosmetics-button'>"
-									+ "<span style='color:"+Colour.FEMININE.getShades()[0]+";'>"+ForcedTFTendency.FEMININE_HEAVY.getName()+"</span>"
-									+ "</div>")
-					
+						?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.FEMININE_HEAVY+\"' class='cosmetics-button active'>"
+						+ "[style.boldGood("+ForcedTFTendency.FEMININE_HEAVY.getName()+")]"
+						+ "</div>"
+						:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.FEMININE_HEAVY+"' class='cosmetics-button'>"
+						+ "<span style='color:"+Colour.FEMININE.getShades()[0]+";'>"+ForcedTFTendency.FEMININE_HEAVY.getName()+"</span>"
+						+ "</div>")
+						
 					+(Main.getProperties().forcedTFTendency==ForcedTFTendency.MASCULINE
-							?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.MASCULINE+\"' class='cosmetics-button active'>"
-									+ "[style.boldGood("+ForcedTFTendency.MASCULINE.getName()+")]"
-									+ "</div>"
-							:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.MASCULINE+"' class='cosmetics-button'>"
-									+ "<span style='color:"+Colour.MASCULINE.getShades()[0]+";'>"+ForcedTFTendency.MASCULINE.getName()+"</span>"
-									+ "</div>")
+						?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.MASCULINE+\"' class='cosmetics-button active'>"
+						+ "[style.boldGood("+ForcedTFTendency.MASCULINE.getName()+")]"
+						+ "</div>"
+						:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.MASCULINE+"' class='cosmetics-button'>"
+						+ "<span style='color:"+Colour.MASCULINE.getShades()[0]+";'>"+ForcedTFTendency.MASCULINE.getName()+"</span>"
+						+ "</div>")
 					+(Main.getProperties().forcedTFTendency==ForcedTFTendency.MASCULINE_HEAVY
-							?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.MASCULINE_HEAVY+\"' class='cosmetics-button active'>"
-									+ "[style.boldGood("+ForcedTFTendency.MASCULINE_HEAVY.getName()+")]"
-									+ "</div>"
-							:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.MASCULINE_HEAVY+"' class='cosmetics-button'>"
-									+ "<span style='color:"+Colour.MASCULINE.getShades()[0]+";'>"+ForcedTFTendency.MASCULINE_HEAVY.getName()+"</span>"
-									+ "</div>")
+						?"<div id='FORCED_TF_TENDENCY_\"+ForcedTFTendency.MASCULINE_HEAVY+\"' class='cosmetics-button active'>"
+						+ "[style.boldGood("+ForcedTFTendency.MASCULINE_HEAVY.getName()+")]"
+						+ "</div>"
+						:"<div id='FORCED_TF_TENDENCY_"+ForcedTFTendency.MASCULINE_HEAVY+"' class='cosmetics-button'>"
+						+ "<span style='color:"+Colour.MASCULINE.getShades()[0]+";'>"+ForcedTFTendency.MASCULINE_HEAVY.getName()+"</span>"
+						+ "</div>")
+						+ "</div>" 
 					+ "</div>" 
+						
+						
+					
 				
 
 				+ "<div class='container-full-width' style='background:transparent; padding:0; margin-bottom:0; margin-top:0;'>"


### PR DESCRIPTION
This patch implements a new setting on the content options screen which allows the user to choose between five options for how preferred gender is selected for forced TFs.

- Neutral: The game behaves as it did before this change, selecting preferred gender for forced TFs based solely upon the tastes of the NPC conducting the transformation.
- Feminine: Without completely disregarding NPC tastes, the preferred gender will tend more towards feminine options.
- Feminine (Heavy): NPC tastes will be mostly disregarded, and forced TFs will generally move the player towards feminine genders.
- Masculine: Without completely disregarding NPC tastes, the preferred gender will tend more towards masculine options.
- Masculine (Heavy): NPC tastes will be mostly disregarded, and forced TFs will generally move the player towards masculine genders.

As much as possible my goal was to disrupt the existing operation of things as little as possible, both in terms of the presentation of the options screen and in how the game will operate for players who leave the setting as the default neutral value. However, some small tweaks were made to neutral gender options and livelihoods. 

Additionally, when the other options are enabled, I tried to keep the selection of preferred genders within the established patterns and norms presented in the existing code, but if any of my choices differ from what you would want to happen either technically or philosophically, please don't hesitate to correct things!

Thanks!