### PR TITLE
Couple of sex fixes

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -6346,7 +6346,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 					switch(penetrationType) {
 						case PENIS:
 							if(!characterPenetrating.isPlayer()) {
-								switch(getPenisType()){
+								switch(characterPenetrating.getPenisType()){
 									case ANGEL:
 										break;
 									case AVIAN:
@@ -6392,7 +6392,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 					switch(penetrationType) {
 						case PENIS:
 							if(characterPenetrating.isPlayer()) {
-								switch(getAssType()){
+								switch(characterPenetrated.getAssType()){
 									case DEMON_COMMON:
 										return "As the [pc.cockHead+] of your [pc.cock+] pushes its way into [npc.name]'s demonic, pussy-like [npc.asshole],"
 												+ " you feel a series of little writhing tentacles start to massage and stroke your throbbing length.";
@@ -6419,7 +6419,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 					switch(penetrationType) {
 						case PENIS:
 							if(!characterPenetrating.isPlayer()) {
-								switch(getPenisType()){
+								switch(characterPenetrating.getPenisType()){
 									case ANGEL:
 										break;
 									case AVIAN:
@@ -6466,7 +6466,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 					switch(penetrationType) {
 						case PENIS:
 							if(characterPenetrating.isPlayer()) {
-								switch(getVaginaType()){
+								switch(characterPenetrated.getVaginaType()){
 									case DEMON_COMMON:
 										return "As the [pc.cockHead+] of your [pc.cock+] pushes its way into [npc.name]'s demonic [npc.pussy], you feel a series of little writhing tentacles start to massage and stroke your throbbing length.";
 									default:
@@ -6492,7 +6492,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 					switch(penetrationType) {
 						case PENIS:
 							if(!characterPenetrating.isPlayer()) {
-								switch(getPenisType()){
+								switch(characterPenetrating.getPenisType()){
 									case ANGEL:
 										break;
 									case AVIAN:
@@ -6539,7 +6539,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 					switch(penetrationType) {
 						case PENIS:
 							if(characterPenetrating.isPlayer()) {
-								switch(getBreastType()){
+								switch(characterPenetrated.getBreastType()){
 									case DEMON_COMMON:
 										return "As the [pc.cockHead+] of your [pc.cock+] pushes its way into [npc.name]'s [npc.nipples+], you feel a series of little writhing tentacles start to massage and stroke your throbbing length.";
 									default:
@@ -6564,7 +6564,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 					switch(penetrationType) {
 						case PENIS:
 							if(!characterPenetrating.isPlayer()) {
-								switch(getPenisType()){
+								switch(characterPenetrating.getPenisType()){
 									case ANGEL:
 										break;
 									case AVIAN:
@@ -6614,7 +6614,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 					switch(penetrationType) {
 						case PENIS:
 							if(characterPenetrating.isPlayer()) {
-								switch(Main.game.getPlayer().getPenisType()){
+								switch(characterPenetrating.getPenisType()){
 									case ANGEL:
 										break;
 									case AVIAN:

--- a/src/com/lilithsthrone/game/sex/sexActions/universal/consensual/ConChairTop.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/universal/consensual/ConChairTop.java
@@ -1189,6 +1189,37 @@ public class ConChairTop {
 		}
 		
 	};
+		
+	public static final SexAction PLAYER_STOP_GETTING_PEGGED = new SexAction(
+		        SexActionType.PLAYER_STOP_PENETRATION,
+		        ArousalIncrease.TWO_LOW,
+		        ArousalIncrease.TWO_LOW,
+		        CorruptionLevel.ZERO_PURE,
+		        PenetrationType.TAIL,
+		        OrificeType.ANUS,
+		        SexParticipantType.CATCHER) {
+	    @Override
+	    public String getActionTitle() {
+		    return "Stop getting tail-pegged";
+	    }
+            @Override
+	    public String getActionDescription() {
+		    return "Get [npc.name] to pull [npc.her] [npc.tail] out of your [pc.asshole+].";
+	    }
+		
+	    @Override
+	    public String getDescription() {
+		    UtilText.nodeContentSB.setLength(0);
+		    
+		    UtilText.nodeContentSB.append(UtilText.returnStringAtRandom(
+				"Sliding [npc.name]'s [npc.tail] out of your [pc.asshole+], you let out [pc.a_moan+] as you tell [npc.herHim] to stop fucking you.",
+				"You lean into [npc.name], inhaling [npc.her] [npc.scent] before sliding [npc.her] [npc.tail] out of your [pc.asshole+]."));
+		    UtilText.nodeContentSB.append(UtilText.returnStringAtRandom(
+				" [npc.Name] lets out [npc.a_moan+] as you stop [npc.herHim] from fucking your [pc.asshole+].",
+				" [npc.A_moan+] escapes from between [npc.her] [npc.lips+], betraying [npc.her] desire to continue fucking your [pc.asshole+]."));
+		    return UtilText.nodeContentSB.toString();
+	    }
+	};
 	
 	public static final SexAction PLAYER_GET_TAIL_FUCKED = new SexAction(
 			SexActionType.PLAYER,


### PR DESCRIPTION
Currently, if a player is getting tail-pegged while on top during chair sex, they have no ability to stop it, which in turn means no changing positions. This fixes that.

Tested with Kate.

Also correct pulling the wrong orifice/penetration description on initial penetration.