### PR TITLE
Encoding compatibility for special characters

### DIFF
--- a/res/txt/places/dominion/shoppingArcade/dreamLover.xml
+++ b/res/txt/places/dominion/shoppingArcade/dreamLover.xml
@@ -3,10 +3,10 @@
 	<htmlContent tag="EXTERIOR"><![CDATA[
 	<p>
 		Unlike the rest of the buildings in the Arcade, the one in front of you has no real storefront to speak of, and the only indication of it being a shop at all is the rather plain-looking sign above the entrance bearing the name 'Dream Lover'.
-		 It's not like the place is in a state of decay, so you can’t say that it’s the worst looking shop you’ve ever seen, although it would definitely be in the running for the blandest.
+		 It's not like the place is in a state of decay, so you can't say that it's the worst looking shop you've ever seen, although it would definitely be in the running for the blandest.
 	</p>
 	<p>
-		Taking a closer inspection of the property, you can’t find any information that reveals the shop’s working hours, or even what sort of goods are stocked here.
+		Taking a closer inspection of the property, you can't find any information that reveals the shop's working hours, or even what sort of goods are stocked here.
 		 Despite all of this, there's also no indication that the store is closed, so you could take a look inside if you wanted to.
 	</p>
 	]]>
@@ -15,13 +15,13 @@
 	<htmlContent tag="EXIT"><![CDATA[
 	<p>
 		Having had enough of this store for now, you turn to look at Ashley, wondering if you should wave them goodbye.
-		 You doubt you’ll get any response, but, considering that you're the only two people here, it seems a little impolite not to say anything, so you call out,
-		 [pc.speech(I’ll be leaving now.)]
+		 You doubt you'll get any response, but, considering that you're the only two people here, it seems a little impolite not to say anything, so you call out,
+		 [pc.speech(I'll be leaving now.)]
 	</p>
 	<p>
-		Ashley doesn’t look at you, but you hear them mutter,
+		Ashley doesn't look at you, but you hear them mutter,
 		 [Ashley.speech(Feel free to come back any time.)]
-		 It’s a passionless plea, more like a social obligation than anything else, but at least they said something back.
+		 It's a passionless plea, more like a social obligation than anything else, but at least they said something back.
 	</p>
 	<p>
 		With a sigh of relief, you finally leave the building and the rude owner within it.
@@ -36,22 +36,22 @@
 	</p>
 	<p>
 		The first thing that strikes you is how huge the shop floor is; despite the unassuming exterior, you think that this must be one of the largest stores here in the Arcade.
-		 Rows and rows of free-standing shelves fill every available spot in the room, with each and every one of them being filled with so many different types of items that you can’t begin to guess what the store specialises in.
-		 The second thing that strikes you is how boring the shop looks; barring the products for sale, there’s not a single poster, potted plant, or any other form of decoration to be seen, giving the store a very 'brown' feel.
-		 Beige walls, plain wooden floor, brown shelves, brown counters... this dull aesthetic is accentuated by the fact that the store isn’t very well lit.
+		 Rows and rows of free-standing shelves fill every available spot in the room, with each and every one of them being filled with so many different types of items that you can't begin to guess what the store specialises in.
+		 The second thing that strikes you is how boring the shop looks; barring the products for sale, there's not a single poster, potted plant, or any other form of decoration to be seen, giving the store a very 'brown' feel.
+		 Beige walls, plain wooden floor, brown shelves, brown counters... this dull aesthetic is accentuated by the fact that the store isn't very well lit.
 	</p>
 	<p>
 		At the back of this richly stocked, but poorly decorated, shop is what you assume to be the owner, resting their head in their hands and adopting a slumped pose suggestive of extreme boredom.
-		 Strangely enough, they're wearing a black hooded cloak that covers them from head to toe, obscuring their body and face so much that you can’t possibly tell what gender or even what species they are.
-		 The counter behind which this figure is seated is located in the darkest corner of the room, which doesn’t help in your efforts to identify them.
+		 Strangely enough, they're wearing a black hooded cloak that covers them from head to toe, obscuring their body and face so much that you can't possibly tell what gender or even what species they are.
+		 The counter behind which this figure is seated is located in the darkest corner of the room, which doesn't help in your efforts to identify them.
 		 All you can make out from under the dark fabric is the faint shimmer of blue eyes; eyes that you now realise have been staring at you since the moment you walked into the store.
 	</p>
 	<p>
 		Deciding that it'd in your best interests to be polite, you walk over the counter and introduce yourself,
-		 [pc.speech(Hello, I’m [pc.name].)]
+		 [pc.speech(Hello, I'm [pc.name].)]
 	</p>
 	<p>
-		[Ashley.speech(I’m Ashley,)]
+		[Ashley.speech(I'm Ashley,)]
 		 an androgynous voice answers, giving you no clue as to what gender this person is.
 		 While Ashley doesn't give any hint of wanting any further interaction with you, they also seem to have lost interest in observing your every move, so you decide to step away and explore the shop.
 	</p>
@@ -65,16 +65,16 @@
 	<p>
 		The shop is filled to the brim with items suited for every taste, from the typical bouquets of flowers and expensive boxes of chocolates, to cosmetics and perfumes, to books and craft supplies, and everything in-between.
 		 Despite the wide range of goods on offer, it's only the chocolates and sweets that seem to be selling, while the rest of the stock, while dusted and in pristine condition, looks like it's never been touched by anyone but the owner.
-		 The sex toys could probably sell really well, but they’re so well hidden that it's almost impossible to find them without combing through the entire store.
+		 The sex toys could probably sell really well, but they're so well hidden that it's almost impossible to find them without combing through the entire store.
 	</p>
 	<p>
 		Other than the richly stocked shelves, the shop has a very lonely and empty feel.
-		 The walls are completely bare of decoration; there’s not even any posters to advertise products, and while the store is clean, it isn’t very well lit.
+		 The walls are completely bare of decoration; there's not even any posters to advertise products, and while the store is clean, it isn't very well lit.
 		 The whole room has a very 'brown' feeling to it, with both the wallpaper and the wooden floor bearing different shades of the dull colour.
 	</p>
 	<p>
 		In the back of the store, lurking in the darkest corner, is Ashley, the owner.
-		 The hooded cloak that they're wearing does a fantastic job of obscuring all of their features, except the faint glimmer of blue eyes, so much so that you can’t even tell what race or gender they are.
+		 The hooded cloak that they're wearing does a fantastic job of obscuring all of their features, except the faint glimmer of blue eyes, so much so that you can't even tell what race or gender they are.
 		 As ever, Ashley is resting their head in their hands and adopting a slumped pose suggestive of extreme boredom, while simultaneously giving off the vibe that they'll bite your head off if you dare bother them.
 	</p>
 	<p>
@@ -87,7 +87,7 @@
 	<htmlContent tag="ENTRY_REPEAT_ATTITUDE"><![CDATA[
 	<p>
 		As Ashley sees you walking around the store, they begin to throw the occasional grunt in your general direction.
-		 You can’t help but get annoyed at their rude attitude again...
+		 You can't help but get annoyed at their rude attitude again...
 	</p>
 	]]>
 	</htmlContent>
@@ -97,7 +97,7 @@
 		Wanting to discover what items there are on offer, you set off into the store, quickly losing yourself amongst the endless rows of shelves.
 	</p>
 	<p>
-		The first section that you walk through, being the one closest to the entrance, is filled with bouquets of flowers and boxes of chocolates; a scene, you think to yourself, reminiscent of a store in the build-up to Valentine’s day.
+		The first section that you walk through, being the one closest to the entrance, is filled with bouquets of flowers and boxes of chocolates; a scene, you think to yourself, reminiscent of a store in the build-up to Valentine's day.
 		 Judging by the number of out-of-stock products, it seems that the chocolates sell quite well, even if the flowers do look a little neglected...
 		 Continuing with your exploration, you soon discover that this store stocks items of all sorts.
 		 You find books that would be fit for an academy, art supplies that would make craft stores green with envy, sweets that one could find in a bakery, fishing supplies, exercise shoes, perfumes, even over-the-counter medicine; it seems that this shop has a little bit of everything.
@@ -105,7 +105,7 @@
 	</p>
 	<p>
 		You wonder why this store would offer such a huge variety of products if only some of them sell.
-		 Shouldn’t the space be used to stock more of the popular items instead?
+		 Shouldn't the space be used to stock more of the popular items instead?
 		 Despite their unpopularity, the goods all appear to be clean and kept free of dust, so it's obvious that the owner spends their time keeping them looking presentable.
 		 Was this meant to be a different type of store in its conception?
 		 With these questions in mind, you set off to get some answers from the mysterious shopkeeper, Ashley.
@@ -114,11 +114,11 @@
 		[Ashley.speech(What do you want?)]
 		 the hooded figure groans as they see you approach.
 		 Taken aback by the owner's brusque tone, you falter for a moment before starting to ask your questions, but before you can even get two sentences out, Ashley grunts in frustration and rudely interrupts you,
-		 [Ashley.speech(If you bother to look, you’ll notice that I have placed descriptions beneath each item I sell.
+		 [Ashley.speech(If you bother to look, you'll notice that I have placed descriptions beneath each item I sell.
 		 If you need any more clues than that, then you have no business being here.)]
 	</p>
 	<p>
-		That wasn’t actually what you were going to ask, but as you turn to scan your eyes over the shelves in order to confirm what's just been said, you see that there are indeed various plaques beneath each product which offer some hints at what they could be used for.
+		That wasn't actually what you were going to ask, but as you turn to scan your eyes over the shelves in order to confirm what's just been said, you see that there are indeed various plaques beneath each product which offer some hints at what they could be used for.
 		 Mildly annoyed at how this rude shopkeeper just treated you, you decide to drop your inquiries about the shop's curious inventory and head back to read some of the plaques instead.
 	</p>
 	<p>
@@ -135,11 +135,11 @@
 		 Seriously, what did I do to you to deserve this attitude?)]
 	</p>
 	<p>
-		[Ashley.speech(What’s with <i>my</i> attitude? The question you should be asking is what’s with <i>everyone else’s</i> attitude!)] they blurt out.
+		[Ashley.speech(What's with <i>my</i> attitude? The question you should be asking is what's with <i>everyone else's</i> attitude!)] they blurt out.
 	</p>
 	<p>
 		You open your mouth in an attempt to reply, but Ashley cuts you off,
-		 [Ashley.speech(When I opened this store I had only the noblest of intentions: to make this the one-stop place for everyone’s romantic needs. I gathered stock for <i>every</i> occasion.
+		 [Ashley.speech(When I opened this store I had only the noblest of intentions: to make this the one-stop place for everyone's romantic needs. I gathered stock for <i>every</i> occasion.
 		 Going on a first date? A rose bouquet is sure to please your partner.
 		 Planning a romantic dinner? I've got a wide selection of coloured and scented candles to help set the mood.
 		 Celebrating an anniversary? Need something with a bit more meaning? I have something on offer for almost every hobby!)]
@@ -149,25 +149,25 @@
 		 [Ashley.speech(But you've seen my store.
 		 The only things that sell are the chocolates, sweets, and other piddly items that people buy for <i>themselves</i>.
 		 People seem to be completely incapable of buying a bag of candies without starting to eat them before they've even exited the store!
-		 They don’t even taste any good!)]
+		 They don't even taste any good!)]
 		 Ashley snorts at the last part.
 	</p>
 	<p>
-		[Ashley.speech(It’s like nobody cares for anybody but themselves. My good intentions went down the drain!)]
+		[Ashley.speech(It's like nobody cares for anybody but themselves. My good intentions went down the drain!)]
 		 they exclaim, slamming a fist down on the counter,
-		[Ashley.speech(So yeah, that's what's up with my 'attitude'. I just want to see my products be appreciated, but no! Well, if my customers don’t care, then I won’t either!)]
+		[Ashley.speech(So yeah, that's what's up with my 'attitude'. I just want to see my products be appreciated, but no! Well, if my customers don't care, then I won't either!)]
 	</p>
 	<p>
 		You feel a little awkward at being forced to witness Ashley's outburst.
-		 Although they seem to quickly calm down, you don’t want to risk angering them again, so you quietly turn back to check out some of the merchandise.
+		 Although they seem to quickly calm down, you don't want to risk angering them again, so you quietly turn back to check out some of the merchandise.
 		 As you get some distance between yourself and the frustrated shopkeeper, you note that maybe the descriptions aren't as useless as you assumed; after all, it saves customers from having to deal with the owner...
 	</p>
 	<p>
 		As you're getting lost looking at the rows and rows of ignored merchandise, you hear Ashley call out,
-		 [Ashley.speech(If you haven’t guessed already, no 'sex' discounts. I’m not interested in <i>that</i>. But...)]
+		 [Ashley.speech(If you haven't guessed already, no 'sex' discounts. I'm not interested in <i>that</i>. But...)]
 		 their voice drops to a whisper,
-		 [Ashley.speech(If you manage to use these gifts properly instead of buying them only for yourself, I’d be more willing to negotiate.
-		 It’d be nice to see some of these items being appreciated... But I’m not going to wait on <i>that</i>. So buy the chocolates you were eyeing, or whatever.)]
+		 [Ashley.speech(If you manage to use these gifts properly instead of buying them only for yourself, I'd be more willing to negotiate.
+		 It'd be nice to see some of these items being appreciated... But I'm not going to wait on <i>that</i>. So buy the chocolates you were eyeing, or whatever.)]
 	</p>
 	<p>
 		With a roll of your eyes, you resume looking at the products, wondering how you'd ever prove to Ashley that you'd used them 'properly'...

--- a/src/com/lilithsthrone/game/character/npc/dominion/Ashley.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Ashley.java
@@ -133,7 +133,7 @@ public class Ashley extends NPC {
 					+ (Main.game.getPlayer().hasTraitActivated(Perk.OBSERVANT)
 							?"Despite the fact that you're highly observant, there's no giveaway whatsoever which would hint as to what Ashley's gender is."
 							:"You have no idea what Ashley's gender is.")
-					+ " Standing at full height, they measure 6' 1” (186cm)."
+					+ " Standing at full height, they measure [npc.heightFeetInches] ([npc.heightCm]cm)."
 				+ "</p>"
 				+ "<p>"
 					+ "The hood of their cloak is pulled up, completely obscuring their facial features."

--- a/src/com/lilithsthrone/game/character/npc/dominion/Pazu.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Pazu.java
@@ -46,8 +46,8 @@ public class Pazu extends NPC {
 				 *  Pazu is a harpy matriarch, and a particularly gorgeous one at that. Despite this, he is actually a male harpy, a fact that he keeps hidden from everyone else for obvious reasons.
 				 *  He has a friendly relationship with you, so you can visit his nest at any time*
 				 * TODO (Once lover)
-				 *  Pazu is a beautiful male harpy, and also your boyfriend. Despite being an ex-matriarch, he can act rather shy and bashful, and is still rather naïve.
-				 *  He adores with all his heart, but due to this, he’s not keen on sharing you with anybody else.
+				 *  Pazu is a beautiful male harpy, and also your boyfriend. Despite being an ex-matriarch, he can act rather shy and bashful, and is still rather na&iuml;ve.
+				 *  He adores with all his heart, but due to this, he's not keen on sharing you with anybody else.
 				 * TODO ( If he opens his candy shop and you're not his lover)
 				 *  Pazu is a beautiful male harpy, and the owner of a candy shop. He used to be a harpy matriarch, but left the oppressing nests in search of a simpler life.
 				 *  (if he opens the shop and is still your lover, his description is the same but with, "He also owns a candy shop in the shopping arcade." at the end)

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/shoppingArcade/SuccubisSecrets.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/shoppingArcade/SuccubisSecrets.java
@@ -429,7 +429,7 @@ public class SuccubisSecrets {
 						+ "She hands you a nearby brochure, and as you thank her, you can't help but feel quite taken aback at how casual she's acting about this."
 						+ "</p>"
 						+ "<p>"
-						+ "[pc.speech(Is there anything I can get for you?)] you ask, unsure of quite how to react to Kate's blasé attitude, [pc.speech(You don't seem very concerned about being pregnant...)]"
+						+ "[pc.speech(Is there anything I can get for you?)] you ask, unsure of quite how to react to Kate's blas&eacute; attitude, [pc.speech(You don't seem very concerned about being pregnant...)]"
 						+ "</p>"
 						+ "<p>"
 						+ "[kate.speech(Aww that's sweet of you, but I'm fine thanks. I love being pregnant!)] she laughs again, [kate.speech(It gives me an excuse to just lie around all day. Anyway, just let me know if you need something.)]"

--- a/src/com/lilithsthrone/game/inventory/item/ItemType.java
+++ b/src/com/lilithsthrone/game/inventory/item/ItemType.java
@@ -3396,8 +3396,8 @@ public class ItemType {
 			"Rose Bouquet",
 			"Rose Bouquets",
 			"A bouquet filled with roses of many colours, it smells pleasant even from a distance."
-				+ " [Ashley.speech(Just in case you're clueless to the point that you don’t even know the favourite colour of your intended recipient, every natural colour is included here.)]",
-			//				+ " If their favourite happens to be blue, tough luck; maybe you should try getting acquainted with another species of flower instead of going with what’s safe.)] ",
+				+ " [Ashley.speech(Just in case you're clueless to the point that you don't even know the favourite colour of your intended recipient, every natural colour is included here.)]",
+			//				+ " If their favourite happens to be blue, tough luck; maybe you should try getting acquainted with another species of flower instead of going with what's safe.)] ",
 			"giftRoseBouquet",
 			Colour.BASE_RED,
 			Colour.BASE_ORANGE,
@@ -3412,7 +3412,7 @@ public class ItemType {
 		public String getDescription() {
 			if(Main.game.getPlayer().getLocationPlace().getPlaceType()==PlaceType.SHOPPING_ARCADE_ASHLEYS_SHOP) {
 				return "A bouquet filled with roses of many colours, it smells pleasant even from a distance."
-						+ " [Ashley.speech(Just in case you're clueless to the point that you don’t even know the favourite colour of your intended recipient, every natural colour is included here.)]";
+						+ " [Ashley.speech(Just in case you're clueless to the point that you don't even know the favourite colour of your intended recipient, every natural colour is included here.)]";
 			} else {
 				return "A bouquet filled with roses of many colours, it smells pleasant even from a distance.";
 			}

--- a/src/com/lilithsthrone/game/inventory/weapon/WeaponType.java
+++ b/src/com/lilithsthrone/game/inventory/weapon/WeaponType.java
@@ -331,8 +331,8 @@ public class WeaponType {
 		public String getDescription() {
 			if(Main.game.getPlayer().getLocationPlace().getPlaceType()==PlaceType.SHOPPING_ARCADE_ASHLEYS_SHOP) {
 				return "A short-handled feather duster, ideal for keeping a house clean, but not much use in combat..."
-						+ " [Ashley.speech(A feather duster: the epitome of romance, at least for those who don’t know anything about their lover, other than that they're the person who keeps the house clean.)]";
-//						+ " Surely, that’s all that’s going on with their lives, right?)]";
+						+ " [Ashley.speech(A feather duster: the epitome of romance, at least for those who don't know anything about their lover, other than that they're the person who keeps the house clean.)]";
+//						+ " Surely, that's all that's going on with their lives, right?)]";
 			} else {
 				return "A short-handled feather duster, ideal for keeping a house clean, but not much use in combat...";
 			}

--- a/src/com/lilithsthrone/res/doc/bugs.txt
+++ b/src/com/lilithsthrone/res/doc/bugs.txt
@@ -9,23 +9,23 @@
 	
 	you still haven't put in a way to change the keybinds for the third row of commands.
 	
-	Perhaps adding a �cute� element to responses under the different Talks to include hearts?
+	Perhaps adding a 'cute' element to responses under the different Talks to include hearts?
 
 	dnieing selfaction still has no effect :/
 
-	NPCs don�t have pace change mechanic it seems. I am certain you�ll work on that, just putting it out there.
+	NPCs don't have pace change mechanic it seems. I am certain you'll work on that, just putting it out there.
 	
 	Suggestion for fetish gain: Fetishes normally are developed over time so gaining the anal fetish after fucking a few times is to be expected.
 	 What could be added is a small dialogue display asking if the player is interested in gaining a certain fetish after some conditions are met.
 	
-	I know that this version you�ll be adding more content as you�ve wrapped up with the pace mechanic, so I�d suggest to add more skin tones to be available to random NPCs and to Kate�s shop.
+	I know that this version you'll be adding more content as you've wrapped up with the pace mechanic, so I'd suggest to add more skin tones to be available to random NPCs and to Kate's shop.
 	
 	Succubus encounter, submitting: She apparently selected to kiss the PC but not actual text shows up to that effect. There is a gap where her action description should be; 
 	After selecting one of the request choices, they disappear never to be seen as options again.
 	
-	�Beg her/him to stop� says �Talk dirty to �� in the hover-over text.
+	'Beg her/him to stop' says 'Talk dirty to _' in the hover-over text.
 	
-	�Resisting� should have the same or similar effect on Arousal as �Calm Down� as, even if the rapist is still molesting you, you should not be getting aroused because you�re resisting and trying to get away.
+	'Resisting' should have the same or similar effect on Arousal as 'Calm Down' as, even if the rapist is still molesting you, you should not be getting aroused because you're resisting and trying to get away.
 	
 	some times see contrasting fetishes on mobs like androphilic + impregnation fetish
 	--------
@@ -171,7 +171,7 @@
 	
 	Double check the weather as it seems to apply inside buildings. I see it apply in Enforcer HQ.
 	Vaginal statues are still applied even with no vagina. This is due to the importer removing vaginas.
-	Fluff: The replace pans dialogue shows up before replacing panties, after which the replace pants dialogue shows up again. I don’t think women wear their panties on top of skirts or pants or w/e lol.
+	Fluff: The replace pans dialogue shows up before replacing panties, after which the replace pants dialogue shows up again. I don't think women wear their panties on top of skirts or pants or w/e lol.
 	
 	female (didn't encounter male, so I don't know if it affects them too) harpy parser pronouns not working? (they display as blank)
 	After Brax defeat/transformation (starting as male - androgynous) - "Your precum quickly lubricates your ." and "Your precum quickly lubricates your hard ."

--- a/src/com/lilithsthrone/res/doc/suggestions.txt
+++ b/src/com/lilithsthrone/res/doc/suggestions.txt
@@ -130,21 +130,21 @@ Perhaps there could be options to look for trouble/attack hostile NPCs in alleys
 	
 	
 	
-	Flesh out the post-sex page a little. We’ve talked before about variation based on just how well fucked the NPC is, but there could also be some other things. Some ideas:
-• Have a short description of them replacing their clothing. This pretty much exists already, the game gives narration when you swap your equipment around.
-• Have them wipe their face off if you gave them a facial.
-• Have them scoop the cum into their mouth if you gave them a facial and they’re a cum addict — Might have consequences if the cum has special effects.
-• If they have the “Dominant” fetish, they could say how they’ll get you next time, like the witches do.
-• If they (still) have the virginity fetish, they could thank you for not taking it.
-• If you took one of their virginities, they could comment on that. There’s a pretty long piece when the player loses one of their virginities, but the single line you get when you take an NPC’s virginity makes the “Deflowering” fetish basically just about the bonus XP.
-• If you gave them the broken virgin fetish, they could thank you for breaking them in and showing them the little slut they truly are.
-I’m sure there are a lot more, probably by the time you read this others will have suggested things I didn’t think of.
+	Flesh out the post-sex page a little. We've talked before about variation based on just how well fucked the NPC is, but there could also be some other things. Some ideas:
+* Have a short description of them replacing their clothing. This pretty much exists already, the game gives narration when you swap your equipment around.
+* Have them wipe their face off if you gave them a facial.
+* Have them scoop the cum into their mouth if you gave them a facial and they're a cum addict - Might have consequences if the cum has special effects.
+* If they have the "Dominant" fetish, they could say how they'll get you next time, like the witches do.
+* If they (still) have the virginity fetish, they could thank you for not taking it.
+* If you took one of their virginities, they could comment on that. There's a pretty long piece when the player loses one of their virginities, but the single line you get when you take an NPC's virginity makes the "Deflowering" fetish basically just about the bonus XP.
+* If you gave them the broken virgin fetish, they could thank you for breaking them in and showing them the little slut they truly are.
+I'm sure there are a lot more, probably by the time you read this others will have suggested things I didn't think of.
 
 Let us adjust how often whores appear relative to muggers, like we can with sex and gender ratios.
 
-Add actions to make subs lick off any cum you’ve got on you. Might have consequences if the cum has special effects.
+Add actions to make subs lick off any cum you've got on you. Might have consequences if the cum has special effects.
 
-Before the sex system is frozen, you should probably implement a system for restraint of limbs. This would be used for scenes like the stocks, for characters wearing cuffs, or just if the dominant decides to pin the sub’s hands in place with one of their own. The effect of this should be obvious — restricting any actions that require free hands. (And add a few for struggling or wiggling, I guess, to make up the difference)
+Before the sex system is frozen, you should probably implement a system for restraint of limbs. This would be used for scenes like the stocks, for characters wearing cuffs, or just if the dominant decides to pin the sub's hands in place with one of their own. The effect of this should be obvious - restricting any actions that require free hands. (And add a few for struggling or wiggling, I guess, to make up the difference)
 	
 	
 	
@@ -256,7 +256,7 @@ Receving cowgirl
 Sixty-nine where you can choose to be bottom whilst being dom (sometimes people might prefer to be gently sucked as bottom rather than ramming their cock in someone's mouth from top) : P 
 
 Receving/performing oral in missionary position;
-Being able to choose to face the wall yourself should you play as a sub (or facing the wall in general without the need to be a sub) ; ) The same goes for the ”Back to wall” position too.
+Being able to choose to face the wall yourself should you play as a sub (or facing the wall in general without the need to be a sub) ; ) The same goes for the "Back to wall" position too.
 
 And while this is fresh in my head, having relationships with slaves/Lilaya/Rose/shop owners/prostitutes would be awesome. Though I'm guessing that is for a future update.
 
@@ -465,21 +465,21 @@ Torn and destroyed items will be able to be repaired, so you won't lose your clo
 	
 	
 	
-	Now that multiple clothing colours are a thing, probably some of the old clothing items could do with them. Ones that spring immediately to mind as having significant non-primary-coloured parts would be the Bike Shorts, Shin Guards, Trainers, and Skater Shoes. Some of the panties also have that thing where if they’re light pink, they turn out white with trim, which would also suggest multiple coloured areas would fit nicely.
+	Now that multiple clothing colours are a thing, probably some of the old clothing items could do with them. Ones that spring immediately to mind as having significant non-primary-coloured parts would be the Bike Shorts, Shin Guards, Trainers, and Skater Shoes. Some of the panties also have that thing where if they're light pink, they turn out white with trim, which would also suggest multiple coloured areas would fit nicely.
 
-We’ll be able to set up slaves in double rooms soon, correct? Will roommates have relationships with each other? I can imagine a bit of variety depending on if they get along or not, maybe if they start fighting the player has to step in and make them resolve things?
+We'll be able to set up slaves in double rooms soon, correct? Will roommates have relationships with each other? I can imagine a bit of variety depending on if they get along or not, maybe if they start fighting the player has to step in and make them resolve things?
 
-In full character descriptions (selfie + examining NPC), animalistic faces are described, while human faces simply say “face”. Also, neither describes the colour of the face. IMO it should say something like “She has a feminine, human face with pale skin” or “He has a masculine, muzzled wolf-like face with white fur”.
+In full character descriptions (selfie + examining NPC), animalistic faces are described, while human faces simply say "face". Also, neither describes the colour of the face. IMO it should say something like "She has a feminine, human face with pale skin" or "He has a masculine, muzzled wolf-like face with white fur".
 
-Unzipping trousers or shorts doesn’t provide access to a character’s pussy. While that might not be enough of an opening to fuck someone, it should easily be enough to get a hand in and finger them.
+Unzipping trousers or shorts doesn't provide access to a character's pussy. While that might not be enough of an opening to fuck someone, it should easily be enough to get a hand in and finger them.
 
-The “Frustrated” status effect has been discussed before, but while quite a few people have complained about it, I don’t recall anyone else suggesting a way to improve it. One way would be, instead of basing it on orgasm count, to base it off of arousal level at the point sex ends; if you’re not aroused, you don’t get frustrated, if you’re building up to an orgasm and get denied, you do. Whether you’ve stayed calm while masturbating someone into oblivion, or are sated after having just cum yourself, either way you wouldn’t get frustrated.
+The "Frustrated" status effect has been discussed before, but while quite a few people have complained about it, I don't recall anyone else suggesting a way to improve it. One way would be, instead of basing it on orgasm count, to base it off of arousal level at the point sex ends; if you're not aroused, you don't get frustrated, if you're building up to an orgasm and get denied, you do. Whether you've stayed calm while masturbating someone into oblivion, or are sated after having just cum yourself, either way you wouldn't get frustrated.
 
-The shield spells are completely useless. They give you +50 resist, but they only last for 2 turns(?!?), so you’re pretty much wasting one action to get half damage on two enemy attacks. However, you’re then one attack behind them, so you actually only break even. Assuming that the enemy made that kind of attack, of course. If they made another kind of attack, you actually end up worse off than if you hadn’t cast anything. It would be worth casting a shield at the start of a fight if it had an extended duration, but with such a short duration they are totally not worth it.
+The shield spells are completely useless. They give you +50 resist, but they only last for 2 turns(?!?), so you're pretty much wasting one action to get half damage on two enemy attacks. However, you're then one attack behind them, so you actually only break even. Assuming that the enemy made that kind of attack, of course. If they made another kind of attack, you actually end up worse off than if you hadn't cast anything. It would be worth casting a shield at the start of a fight if it had an extended duration, but with such a short duration they are totally not worth it.
 
-We can suck our own fingers (or tail if we have one), but we can’t make our partner do it. This would be both an alternative means to get them lubed up before use, or if you’ve already used them, make them taste themself on you.
+We can suck our own fingers (or tail if we have one), but we can't make our partner do it. This would be both an alternative means to get them lubed up before use, or if you've already used them, make them taste themself on you.
 
-When farming for essence, it would be nice to have some form of indicator on the map to show if an NPC will give you any. Maybe a “Hunting Senses” perk? We could sure do with more of those. Or a spell we could learn — we have all sorts of examples of demons doing cool stuff with their magic, most of which we can’t learn to do.
+When farming for essence, it would be nice to have some form of indicator on the map to show if an NPC will give you any. Maybe a "Hunting Senses" perk? We could sure do with more of those. Or a spell we could learn - we have all sorts of examples of demons doing cool stuff with their magic, most of which we can't learn to do.
 	
 	
 	
@@ -671,17 +671,17 @@ more for the proof of concept of the current clothing system:
 	
 	Suggestions:
 
-Lust-inducing spells that attack willpower. I don’t think that needs elaborating.
+Lust-inducing spells that attack willpower. I don't think that needs elaborating.
 
 Some way to change gender preference, be it a new Mystery Kink enchant or something different.
 
-Let the player learn how to do “magic styling” like Kate does (possibly as part of her romance quest?), that they could use on slaves/encounters/themselves. Presumably this would have an essence cost comparable to the price in flames that Kate charges.
+Let the player learn how to do "magic styling" like Kate does (possibly as part of her romance quest?), that they could use on slaves/encounters/themselves. Presumably this would have an essence cost comparable to the price in flames that Kate charges.
 
 Speaking of which, it might be neat if, when buying from Kate, you could pay her in essence or cash.
 
-Items to improve certain specific tease attacks — for example a whip could make a sadist tease more effective.
+Items to improve certain specific tease attacks - for example a whip could make a sadist tease more effective.
 
-How about a perk for “Sterile”, giving -100 virility to match “Barren”?
+How about a perk for "Sterile", giving -100 virility to match "Barren"?
 
 The way gender is determined for androgynous NPCs could use some work. Presently, the only variable used is clothing, however IMO before that the game should take into account certain body features; an extreme example is an NPC I met recently with the cross-dressing and exhibitionism fetishes. Standing there topless, with crotchless chaps on, her huge breasts and pussy were fully on display, but she was wearing a masculine watch, so the game called her a man. So, as I said, IMO a character with visible breasts or an exposed pussy should be considered female, then clothing should be taken into account.
 

--- a/src/com/lilithsthrone/res/doc/todo_list.txt
+++ b/src/com/lilithsthrone/res/doc/todo_list.txt
@@ -225,7 +225,7 @@ color-able bell-collar bell with the metallic colors.
 	
 	I don't know if it always does it as I only had the one, but spraying Scarlett with "Diana's Perfume" gives - "A deep groan escapes from between Scarlett's lips, and she suddenly finds "command_unknown" thinking of how much she wants to dominate the next person she meets!"
 	
-	There is something different with the permissions for the slaves. Before they had sex with each other. But now the only ones who have sex are the ones display for public use. The permissions doesn´t make sense now.
+	There is something different with the permissions for the slaves. Before they had sex with each other. But now the only ones who have sex are the ones display for public use. The permissions doesn't make sense now.
 	
 	Was being spitroasted. Someone was doing an anal penetrative action, and all lines said they were fucking my ass, but when I went to respond to the dick in my ass, it said "eagerly hotdogged" and "eagerly anal fingered". It fixed itself later but I found it odd
 	
@@ -259,18 +259,18 @@ color-able bell-collar bell with the metallic colors.
 	it seems it does not recognise the gamestate as "default" and disables the button
 	
 	
-	“NPCs who hate/dislike non-con should now never use you after combat.”
-This seems a bit extreme, they should still fuck you if you don’t resist, IMO. If an NPC doesn’t resist you, the game doesn’t count it as rape, after all.
+	"NPCs who hate/dislike non-con should now never use you after combat."
+This seems a bit extreme, they should still fuck you if you don't resist, IMO. If an NPC doesn't resist you, the game doesn't count it as rape, after all.
 
 Bug Report:
 
-When I load saves from 1.98.5, my corruption gets reset to zero. The new “Arcane” stat also starts at zero, although I didn’t realise it immediately because of the bonus it has.
+When I load saves from 1.98.5, my corruption gets reset to zero. The new "Arcane" stat also starts at zero, although I didn't realise it immediately because of the bonus it has.
 
-All of the drinks except Feline’s Fancy are for Strength, are some meant to be for Arcane?
+All of the drinks except Feline's Fancy are for Strength, are some meant to be for Arcane?
 
 When enchanting a potion, some of the tooltips are bad:
-• For Arcane says that it increases intelligence.
-• Cold damage & resistance say they increase ice damage & resistance. These are basically the same of course, but they should use the same word I think.
+* For Arcane says that it increases intelligence.
+* Cold damage & resistance say they increase ice damage & resistance. These are basically the same of course, but they should use the same word I think.
 	
 	
 	The slave value calculation is really just a placeholder at the moment (it only takes into account race, obedience, and fetish count). I'll refine it and provide tooltips to show exactly how it's calculated soon! ^^
@@ -374,7 +374,7 @@ at javafx.web/com.sun.webkit.dom.EventListenerImpl.fwkHandleEvent(Unknown Source
 	
 	Using the Witch Seal sex option on a witch doesn't prevent self actions.
 	
-	That’s how the game works at this point. You need to add penis size+ effects if you want a reasonably sized one. I expect that it’ll be fixed before long, and the initial size of cock, balls, and cum (which all start at 0 at the moment) will depend on the race of the potion.
+	That's how the game works at this point. You need to add penis size+ effects if you want a reasonably sized one. I expect that it'll be fixed before long, and the initial size of cock, balls, and cum (which all start at 0 at the moment) will depend on the race of the potion.
 	
 	: I don't think the Sex Stats: Blowjobs (Given) is working correctly; I have 0 given when I know that number to be higher.
 	 BJ Cum given is also 0. Taken at 10 seems about right, and the cum taken is 10. Is cum given/taken supposed to be ejaculations or total spunk?
@@ -386,7 +386,7 @@ at javafx.web/com.sun.webkit.dom.EventListenerImpl.fwkHandleEvent(Unknown Source
 	   Lag also exists when selling all the items, which suggests the game is going through a list of each individual item instead of selling the stack in one go. 
 	
 	
-	Pinning an NPC face-to-wall; she’s wearing a miniskirt, not pulled up, plus pantyhose, plus panties; hotdogging and hotdogging tease are available. Surely all three of these should block that?
+	Pinning an NPC face-to-wall; she's wearing a miniskirt, not pulled up, plus pantyhose, plus panties; hotdogging and hotdogging tease are available. Surely all three of these should block that?
 		Add correct blocking to all clothing
 	
 	I'll see about adding a special tease in sex for if you have the anal/vaginal/oral/etc. fetish at maximum level. :3
@@ -417,10 +417,10 @@ at javafx.web/com.sun.webkit.dom.EventListenerImpl.fwkHandleEvent(Unknown Source
 	
 	It seems a little odd that all items of clothing are the same price. Surely a fancy jacket or dress should cost more than a pair of socks? Even the incredibly posh-looking dress coat is the same price.
 	
-	“Size Queen” fetish (Size King? M/M isn’t my thing, you’d have to ask a gay dude what they call guys who are into big dicks — or rather who like big dicks into them :P)
-	Effects would be a resistance to seduction damage from opponents without a visible bulge, vulnerability to seduction damage from opponents with a visible bulge, and change “Recovering Orifices” debuff for positive version.
+	"Size Queen" fetish (Size King? M/M isn't my thing, you'd have to ask a gay dude what they call guys who are into big dicks - or rather who like big dicks into them :P)
+	Effects would be a resistance to seduction damage from opponents without a visible bulge, vulnerability to seduction damage from opponents with a visible bulge, and change "Recovering Orifices" debuff for positive version.
 	
-	Similar to above, “Breast Lover” fetish could give resistance to seduction from flat opponents, vulnerability to especially busty opponents, “Anal Fetish” for ass size, and “Oral Fetish” for lip size. Orientation already provides effects conditional on opponent attributes, so the framework should be there already.
+	Similar to above, "Breast Lover" fetish could give resistance to seduction from flat opponents, vulnerability to especially busty opponents, "Anal Fetish" for ass size, and "Oral Fetish" for lip size. Orientation already provides effects conditional on opponent attributes, so the framework should be there already.
 	
 	How about clothing fetishes? You could have leather fetishes, jeans fetishes, etc. for various different classes of clothing.
 	
@@ -428,7 +428,7 @@ at javafx.web/com.sun.webkit.dom.EventListenerImpl.fwkHandleEvent(Unknown Source
 	
 Suggestion:
 
-It would be nice to be able to give Candi a good fucking. Perhaps a threesome with Brax once he’s with her.
+It would be nice to be able to give Candi a good fucking. Perhaps a threesome with Brax once he's with her.
 
 
 A couple bugs:
@@ -443,7 +443,7 @@ And not sure about merging health and stamina into one. For one, it takes away s
 
 And a question: do you mind being reminded of older bugs or do you keep a list anyway?
 
-If you want to make a positive version of “Frustrated”, the fetish to link it to would be “Self Denial”. It specifically mentions that you’re into edging if you have that one.
+If you want to make a positive version of "Frustrated", the fetish to link it to would be "Self Denial". It specifically mentions that you're into edging if you have that one.
 
 
 * Cum Stud. Liking or Disliking seems to make little sense, as why would increased/decreased Lust matter when you are already at the point of orgasm? Perhaps these will be tied more to NPC AI than Lust gains and be fairly irrelevant to the PC?
@@ -464,13 +464,13 @@ If you want to make a positive version of “Frustrated”, the fetish to link i
 
 Suggestion:
 
-I previously mentioned that it’s too easy to push a willing partner into unwilling pace, it also seems too easy to push an unwilling partner into willing pace. Don’t get me wrong — I like the idea of breaking down resistance so they start to accept it, but it should take more to do so, maybe making them cum a couple times or something. It would also be nice if they had something like a “Broken” pace, where they’re not resisting any more but aren’t as enthusiastic as an originally willing partner. Maybe gasping and moaning, but not asking you to do anything to them.
+I previously mentioned that it's too easy to push a willing partner into unwilling pace, it also seems too easy to push an unwilling partner into willing pace. Don't get me wrong - I like the idea of breaking down resistance so they start to accept it, but it should take more to do so, maybe making them cum a couple times or something. It would also be nice if they had something like a "Broken" pace, where they're not resisting any more but aren't as enthusiastic as an originally willing partner. Maybe gasping and moaning, but not asking you to do anything to them.
 
-That makes me think of another speech mutator you could add; something like “Non-verbal”, where dialog is replaced by grunts and moans, rather than having them added. You could use this for anyone whose intelligence is reduced below zero, or perhaps a counterpart fetish for “Bimbo”. I guess I’m imagining something like a bull-man whose animalistic side is dominant and who doesn’t speak, although it could be applied to any character technically.
+That makes me think of another speech mutator you could add; something like "Non-verbal", where dialog is replaced by grunts and moans, rather than having them added. You could use this for anyone whose intelligence is reduced below zero, or perhaps a counterpart fetish for "Bimbo". I guess I'm imagining something like a bull-man whose animalistic side is dominant and who doesn't speak, although it could be applied to any character technically.
 
 Bug Report:
 
-When you do your first load from the start screen, the “Load” tooltip hangs around on top of everything (even other windows) until you mouse over something else with a tooltip. Maybe add a line to clear the tooltip at the start of the load game function?
+When you do your first load from the start screen, the "Load" tooltip hangs around on top of everything (even other windows) until you mouse over something else with a tooltip. Maybe add a line to clear the tooltip at the start of the load game function?
 
 
 
@@ -480,13 +480,13 @@ Is there a way to free your slaves?
 
 Bug Report:
 
-When an NPC did the Breast Lover tease, she said “Your going to have fun playing with those!”. I’m pretty sure that should read “I’m going to have fun playing with those!”.
+When an NPC did the Breast Lover tease, she said "Your going to have fun playing with those!". I'm pretty sure that should read "I'm going to have fun playing with those!".
 
 Question:
 
 What is the difference between availablePrimaryColours and availablePrimaryDyeColours for clothing items? At first, I thought it meant that randomly generated items would pick from availablePrimaryColours, and availablePrimaryDyeColours would be a list that the player can choose from when using a dye brush, but this is clearly not the case. After adding colours to the dye list, NPCs started generating with clothes of those colours. So what is the difference between these two lists?
 	
-	Why does Ralph sell dye brushes? Most of his stock is food, with a section for things like condoms that wouldn’t fit in any of the other shops. But there is a shop for selling arcane supplies. It seems they would fit better there, or possibly in Nyan’s “Special” section, as the dye brush is for use on clothes.
+	Why does Ralph sell dye brushes? Most of his stock is food, with a section for things like condoms that wouldn't fit in any of the other shops. But there is a shop for selling arcane supplies. It seems they would fit better there, or possibly in Nyan's "Special" section, as the dye brush is for use on clothes.
 	
 	increase the tooltip delay time
 	
@@ -529,11 +529,11 @@ What is the difference between availablePrimaryColours and availablePrimaryDyeCo
 	
 	pull bandana down, not up
 	
-	I still think Arousal should be renamed to something like “Stimulation”. “Arousal” and “Lust” are kind of synonyms, yet in the game they represent two quite different things. Also, it should really only increase when characters are actually being stimulated for the most part; you still have the issue where characters will spontaneously cum for no reason, which shouldn’t really be the default. Maybe someone with the “Oral performer” fetish could be able to cum just from sucking someone off, someone with sensitive enough breasts could cum from having them played with, or a real masochist could cum from being spanked, but most characters should need more direct stimulation.
+	I still think Arousal should be renamed to something like "Stimulation". "Arousal" and "Lust" are kind of synonyms, yet in the game they represent two quite different things. Also, it should really only increase when characters are actually being stimulated for the most part; you still have the issue where characters will spontaneously cum for no reason, which shouldn't really be the default. Maybe someone with the "Oral performer" fetish could be able to cum just from sucking someone off, someone with sensitive enough breasts could cum from having them played with, or a real masochist could cum from being spanked, but most characters should need more direct stimulation.
 
-The character summary tooltip (mouse over a character’s level and race) currently just shows race type and colour for each part; maybe it could also include the size, for parts that have a size.
+The character summary tooltip (mouse over a character's level and race) currently just shows race type and colour for each part; maybe it could also include the size, for parts that have a size.
 
-There’s an imbalance between manually stimulating cocks and cunts. With a pussy, you can do either a single-turn action or a pink ongoing action, while a cock can only be stroked on a turn-by-turn basis. This also doesn’t seem to provide nearly the same arousal as fingering a pussy, so it takes quite a while to get a cock to cum with a handjob.
+There's an imbalance between manually stimulating cocks and cunts. With a pussy, you can do either a single-turn action or a pink ongoing action, while a cock can only be stroked on a turn-by-turn basis. This also doesn't seem to provide nearly the same arousal as fingering a pussy, so it takes quite a while to get a cock to cum with a handjob.
 	
 	I noticed that the navel piercing is labeled feminine, but there is no masculine equivalent. I'd like to get the piercing but I don't want to have to buy crossdressing just for that. 
 
@@ -549,25 +549,25 @@ Another annoying thing with the npcs is that even if they have seen you naked be
 	
 	Suggestions:
 
-Give each NPC primary, secondary, and tertiary favourite colours; then when they get new clothing, rather than picking the colour of new items at random (so they look less like a rainbow puked all over them), give them a 50/33/17% chance to pick their respective favourite colours. When multiple items are generated at once they only come in one or two colours, but there doesn’t appear to be any effort made to match replacement clothing to existing clothing, resulting in rather odd outfits if you take just one item of clothing each time.
+Give each NPC primary, secondary, and tertiary favourite colours; then when they get new clothing, rather than picking the colour of new items at random (so they look less like a rainbow puked all over them), give them a 50/33/17% chance to pick their respective favourite colours. When multiple items are generated at once they only come in one or two colours, but there doesn't appear to be any effort made to match replacement clothing to existing clothing, resulting in rather odd outfits if you take just one item of clothing each time.
 
-An NPC who dislikes or hates raping will give up pretty soon if you resist them, but maybe they shouldn’t even start? Maybe replace the “Resist sex” button with a dialog where you turn them down and they accept that on the defeat screen?
+An NPC who dislikes or hates raping will give up pretty soon if you resist them, but maybe they shouldn't even start? Maybe replace the "Resist sex" button with a dialog where you turn them down and they accept that on the defeat screen?
 
-If we can’t afford to buy all of an item that a trader has in stock, maybe the button should instead buy all that we can afford to?
+If we can't afford to buy all of an item that a trader has in stock, maybe the button should instead buy all that we can afford to?
 
 Bug Reports:
 
 The lines blanking out cells (0,0), (0,1), and (1,0) on starting a new game are duplicated in the importGame method, causing these cells to be blanked out each time you load the game.
 
-NPCs without a vagina probably shouldn’t generate with the “Pussy slut” fetish.
+NPCs without a vagina probably shouldn't generate with the "Pussy slut" fetish.
 
-If you take an NPCs clothing without fucking them, they don’t get new clothes. The new clothes need linking to the button to continue on without fucking an NPC as well as the post-sex continue button.
+If you take an NPCs clothing without fucking them, they don't get new clothes. The new clothes need linking to the button to continue on without fucking an NPC as well as the post-sex continue button.
 
-If an NPC dominating you gives up due to low lust before they cum, they get the standard “Frustrated” status effect but the post-sex scene plays out that they’re satisfied.
+If an NPC dominating you gives up due to low lust before they cum, they get the standard "Frustrated" status effect but the post-sex scene plays out that they're satisfied.
 
 The attacker and defender are still the wrong way around when calculating seduction damage regarding orientation.
 
-If I take an NPCs panties, it tells me that I pull her skirt up, take her panties off, then pull her skirt down again (which makes sense). The problem is that I then examine her, and it tells me that I haven’t seen her naked groin, so I don’t know that she has down there. If I explicitly pull her skirt up, it reveals her details like it should, but that implicit one when I take her panties doesn’t, yet it should.
+If I take an NPCs panties, it tells me that I pull her skirt up, take her panties off, then pull her skirt down again (which makes sense). The problem is that I then examine her, and it tells me that I haven't seen her naked groin, so I don't know that she has down there. If I explicitly pull her skirt up, it reveals her details like it should, but that implicit one when I take her panties doesn't, yet it should.
 	
 	
 	-Why can't I select my fetishes right from the start? What's the point/fun in leveling this?
@@ -586,15 +586,15 @@ I would also like for NPCs in the submissive position to be able request the use
 
 	One may or may not be a bug, but surprised me. I had a female character who repeatedly had sex with a male who had the Impregnation and Seeder fetishes. He always pulled out after sex. I would have expected him to be *less* likely to pull out (and I would assume female characters with Pregnancy/Brood Mother fetishes to be more inclined for you to cum in them).
 	
-	The description for the “Deflowering” fetish doesn’t mention taking penile virginity.
+	The description for the "Deflowering" fetish doesn't mention taking penile virginity.
 
-	Anal fingering doesn’t have the “Masturbation” fetish attached.
+	Anal fingering doesn't have the "Masturbation" fetish attached.
 	
-	The dirty talk for the PC performing “Paizuri” (maybe a setting to turn off gratuitous japanese? Might be setting creep…) instead plays the lines for the PC receiving same.
+	The dirty talk for the PC performing "Paizuri" (maybe a setting to turn off gratuitous japanese? Might be setting creep...) instead plays the lines for the PC receiving same.
 	
 	Question:
 	
-	Has the rate of item drops increased? It seems like I’m finding items more, and NPCs less when I explore the alleyways.
+	Has the rate of item drops increased? It seems like I'm finding items more, and NPCs less when I explore the alleyways.
 	
 	Bug: Kneeling to give a futa NPC cunnilingus in a submissive scene; the NPC swaps to a blowjob by first sticking her dick in your character's mouth, and stops you eating her out in the following 'round'. That only works if you have two mouths.
 		Additional bug: when you have 15 actions in the Sex Actions window, thus filling every button space, the 15th action (bottom right hand corner) is duplicated to the second page. This duplicated option functions correctly but has no tooltip when you hover over the button.
@@ -603,12 +603,12 @@ I would also like for NPCs in the submissive position to be able request the use
 	
 	When performing a blowjob on the cat girl it says (You're struggling to fit ray's avian shaft down your throat.) Instead of the other way around.
 	
-	Change preg: I’ve looked at the code, and the formula is simply fertility + virility, except if either of these is less than zero.
+	Change preg: I've looked at the code, and the formula is simply fertility + virility, except if either of these is less than zero.
 	
 	Breast reveal reactions using wrong character
 	
 	Hi, imported a character from a previous version: male human named Jason level 4 and got him in the auction. Then decided to transform him in a hermaphrodite greater aligator boy; then impregnate him and waited the 7 days. Suddenly some of his kids started to pop up in the back-allies, but Jason is still pregnant.
-		Is a Little more complicated, Jason appears as still pregnant in the pregnancy stats window, but when i visit him, he isn´t. But the other characters that got pregnant on the same day or after have the resolved pregnancy status.
+		Is a Little more complicated, Jason appears as still pregnant in the pregnancy stats window, but when i visit him, he isn't. But the other characters that got pregnant on the same day or after have the resolved pregnancy status.
 	
 	images
 	
@@ -700,7 +700,7 @@ Need to add cumming on self stomach
 
 I will also add an option to set the size of Dominion. :3
 
-Stopped thigh sex right before I had an orgasm, got “You slide your throbbing horse-like cock out of Player's thighs.”, had orgasm, and then self actions tab appeared blank.  Switching to a few other tabs and then back to self actions fixed it.
+Stopped thigh sex right before I had an orgasm, got "You slide your throbbing horse-like cock out of Player's thighs.", had orgasm, and then self actions tab appeared blank.  Switching to a few other tabs and then back to self actions fixed it.
 
 Going going to page 2 of sex actions and then switching to another tab puts you on the second page of that action tab, which is (usually) blank.
 
@@ -718,8 +718,8 @@ Going going to page 2 of sex actions and then switching to another tab puts you 
 	
 	still have the bug where the last person you had sex with is the only one you see under a magnifying glass when buying slaves.
 	
-One seriously annoying bug here; something seems to be wrong with one of my save files. One character, I can’t export from 97.1 (error log). I can export from 96.5, but when I import into 97.5, I can’t save (error log). This is just the one character; other characters I’m having no problems with.
-OK, so I followed up on that bad save I mentioned. Looks like there’s an entry under game > playerCharacter > character > playerSpecific > booksRead that has an empty string for the value, which translates to a null in game, and the 0.97 exporter is choking on it. Not sure why the 0.96 exporter generated that — I haven’t looked into it that deeply — but deleting that entry from a 0.96 export file fixes the problem, 97.5 will save the resulting game just fine. I was even able to keep the progress I made in 97.1 by making a 97.2 build with the exporter bug fixed.
+One seriously annoying bug here; something seems to be wrong with one of my save files. One character, I can't export from 97.1 (error log). I can export from 96.5, but when I import into 97.5, I can't save (error log). This is just the one character; other characters I'm having no problems with.
+OK, so I followed up on that bad save I mentioned. Looks like there's an entry under game > playerCharacter > character > playerSpecific > booksRead that has an empty string for the value, which translates to a null in game, and the 0.97 exporter is choking on it. Not sure why the 0.96 exporter generated that - I haven't looked into it that deeply - but deleting that entry from a 0.96 export file fixes the problem, 97.5 will save the resulting game just fine. I was even able to keep the progress I made in 97.1 by making a 97.2 build with the exporter bug fixed.
 	
 	Couple last bug reports, it seems like the "Cum on chest" option doesn't work (though maybe that's intentional because you just haven't added it yet)
 	
@@ -769,7 +769,7 @@ The third bug occurs when I go to the Export Character screen. If I try to delet
 	
 	slaves: : It would be nice if there was a permission level right below "use you" something along the lines of "permission to beg". IE instead of permission to aggressively jump you in the hallway they have permission to submissively ask for sex
 	
-	Give the player some control over where NPCs cum, at least if they’re the dominant partner. When I fuck an NPC with a dick in missionary, they keep cumming on me. I’d prefer to make them shoot it on their own stomach, chest, or face.
+	Give the player some control over where NPCs cum, at least if they're the dominant partner. When I fuck an NPC with a dick in missionary, they keep cumming on me. I'd prefer to make them shoot it on their own stomach, chest, or face.
 
 Bug Reports:
 
@@ -777,15 +777,15 @@ Tail-fucking and pegging are still unavailable in the oral positions.
 
 The cells at (0,0), (0,1), and (1,0) are still being obscured on load.
 
-When you strip an NPC during sex, revealing parts of them sometimes doesn’t print a description of the part like it should. I’m guessing this is related to the bug where NPCs won’t react to you stripping off.
+When you strip an NPC during sex, revealing parts of them sometimes doesn't print a description of the part like it should. I'm guessing this is related to the bug where NPCs won't react to you stripping off.
 
-When fucking Kate, there are two “Dirty talk” actions. Also, the buttons to permit/forbid clothing and self-actions aren’t there.
+When fucking Kate, there are two "Dirty talk" actions. Also, the buttons to permit/forbid clothing and self-actions aren't there.
 
-When doing the quick transform with a succubus, the adjective for her breasts doesn’t match up with what breasts of that size are normally called.
+When doing the quick transform with a succubus, the adjective for her breasts doesn't match up with what breasts of that size are normally called.
 
 A couple of possible bugs regarding the fluid soiling system:
-Are females who don’t displace/strip their clothing supposed to dirty their panties when they cum? I ask because girlcum doesn’t seem to dirty anything else that I can see; usually it’s cum that messes things up.
-Is it supposed to dirty the mouth slot if you cum down someone’s throat?
+Are females who don't displace/strip their clothing supposed to dirty their panties when they cum? I ask because girlcum doesn't seem to dirty anything else that I can see; usually it's cum that messes things up.
+Is it supposed to dirty the mouth slot if you cum down someone's throat?
 	
 	Remotely chanigng NPC's clothing should reveal genitals
 	
@@ -804,37 +804,37 @@ This one I'm more than certain is a bug. When I finally got that demon to fuck m
 	Another thing i noticed, though it may not be a bug (i think it is though, due to inconsitency and just not fitting the theme) is when you are preforming oral as the domminant character, you have the choice to "Request" either a creampie (which should just be a "Cum in my Mouth" type order) or "Request" Pullout (which also could be more of a order in this situation)
 		So from the above you may notice my point, your the dominant in this scene, yet you act as a submissive. Also, aldo technicaly correct, i feel cumming in the mouth isnt the same as a creampie, but thats more of a matter of personal preferance i guess.
 
-Also of note is that NPCs seem to disregard your command more often than not. I’ve lost count of the times I’ve told them to pull out and they haven’t.
+Also of note is that NPCs seem to disregard your command more often than not. I've lost count of the times I've told them to pull out and they haven't.
 	
 	Not sure if this is a bug, but when being split roasted and you have a slave NPC's dick in your pussy, and the other in your mouth they both have a chance to impregnate you when they cum.
 	
 	
 	Suggestions:
 
-When enchanting a TF potion, as well as showing the effect we have selected, also show what that stat is currently. When enchanting a potion with more than one or two effects, I keep having to examine myself (or my target — maybe show stats for NPCs in the current cell too?) to check, and that drops you out of enchanting, clearing current effects in the list. I end up literally writing a shopping list of TFs to remind myself what I need to hit my goal.
+When enchanting a TF potion, as well as showing the effect we have selected, also show what that stat is currently. When enchanting a potion with more than one or two effects, I keep having to examine myself (or my target - maybe show stats for NPCs in the current cell too?) to check, and that drops you out of enchanting, clearing current effects in the list. I end up literally writing a shopping list of TFs to remind myself what I need to hit my goal.
 
-Show percentage somewhere on health bars. Since restore potions restore by percent, not by a fixed amount, knowing if I’ll get the most out of one would be nice.
+Show percentage somewhere on health bars. Since restore potions restore by percent, not by a fixed amount, knowing if I'll get the most out of one would be nice.
 
-I posted this as a reply to an older post, but I’m not sure if you’ll have seen it, so again:
-The first time the sub tries to strip you, give you a couple of reaction options like with cumming; either to allow them, or stop them. This would be better than either them being able to get you half-undressed before you stop them, or magically knowing that you don’t want them stripping you.
+I posted this as a reply to an older post, but I'm not sure if you'll have seen it, so again:
+The first time the sub tries to strip you, give you a couple of reaction options like with cumming; either to allow them, or stop them. This would be better than either them being able to get you half-undressed before you stop them, or magically knowing that you don't want them stripping you.
 
 Make stroking a cock transfer fluids from hand to cock, and vice-versa.
 
 Bug Report:
 
-When PC is dominated, NPC fingering PC’s ass, the anal fingering self actions are available.
+When PC is dominated, NPC fingering PC's ass, the anal fingering self actions are available.
 
-Still being dommed by same succubus, she spreads her ass open and presents herself to me. …While standing behind me fucking me in doggy. She seems to like doing this one, did it several times.
+Still being dommed by same succubus, she spreads her ass open and presents herself to me. ...While standing behind me fucking me in doggy. She seems to like doing this one, did it several times.
 
 While I was getting fucked, + sucking my fingers, stroking my own cock was greyed out. It said my urethra was unavailable.
 
-PC dominated by Brax, kneeling, sucking him, both cum at once, there are two options; “Stay in position”, and “Cum on floor”. “Cum on floor” works just fine, but “Stay in position” doesn’t. Error log here.
+PC dominated by Brax, kneeling, sucking him, both cum at once, there are two options; "Stay in position", and "Cum on floor". "Cum on floor" works just fine, but "Stay in position" doesn't. Error log here.
 
-XML saves still don’t save whether or not PC has seen NPC genitals.
+XML saves still don't save whether or not PC has seen NPC genitals.
 
-When getting a big… “Discount” from Ralph, the tooltip for “Take it” refers to your pussy even if you don’t have one and he’s using your ass.
+When getting a big... "Discount" from Ralph, the tooltip for "Take it" refers to your pussy even if you don't have one and he's using your ass.
 
-Also when getting Ralph’s discount, when a customer is at the counter, staying still and doing nothing increases his arousal just as much as teasing him. Also, it seems to be pretty much impossible in the new version to finish before he does.
+Also when getting Ralph's discount, when a customer is at the counter, staying still and doing nothing increases his arousal just as much as teasing him. Also, it seems to be pretty much impossible in the new version to finish before he does.
 
 In 69, a female getting licked blocks her from blowing a male on the bottom.
 
@@ -851,24 +851,24 @@ In 69, a female getting licked blocks her from blowing a male on the bottom.
 	My character is not wearing anything in the over-torso slot, yet it still shows up as being dirty after having sex in a back alley
 	
 	
-	There’s inconsistency with when you can and can’t save; many times, you can quicksave, or overwrite an existing save, but you can’t create a new save because you aren’t in a tile’s default scene. If you aren’t supposed to be able to save here, all saves should be disabled. If, as was the case previously, we should be able to save between beating an NPC and fucking them (for example), the new save button needs fixing.
+	There's inconsistency with when you can and can't save; many times, you can quicksave, or overwrite an existing save, but you can't create a new save because you aren't in a tile's default scene. If you aren't supposed to be able to save here, all saves should be disabled. If, as was the case previously, we should be able to save between beating an NPC and fucking them (for example), the new save button needs fixing.
 
 When domming an NPC in doggy, the hotdogging actions rely on your butt being free, not theirs.
 
-Domming an NPC in doggy; they finger their ass, this shows three “Anal Fingering” actions, which have in the tooltip description “finger their ass”, but requirements for your ass being free.
+Domming an NPC in doggy; they finger their ass, this shows three "Anal Fingering" actions, which have in the tooltip description "finger their ass", but requirements for your ass being free.
 
-The “Last Save” on the initial screen doesn’t reflect the actual save files, if you’ve moved or deleted the one the game thinks was last, it will show wrong. This could be fixed by checking the save file with the most recent timestamp, although given how long it takes to load a file this might not work too well; you’d need to profile a load to see if it’s parsing the XML or creating the gameworld that is expensive before deciding, I think.
+The "Last Save" on the initial screen doesn't reflect the actual save files, if you've moved or deleted the one the game thinks was last, it will show wrong. This could be fixed by checking the save file with the most recent timestamp, although given how long it takes to load a file this might not work too well; you'd need to profile a load to see if it's parsing the XML or creating the gameworld that is expensive before deciding, I think.
 
-If playing with a clean install (no properties.xml), when you start your first game you get the “Demon” and “Cat-morph” encyclopedia entries as soon as you first encounter Lilith. I’d argue that since you don’t actually see her, you shouldn’t get the demon entry until you meet Lilaya. You certainly shouldn’t get the Cat-morph entry that early, and even after you do meet that first cat-morph (it would be interesting to run into her again later, btw), you don’t get the encyclopedia entry for her horse-morph friends.
+If playing with a clean install (no properties.xml), when you start your first game you get the "Demon" and "Cat-morph" encyclopedia entries as soon as you first encounter Lilith. I'd argue that since you don't actually see her, you shouldn't get the demon entry until you meet Lilaya. You certainly shouldn't get the Cat-morph entry that early, and even after you do meet that first cat-morph (it would be interesting to run into her again later, btw), you don't get the encyclopedia entry for her horse-morph friends.
 	
 	
 	
 	Simple but great addition would be to check if we have same version of java as you did while working on the jar & warn us if we don't (same place we see our java ver.) Bold warning with correct ver written will save a lot of trouble in the future...
 	
 
-“Shifting aside” makes sense for panties, but seems less fitting for boxers. I would expect those to have similar displacement options to trousers, such as “unbutton” and “pull down”.
+"Shifting aside" makes sense for panties, but seems less fitting for boxers. I would expect those to have similar displacement options to trousers, such as "unbutton" and "pull down".
 
-When raping an NPC who isn’t into your gender, it seems way too hard to make them cum. This may be related to the general sex bugs; the effects in the sidebar show two sets of “+your arousal”, rather than one for each partner, but I remember it being a real chore to get an unwilling partner off in previous versions too. Hopefully when you split physical stimulation off from mental arousal, this will work out better.
+When raping an NPC who isn't into your gender, it seems way too hard to make them cum. This may be related to the general sex bugs; the effects in the sidebar show two sets of "+your arousal", rather than one for each partner, but I remember it being a real chore to get an unwilling partner off in previous versions too. Hopefully when you split physical stimulation off from mental arousal, this will work out better.
 
 There are presently technical issues preventing saving during combat or sex; would these also disallow loading the game during these? I often find I want to do that, for various reasons.
 	
@@ -896,7 +896,7 @@ There are presently technical issues preventing saving during combat or sex; wou
 	so if you import a char as a slave they wont be attracted to you no matter what if they dont has the incest fetish
 	
 	
-	Lilaya & Kate: I’m also hoping that soon using any of the “Rough” actions will switch the pace to rough, like they do in most scenes.
+	Lilaya & Kate: I'm also hoping that soon using any of the "Rough" actions will switch the pace to rough, like they do in most scenes.
 	
 	The action buttons in sex scenes are all jumbled up now.
 	
@@ -986,7 +986,7 @@ There are presently technical issues preventing saving during combat or sex; wou
 	
 	add the option for a bigger map
 	
-	NPCs with the “TF Test Subject” fetish object to being fed potions (during sex). I’m guessing they’re not supposed to.
+	NPCs with the "TF Test Subject" fetish object to being fed potions (during sex). I'm guessing they're not supposed to.
 	
 	
 	
@@ -1073,14 +1073,14 @@ It was actually quite amusing, I got to grind out 8 condoms super quick
 -also, making these and the existing lubricate fingers repeatable might be nice(maybe rename it "lick fingers"), some people might like being able to stick their fingers in their parter then licking the fluids on their fingers.
 
 	
-When neither partner is doing anything, dirty talk is something like “I’ll be gentle” or “I’m going to fuck you senseless”, depending on pace. Maybe if the scene has been going on long enough for one of you to cum, there should be other lines, like “Did you like that, you little slut?” or “Good girl, I enjoyed that!”
+When neither partner is doing anything, dirty talk is something like "I'll be gentle" or "I'm going to fuck you senseless", depending on pace. Maybe if the scene has been going on long enough for one of you to cum, there should be other lines, like "Did you like that, you little slut?" or "Good girl, I enjoyed that!"
 
-While I’m thinking about dirty talk, there’s a noticable difference in tone between the rough talk when you’re doing something to them, and the rough talk when you’re making them do something to you.
-The former are basically all variants on “You’re enjoying that, aren’t you slut?”, while the latter has both that and a number of lines telling them how worthless they are, or how they’re no good at what they’re doing. Maybe those should only appear if you have a fetish for that kind of thing?
+While I'm thinking about dirty talk, there's a noticable difference in tone between the rough talk when you're doing something to them, and the rough talk when you're making them do something to you.
+The former are basically all variants on "You're enjoying that, aren't you slut?", while the latter has both that and a number of lines telling them how worthless they are, or how they're no good at what they're doing. Maybe those should only appear if you have a fetish for that kind of thing?
 
 It might be nice to be able to change the pace of a scene without having to already be doing anything.
 
-Some positions should probably have limits on clothing displacement. If I’m pinning someone face-first against a wall, or face down on the floor, they’re probably going to have a hard time undressing me.
+Some positions should probably have limits on clothing displacement. If I'm pinning someone face-first against a wall, or face down on the floor, they're probably going to have a hard time undressing me.
 	
 	
 	Wouldn't "Broken virgin" also give positive points in the stocks since they're desperate for sex?
@@ -1106,22 +1106,22 @@ Some positions should probably have limits on clothing displacement. If I’m pi
 	
 	Suggestions:
 
-I’m not so keen on how the equipped icons are now even smaller than they were before.
- It wouldn’t be so bad if there was a nice big picture of each item in its tooltip.
-  You could also enlarge that panel quite a bit; there’s a lot of empty space around it, after all.
+I'm not so keen on how the equipped icons are now even smaller than they were before.
+ It wouldn't be so bad if there was a nice big picture of each item in its tooltip.
+  You could also enlarge that panel quite a bit; there's a lot of empty space around it, after all.
    The layout also seems poorer than it was previously; before, clothing was largely arranged from head to foot vertically, and from outer to inner horizontally. Now, it just seems more random.
 
-The default for dominant scenes used to be that the sub couldn’t touch your clothes unless you told them they could.
- Now this has changed to being permitted by default. One isn’t inherently better than the other, but having gotten used to the old way, I keep forgetting to do so.
-  Maybe adding something on the UI to indicate these permissions would help remind us that we need to manually forbid each time? Maybe even an option to choose the default, so we don’t have to explicitly say it each time?
+The default for dominant scenes used to be that the sub couldn't touch your clothes unless you told them they could.
+ Now this has changed to being permitted by default. One isn't inherently better than the other, but having gotten used to the old way, I keep forgetting to do so.
+  Maybe adding something on the UI to indicate these permissions would help remind us that we need to manually forbid each time? Maybe even an option to choose the default, so we don't have to explicitly say it each time?
 
-I’m hoping that part of the sex re-work will be changing it so the submissive partner can no longer push the dominant away when they (the submissive) cum.
+I'm hoping that part of the sex re-work will be changing it so the submissive partner can no longer push the dominant away when they (the submissive) cum.
 
-Allow us to use more than just letters and numbers for save names. I can’t see any point to that restriction. Unicode would be ideal, but even the full set of printable ASCII would be better than it is now. (Less characters banned from filenames, of course)
+Allow us to use more than just letters and numbers for save names. I can't see any point to that restriction. Unicode would be ideal, but even the full set of printable ASCII would be better than it is now. (Less characters banned from filenames, of course)
 
 Bug Reports:
 
-There are a bunch of warnings (five) in the log about how “An instance of AbstractItem was unable to be imported”. I’m not noticing anything missing from anyone’s inventory, but five out of hundreds of items in the world would be easy to miss.
+There are a bunch of warnings (five) in the log about how "An instance of AbstractItem was unable to be imported". I'm not noticing anything missing from anyone's inventory, but five out of hundreds of items in the world would be easy to miss.
 
 	
 	Clothing removal - Before your chemise is able to be removed, Chemise and Dress coat need to be removed.
@@ -1168,46 +1168,46 @@ There are a bunch of warnings (five) in the log about how “An instance of Abst
 	
 	Suggestions:
 
-		Maybe the “Anal Fingering” action should have the “Masturbation” fetish applied to it?
+		Maybe the "Anal Fingering" action should have the "Masturbation" fetish applied to it?
 		
-		It might be a good idea to block NPCs from doing the “spread pussy/ass” action if you’re already fucking them.
+		It might be a good idea to block NPCs from doing the "spread pussy/ass" action if you're already fucking them.
 		
-		There really should be a way to access a slave’s inventory while talking to them.
+		There really should be a way to access a slave's inventory while talking to them.
 		
-		It would be good if, during sex scenes, it remembered which tab you’re on when an orgasm reaction comes up; as of now, you get switched to the “Misc. Actions” tab, rather than back to the one you were on.
+		It would be good if, during sex scenes, it remembered which tab you're on when an orgasm reaction comes up; as of now, you get switched to the "Misc. Actions" tab, rather than back to the one you were on.
 		
-		It might be an idea for finger sucking (and tail sucking for demons) to be limited to those with the “Oral Performer” fetish. Quickly getting them wet is one thing, but keeping on sucking them is kind of weird, unless it’s a stand in for some other kind of sucking they’d rather be doing.
+		It might be an idea for finger sucking (and tail sucking for demons) to be limited to those with the "Oral Performer" fetish. Quickly getting them wet is one thing, but keeping on sucking them is kind of weird, unless it's a stand in for some other kind of sucking they'd rather be doing.
 		
 		If a wandering NPC is addicted to you, maybe their encounter rate should go up as they go into withdrawal? I mean, they should be actively seeking you out, right?
 		
-		Currently, when you leave a wandering NPC, they get brand new clothing for six of their slots (less the bra if they have no breasts). Presently, they always seem to get this, but maybe they sometimes shouldn’t. It might be nice if NPCs didn’t always bother with underwear, or for some items of underwear, they don’t really need anything on top — the bikini and croptop spring to mind here, and I’ve used the boyshorts as a stand-in for athletic wear before too. Exhibitionist NPCs might not bother with anything, going topless or even full nude.
+		Currently, when you leave a wandering NPC, they get brand new clothing for six of their slots (less the bra if they have no breasts). Presently, they always seem to get this, but maybe they sometimes shouldn't. It might be nice if NPCs didn't always bother with underwear, or for some items of underwear, they don't really need anything on top - the bikini and croptop spring to mind here, and I've used the boyshorts as a stand-in for athletic wear before too. Exhibitionist NPCs might not bother with anything, going topless or even full nude.
 		
 		Bug Reports:
 		
-		The introduction for prostitutes refers to slutty clothes and heavy makeup, but as far as I can see they actually wear pretty much the same outfits as any other NPC, and don’t necessarily wear makeup either (and males don’t seem to ever wear makeup without the crossdressing fetish).
+		The introduction for prostitutes refers to slutty clothes and heavy makeup, but as far as I can see they actually wear pretty much the same outfits as any other NPC, and don't necessarily wear makeup either (and males don't seem to ever wear makeup without the crossdressing fetish).
 		
-		In character descriptions, “dark grey” text appears as red.
+		In character descriptions, "dark grey" text appears as red.
 		
-		I went to the slavery screen, opened a slave’s inventory, then clicked on their name at the top-right to examine them. What I got was not them, but the last NPC I examined out in the city.
+		I went to the slavery screen, opened a slave's inventory, then clicked on their name at the top-right to examine them. What I got was not them, but the last NPC I examined out in the city.
 		
-		During a sex scene, on the NPC’s turn, instead of them taking an action it played out that I was spreading my ass out for them.
+		During a sex scene, on the NPC's turn, instead of them taking an action it played out that I was spreading my ass out for them.
 		
 		
 	Suggestion:
 
-This first one was written before I read this post, so it might be obsolete given the upcoming changes; I’m going to post it anyway because it might still be useful.
-NPCs always seem to end sex scenes as soon as each participant has had at least one orgasm (or sometimes if they have had one orgasm for rape scenes). It would be cool if, instead, they would want to end it after they’d had as many orgasms as they want, based on something like a “sex appetite” stat. This would vary from NPC to NPC (demons would obviously have a very high one). This could also link up with the orgasm control stuff we talked about before; when an NPC reaches their orgasm limit, they’d try to end the scene, depending on factors (they might not if they had lost combat, or had the forced orgasm or submissive fetishes, for example).
-This would also add depth to the post-sex scene, which at the moment is typically a binary satisfied/unsatisfied thing. You could have several varieties, from totally unsatisfied, through partially sated, totally satisfied, then a couple of overstimulated levels of panting and gasping exhaustion, depending on the ratio of orgasms to orgasm limit. One side-effect of this would be that player-submissive scenes could get very long if, for example, you lost a fight with a demon; one possible fix would be to have the PC pass out and wake up later, skipping the scene so you don’t have to watch the NPC fuck you to several dozen orgasms or whatever. Another could be a sensitivity stat so demons might come really quickly, reducing the time to rack up a high orgasm count.
+This first one was written before I read this post, so it might be obsolete given the upcoming changes; I'm going to post it anyway because it might still be useful.
+NPCs always seem to end sex scenes as soon as each participant has had at least one orgasm (or sometimes if they have had one orgasm for rape scenes). It would be cool if, instead, they would want to end it after they'd had as many orgasms as they want, based on something like a "sex appetite" stat. This would vary from NPC to NPC (demons would obviously have a very high one). This could also link up with the orgasm control stuff we talked about before; when an NPC reaches their orgasm limit, they'd try to end the scene, depending on factors (they might not if they had lost combat, or had the forced orgasm or submissive fetishes, for example).
+This would also add depth to the post-sex scene, which at the moment is typically a binary satisfied/unsatisfied thing. You could have several varieties, from totally unsatisfied, through partially sated, totally satisfied, then a couple of overstimulated levels of panting and gasping exhaustion, depending on the ratio of orgasms to orgasm limit. One side-effect of this would be that player-submissive scenes could get very long if, for example, you lost a fight with a demon; one possible fix would be to have the PC pass out and wake up later, skipping the scene so you don't have to watch the NPC fuck you to several dozen orgasms or whatever. Another could be a sensitivity stat so demons might come really quickly, reducing the time to rack up a high orgasm count.
 
-There perhaps should be a lesser version of the “Exposed” statuses for when a character’s underwear is exposed, but not their body. This probably shouldn’t have it’s own fetish, simply being covered by the exhibitionist fetish. Too many more fetishes will make the screen unwieldy, and require them to be categorised in some way. This would of course require clothing items to be flagged as being underwear or outerwear, since as I’ve previously observed, it isn’t reliable to do it by clothing slot.
+There perhaps should be a lesser version of the "Exposed" statuses for when a character's underwear is exposed, but not their body. This probably shouldn't have it's own fetish, simply being covered by the exhibitionist fetish. Too many more fetishes will make the screen unwieldy, and require them to be categorised in some way. This would of course require clothing items to be flagged as being underwear or outerwear, since as I've previously observed, it isn't reliable to do it by clothing slot.
 
-The feminine watch is really restricted in available colours. I can’t see why it shouldn’t have the same colour palette as any other item of clothing. Similarly, jewelry could easily be any of the regular colours as well as the metallic ones.
+The feminine watch is really restricted in available colours. I can't see why it shouldn't have the same colour palette as any other item of clothing. Similarly, jewelry could easily be any of the regular colours as well as the metallic ones.
 
 Bug Reports:
 
-I recently commented on how NPCs might sometimes not fill all clothing slots, and how some underwears could really pass as outerwear. A counterpart to that is that, even when filling all slots, NPCs often end up not covering up fully. I’ve often seen NPCs spawning with the crotchless and cupless underwears in conjunction with a microskirt or fishnet top. This seems to be the norm for exhibitionists, but it happens with NPCs without the exhibitionist fetish too.
+I recently commented on how NPCs might sometimes not fill all clothing slots, and how some underwears could really pass as outerwear. A counterpart to that is that, even when filling all slots, NPCs often end up not covering up fully. I've often seen NPCs spawning with the crotchless and cupless underwears in conjunction with a microskirt or fishnet top. This seems to be the norm for exhibitionists, but it happens with NPCs without the exhibitionist fetish too.
 
-When you use Arthur’s hypno-watch on someone, it says they are now “command_unknown”.
+When you use Arthur's hypno-watch on someone, it says they are now "command_unknown".
 	
 	Bug: The bug with the alligator head transformation reappeared. This is the one where the PC's description will describe their hair as, for example "You have 'long', 'brown', 'scales' in place of hair, [...]" showing both hair length, hair color, and hair style, when these do not apply to alligator hair transformations.
 Perhaps you could add a rule, like if the hair type equals to alligator, then there shouldn't be any type of hair descriptions, instead opting for the one which states that the hair is made of scales?
@@ -1259,8 +1259,8 @@ Perhaps you could add a rule, like if the hair type equals to alligator, then th
 	you can tell that giving harpies beaks isn't fully supported yet. Kissing: 'you slide your tongue past her full lips'
 	
 	And now here's an odd one:
-		If you have enchanted (green/blue, doesn't matter) panties (also doesn't matter which exactly, anything in the groin slot apart from the groinless options) and an unenchanted pantyhose, and then get creampied—ass or vagina, doesn't matter—then your pantyhose gets dirtied, not your panties. If the pantyhose is enchanted as well or if the pantyhose is enchanted and the panties are unenchanted, it works normally and dirties the panties.
-		And in that same vein: If you have an enchanted pantyhose and any—enchanted or unenchanted—onepiece bodysuit or swimsuit, then getting creampied dirties the onepiece, even though it's supposed to go over the pantyhose. All other enchantment configurations seem to work normally.
+		If you have enchanted (green/blue, doesn't matter) panties (also doesn't matter which exactly, anything in the groin slot apart from the groinless options) and an unenchanted pantyhose, and then get creampied-ass or vagina, doesn't matter-then your pantyhose gets dirtied, not your panties. If the pantyhose is enchanted as well or if the pantyhose is enchanted and the panties are unenchanted, it works normally and dirties the panties.
+		And in that same vein: If you have an enchanted pantyhose and any-enchanted or unenchanted-onepiece bodysuit or swimsuit, then getting creampied dirties the onepiece, even though it's supposed to go over the pantyhose. All other enchantment configurations seem to work normally.
 	
 	[old tooltip bug]
 	I can't add any points in my skill tree that is on the right side. i.e, i can't get runner, flirty, barren etc, but i can get arcane power.
@@ -1339,41 +1339,41 @@ Perhaps you could add a rule, like if the hair type equals to alligator, then th
 	
 	Suggestions:
 
-	Presently, some hairstyles have a minimum hair length. Maybe some hairstyles should have a maximum length, too? I’m imagining someone with hair down to their knees trying to style it in a mohawk or afro. I’m no stylist, but that doesn’t seem possible.
+	Presently, some hairstyles have a minimum hair length. Maybe some hairstyles should have a maximum length, too? I'm imagining someone with hair down to their knees trying to style it in a mohawk or afro. I'm no stylist, but that doesn't seem possible.
 	
-	Make spanking someone reduce their arousal if they don’t have the Masochist fetish.
+	Make spanking someone reduce their arousal if they don't have the Masochist fetish.
 	
 	Bug Report:
 	
 	The thigh high boots and the heart necklace are darker than other items of clothing.
 	
-	NPC’s hair seems wrong. Examining one, she has 43″ hair, which should be “incredibly long”, but her description just lists it as “long”.
+	NPC's hair seems wrong. Examining one, she has 43" hair, which should be "incredibly long", but her description just lists it as "long".
 	
 	
 	
 	
 	Are NPCs supposed to spawn with snowflake jewelry out of season? Playing a save still in October, and NPCs are spawning with them.
 
-Vicky sells essences, but won’t buy them. Ralph doesn’t sell them, but will buy them from you. This is probably wrong.
+Vicky sells essences, but won't buy them. Ralph doesn't sell them, but will buy them from you. This is probably wrong.
 
-Most potions are named in the style of “Canine elixir of <whatever>”, or something similar. However, reindeer potions are simply named “Elixir of <whatever>”.
+Most potions are named in the style of "Canine elixir of <whatever>", or something similar. However, reindeer potions are simply named "Elixir of <whatever>".
 
-The demon transform menu is a bit inconsistent if you’re only part demon:
-If your arms or legs aren’t demonic, you can’t edit them at all (and if they are, you can’t change them to anything else — what is that section even for?);
-If your eyes aren’t demonic, you’re permitted to edit what your eyes would be if they were demonic, but this doesn’t affect your actual, non-demonic eyes;
-For the rest of your body, you seem to be able to edit it freely even if it’s still human (or one of the furry types).
+The demon transform menu is a bit inconsistent if you're only part demon:
+If your arms or legs aren't demonic, you can't edit them at all (and if they are, you can't change them to anything else - what is that section even for?);
+If your eyes aren't demonic, you're permitted to edit what your eyes would be if they were demonic, but this doesn't affect your actual, non-demonic eyes;
+For the rest of your body, you seem to be able to edit it freely even if it's still human (or one of the furry types).
 
-If you start a new game while in an existing one, any characters in the current cell get added to the new game’s contact list.
+If you start a new game while in an existing one, any characters in the current cell get added to the new game's contact list.
 
 I met a brand new NPC in cell (0,0) and immediately knew the details of her cock and ass, before getting her naked. This is an update, I reported a similar case before and suggested it might be related to an import error, but this time was in a new game started in version 1.96.1, so not an import error.
 
-Given how long the demon tail is described as being, you should really be able to tail-fuck or tail-peg a partner from any position, but some of them don’t allow you to. Seems to be the oral positions (doggy, kneeling, and 69) that are missing it.
+Given how long the demon tail is described as being, you should really be able to tail-fuck or tail-peg a partner from any position, but some of them don't allow you to. Seems to be the oral positions (doggy, kneeling, and 69) that are missing it.
 
-The “Tease Clit” action disappears when you start fucking someone.
+The "Tease Clit" action disappears when you start fucking someone.
 
 When you drink a stat boost potion (as opposed to a TF potion), the list of effects is printed out twice.
 
-I’m guessing this one is a “WONTFIX”, but for completeness sake: When you start a new game with an imported character, in the intro sequence in the street, the catgirl says “He’s human” even if you aren’t. Even if you’re a full demon, they don’t react, and Lilaya still finds it surprising that you aren’t affected by the storm.
+I'm guessing this one is a "WONTFIX", but for completeness sake: When you start a new game with an imported character, in the intro sequence in the street, the catgirl says "He's human" even if you aren't. Even if you're a full demon, they don't react, and Lilaya still finds it surprising that you aren't affected by the storm.
 	
 	
 	Tail and horn rings. These items go in the tail and horn slots, respectively, and are essentially rings that fit (or clasp around) on tails and horns.
@@ -1405,20 +1405,20 @@ I'll also add a way to change NPC's sexuality soon, as that seems to be a heavil
 	
 	add the "self-insemination" action to sex scenes soon (the one that used to be present in Brax's sex scene), so I'll get virgins with pregnancy/broodmother fetishes to use that
 	
-	Slaves without the “Exhibitionist” fetish should probably lose affection if you make them go naked.
+	Slaves without the "Exhibitionist" fetish should probably lose affection if you make them go naked.
 	
-	Likewise, alley encounters don’t react to storm conditions. Not such a big deal with muggers, since all they do is attack you anyway, but prostitutes probably shouldn’t still be working.
+	Likewise, alley encounters don't react to storm conditions. Not such a big deal with muggers, since all they do is attack you anyway, but prostitutes probably shouldn't still be working.
 	
 	
 	I'll see about adding a small variation to NPC's levels when using a level-scaling difficulty (+/- 3 sounds good).
 	
-	There’s some sort of problem with the public stocks. The scenes are fine, but the first intro line (You decide to have some fun with the <Insert Race Here> in the stocks nearest you) is buggy. At first I thought it was just going off the first one regardless of which one you picked, but subsequently I realised it was more than that when it told me I was fucking a wolf-girl when there wasn’t a wolf-girl there.
+	There's some sort of problem with the public stocks. The scenes are fine, but the first intro line (You decide to have some fun with the <Insert Race Here> in the stocks nearest you) is buggy. At first I thought it was just going off the first one regardless of which one you picked, but subsequently I realised it was more than that when it told me I was fucking a wolf-girl when there wasn't a wolf-girl there.
 
-Well, I say the scenes are fine, but they obviously need a lot more work; they use the same actions as the regular scenes, leading to such things as non-con slaves “trying to pull away from you, but you easily stop them”, or willing slaves masturbating despite being restrained.
+Well, I say the scenes are fine, but they obviously need a lot more work; they use the same actions as the regular scenes, leading to such things as non-con slaves "trying to pull away from you, but you easily stop them", or willing slaves masturbating despite being restrained.
 
-I just met a trap, and despite never having seen her naked, I apparently just knew she was a trap and what her cock and ass look like. If it’s relevant, she was in one of the cells that was obfuscated on import.
+I just met a trap, and despite never having seen her naked, I apparently just knew she was a trap and what her cock and ass look like. If it's relevant, she was in one of the cells that was obfuscated on import.
 
-NPCs with the “Transformer” fetish don’t respect gender content options. They don’t need to follow the same frequency or anything, but if I’ve completely disabled a body-type from being in the game, it might be an idea to filter it from NPC TF preferences too.
+NPCs with the "Transformer" fetish don't respect gender content options. They don't need to follow the same frequency or anything, but if I've completely disabled a body-type from being in the game, it might be an idea to filter it from NPC TF preferences too.
 	
 	have a button for Take All, Sell All in the inventory
 	
@@ -1503,7 +1503,7 @@ Npc's are doing that black magic voodoo thing where they're pulling up my chemis
 		submissive sex to alleyway attackers is still locked behind the submissive fetish
 		
 		
-	Also on that note, the selfie screen then says you lost that virginity—including oral if you sucked your tail—to that partner instead of to yourself. Should sucking your tail even count as "giving head"?
+	Also on that note, the selfie screen then says you lost that virginity-including oral if you sucked your tail-to that partner instead of to yourself. Should sucking your tail even count as "giving head"?
 	
 	Having multiple tails only lets you occupy a single one. Same with more than two hands, you can only use two at a time.
 	
@@ -1572,30 +1572,30 @@ Npc's are doing that black magic voodoo thing where they're pulling up my chemis
 	
 	
 	
-	Started a new game in 1.95, chose “very experienced”, Lilaya’s tests, “You’ll always remember this moment as the time that you lost your penile virginity!”.
+	Started a new game in 1.95, chose "very experienced", Lilaya's tests, "You'll always remember this moment as the time that you lost your penile virginity!".
 	
-	Importing a save exported from 1.89, the center panel appears but the side panels don’t. Needless to say, the game is not playable in this state.
+	Importing a save exported from 1.89, the center panel appears but the side panels don't. Needless to say, the game is not playable in this state.
 	
-	Tried out the new thigh sex, and it told me that my partner’s pre-cum lubricated their thighs. It obviously should have been my thighs (and status-effect-wise it was, it’s just the narration that was wrong).
+	Tried out the new thigh sex, and it told me that my partner's pre-cum lubricated their thighs. It obviously should have been my thighs (and status-effect-wise it was, it's just the narration that was wrong).
 	
-	The new Paizuri dirty talk is for the be-cocked partner, but not for the boobèd one.
-	Paizuri doesn’t have ongoing narration (pink italic text).
-	Thigh sex doesn’t have ongoing narration or dirty talk.
-	Hotdogging doesn’t have ongoing narration or dirty talk.
+	The new Paizuri dirty talk is for the be-cocked partner, but not for the boobed one.
+	Paizuri doesn't have ongoing narration (pink italic text).
+	Thigh sex doesn't have ongoing narration or dirty talk.
+	Hotdogging doesn't have ongoing narration or dirty talk.
 	
-	When you’re fucking someone’s ass, and they come, it talks about their pussy squeezing down (if they have one), but not their ass. One would think that you’d be more likely to notice the one that you were actually in.
+	When you're fucking someone's ass, and they come, it talks about their pussy squeezing down (if they have one), but not their ass. One would think that you'd be more likely to notice the one that you were actually in.
 	
-	My “Strengthened Aura” effect doesn’t seem to be affecting my willpower resist, at least according to the stat screen. It’s showing -70 from my “Frustrated” effect and my corruption, but that should be brought back up to -45 from the “Strengthened Aura”, which doesn’t appear to be the case.
+	My "Strengthened Aura" effect doesn't seem to be affecting my willpower resist, at least according to the stat screen. It's showing -70 from my "Frustrated" effect and my corruption, but that should be brought back up to -45 from the "Strengthened Aura", which doesn't appear to be the case.
 	
 	Weirdness:
 	
-	The “lacy plunge bra” and “lacy panties” don’t look particularly lacy to me.
+	The "lacy plunge bra" and "lacy panties" don't look particularly lacy to me.
 	
 	A black blazer is noticeably darker than other black clothing.
 	
-	I see a bunch of items geing generated with “+Stamina Damage” effect. Does this actually do anything? I don’t think I’ve come across any stamina damaging attacks so far.
+	I see a bunch of items geing generated with "+Stamina Damage" effect. Does this actually do anything? I don't think I've come across any stamina damaging attacks so far.
 	
-	Lilaya makes such a big deal about your amazing aura after her “tests”, even going so far as saying you should warn any other demons you meet, yet none of these other demons seem to notice. OK, OK, maybe I just want to see the “lazy demon” get all hyper. I think that would be cute.
+	Lilaya makes such a big deal about your amazing aura after her "tests", even going so far as saying you should warn any other demons you meet, yet none of these other demons seem to notice. OK, OK, maybe I just want to see the "lazy demon" get all hyper. I think that would be cute.
 	
 	
 	idle slaves with house freedom be able to use or be used by other idle slaves or working slaves?
@@ -1715,31 +1715,31 @@ BlobHyperSweats1
 	
 	Suggestions:
 
-If you force your way into Zaranix’s house, Katherine clearly hears you, but when you meet her she reacts the same as she does if you sneak in. Maybe she should say something about how you must have beaten Amber instead?
+If you force your way into Zaranix's house, Katherine clearly hears you, but when you meet her she reacts the same as she does if you sneak in. Maybe she should say something about how you must have beaten Amber instead?
 
-You could put in interactions between slave’s obedience and affection, for example a slave that loves you but is defiant could gain obedience over time. Conversely, a slave that hates you could see their obedience suffer. I’m not sure if affection should track towards obedience, you could probably make a case either way for that.
+You could put in interactions between slave's obedience and affection, for example a slave that loves you but is defiant could gain obedience over time. Conversely, a slave that hates you could see their obedience suffer. I'm not sure if affection should track towards obedience, you could probably make a case either way for that.
 
-NPC dirty talk regarding virginity is a little odd. They will mention that they’re a virgin every other sentence, even if you don’t have a cock and couldn’t possibly take it, but they never mention they’re an anal or oral virgin even when you put them on their knees or rub your cock on their ass. They just say “That's right, fuck my ass!”, same as anyone else. Maybe they should wait until you actually get your cock out (especially if you’re feminine), and have some sort of comment if losing one of their other virginities is apparently imminent.
+NPC dirty talk regarding virginity is a little odd. They will mention that they're a virgin every other sentence, even if you don't have a cock and couldn't possibly take it, but they never mention they're an anal or oral virgin even when you put them on their knees or rub your cock on their ass. They just say "That's right, fuck my ass!", same as anyone else. Maybe they should wait until you actually get your cock out (especially if you're feminine), and have some sort of comment if losing one of their other virginities is apparently imminent.
 
 Bug Reports:
 
-The “Repeat Actions” tab could still use a little work; actions that are unavailable even momentarily get removed from it, and stay out of it even if they become available again. It might be better to simply keep a list of all actions taken, and rebuild the “Repeat Actions” tab each turn. That way, you’d not only not lose actions that had been unavailable, the buttons would automatically be in order of how recently you used that action.
+The "Repeat Actions" tab could still use a little work; actions that are unavailable even momentarily get removed from it, and stay out of it even if they become available again. It might be better to simply keep a list of all actions taken, and rebuild the "Repeat Actions" tab each turn. That way, you'd not only not lose actions that had been unavailable, the buttons would automatically be in order of how recently you used that action.
 
 When you drink a potion in combat, the description header still says the action you did last turn.
 
 While most of the witch set is obviously feminine, the hat should really be neutral.
 
-I beat a witch, transformed her, and there was no hilight on her current height (6′3″).
+I beat a witch, transformed her, and there was no hilight on her current height (6'3").
 
 After finishing with that witch, I decided to start a new game. The new game character customisation screen was showing everything for the witch, and no changes I made actually affected me.
 
 The heart necklace is noticably darker than other jewelry of the same colour.
 
-If you give someone (who doesn’t have one) a cock with a potion, it defaults to zeroes on all three sizes. I’m frankly amazed that nobody seems to have reported this before! I guess F2M isn’t all that popular or something?
+If you give someone (who doesn't have one) a cock with a potion, it defaults to zeroes on all three sizes. I'm frankly amazed that nobody seems to have reported this before! I guess F2M isn't all that popular or something?
 
-If you fuck someone who is too loose, the “Too loose” status remains even after you stop.
+If you fuck someone who is too loose, the "Too loose" status remains even after you stop.
 
-Both Arthur’s package and his watch can be found randomly in alleyways.
+Both Arthur's package and his watch can be found randomly in alleyways.
 	
 	
 	
@@ -1747,33 +1747,33 @@ Both Arthur’s package and his watch can be found randomly in alleyways.
 	
 	----------
 	
-		When buying Scarlett, maybe add a third option for players who aren’t that keen on owning a slave but don’t want to just eat the ¤2500 they spent, so offer that you’ll free her if she works it off. She’d presumably start out hating you less, and being less unruly, with a big hit later if you decide to screw her over down the line.
+		When buying Scarlett, maybe add a third option for players who aren't that keen on owning a slave but don't want to just eat the 2500 they spent, so offer that you'll free her if she works it off. She'd presumably start out hating you less, and being less unruly, with a big hit later if you decide to screw her over down the line.
 	
-		In a scene, when an NPC rubs their crotch through their clothes, maybe it shouldn’t tell you that a trap or shemale is rubbing their cock if you haven’t seen it before, just say “crotch”?
+		In a scene, when an NPC rubs their crotch through their clothes, maybe it shouldn't tell you that a trap or shemale is rubbing their cock if you haven't seen it before, just say "crotch"?
 		
-		Speaking of which, how come we can grope our own crotch, but not an NPC’s?
+		Speaking of which, how come we can grope our own crotch, but not an NPC's?
 		
 		Bug Reports:
 		
-		I know it’s on the radar already, but I thought it worth a reminder that there is basically no lesbian option for the chair scene Lilaya and Kate use.
+		I know it's on the radar already, but I thought it worth a reminder that there is basically no lesbian option for the chair scene Lilaya and Kate use.
 		
-		Speaking of Lilaya, I just had a scene with her where she kept on using her tail on herself, I kept pulling it out and she immediately reinserted it, Every. Single. Time. Something like a couple dozen times in a row. And because you’re technically still the submissive partner in that scene even if you turn things around, you can’t forbid her from doing this.
+		Speaking of Lilaya, I just had a scene with her where she kept on using her tail on herself, I kept pulling it out and she immediately reinserted it, Every. Single. Time. Something like a couple dozen times in a row. And because you're technically still the submissive partner in that scene even if you turn things around, you can't forbid her from doing this.
 		
-		I think I found a bug with an encounter with an NPC with the “Unwilling Fuck-toy” fetish. She was ambiphillic, so her resisting should have been an act, but her arousal obviously had the large penalty an NPC gets when they really don’t want you fucking them, as it kept dropping to zero. This might have had something to do with her being a slave in the stocks; maybe that uses the wrong “resisting” scene, the real one, by mistake?
+		I think I found a bug with an encounter with an NPC with the "Unwilling Fuck-toy" fetish. She was ambiphillic, so her resisting should have been an act, but her arousal obviously had the large penalty an NPC gets when they really don't want you fucking them, as it kept dropping to zero. This might have had something to do with her being a slave in the stocks; maybe that uses the wrong "resisting" scene, the real one, by mistake?
 		
-		Penises are regaining their virginity on export/import. Well… sort of. They show as virgin on the selfie screen, and are described as virgin when exposed, but using one doesn’t count as losing/taking virginity. This affects NPCs as well as the player.
+		Penises are regaining their virginity on export/import. Well... sort of. They show as virgin on the selfie screen, and are described as virgin when exposed, but using one doesn't count as losing/taking virginity. This affects NPCs as well as the player.
 		
-		Imported potions have proper backgrounds now, but they still don’t stack with newly brewed ones, even when they have identical effects. Given the limited number of inventory slots, this is something of an issue.
+		Imported potions have proper backgrounds now, but they still don't stack with newly brewed ones, even when they have identical effects. Given the limited number of inventory slots, this is something of an issue.
 		
-		I’m not sure why ankle boots are listed as feminine; they look pretty neutral to me. Likewise with the headband, which is listed as neutral despite looking obviously feminine.
+		I'm not sure why ankle boots are listed as feminine; they look pretty neutral to me. Likewise with the headband, which is listed as neutral despite looking obviously feminine.
 		
-		When switching to doggy style, PC’s line (“Be a good girl and hold still while I fuck you like the bitch you are!”) fits in fine with the dirty talk from the “Rough” pace, but seems rather out of place if you’re in the “Gentle” pace.
+		When switching to doggy style, PC's line ("Be a good girl and hold still while I fuck you like the bitch you are!") fits in fine with the dirty talk from the "Rough" pace, but seems rather out of place if you're in the "Gentle" pace.
 		
-		Kate’s intro says she has plump lips and wavy hair, but she actually has full lips and a bob cut. Also says she has three pairs of breasts even if your settings limit her to one pair.
+		Kate's intro says she has plump lips and wavy hair, but she actually has full lips and a bob cut. Also says she has three pairs of breasts even if your settings limit her to one pair.
 		
-		Looking back on things, I’m pretty sure every feminine NPC I’ve met has had “full” sized lips, they never seem to have larger or smaller ones.
+		Looking back on things, I'm pretty sure every feminine NPC I've met has had "full" sized lips, they never seem to have larger or smaller ones.
 		
-		Found a bug with the character generation screen; I went to start a new game (from within a running game, not a new session) and when I went to change body style (that is, skinny-huge and soft-ripped) the result body type stayed fixed at “Average”, not changing like it should. Unfortunately, I haven’t been able to reproduce it, and there was nothing in the error log, so this report probably isn’t going to be useful; I include it simply so you know there’s a possible issue there.
+		Found a bug with the character generation screen; I went to start a new game (from within a running game, not a new session) and when I went to change body style (that is, skinny-huge and soft-ripped) the result body type stayed fixed at "Average", not changing like it should. Unfortunately, I haven't been able to reproduce it, and there was nothing in the error log, so this report probably isn't going to be useful; I include it simply so you know there's a possible issue there.
 	
 	
 	-----------
@@ -2192,7 +2192,7 @@ Another bug report: can't seem to remove those who identify as prostitutes from 
 	
 	Weirdness
 	It's pretty weird that the descriptions for the stat "Fitness" are all about flexibility. What it actually does is in line with what I'd expect "Fitness" to do, but the flavour text is all about flexibility.
-	Tried out a harpy transformation, got told "You now have avian breasts and nipples, and when lactating, you will produce avian milk". Something about that sounds wrong…
+	Tried out a harpy transformation, got told "You now have avian breasts and nipples, and when lactating, you will produce avian milk". Something about that sounds wrong...
 	
 	
 	
@@ -2870,7 +2870,7 @@ So basically, the transformer fetish actually reduces the cost of enchantments b
 	sort of a bug descripting error. When you have a breeding bitch walking around and you ignore her for a few days to let one of your slave studs knock her up.
 	 She blames you for being the dad even though you and she know you didn't have sex with her. not sure how to fix it
 	
-	For me the people that I get pregnant stay pregnant. To prove if it wasn’t just my mind I rested for 32 days and I check my pregnancy stats to see that all the women I impregnated are still pregnant.
+	For me the people that I get pregnant stay pregnant. To prove if it wasn't just my mind I rested for 32 days and I check my pregnancy stats to see that all the women I impregnated are still pregnant.
 	
 	Found a bug: If you play as a male and have a male and a female slave and both are allowed to have sex with each other and the female gets pregnant, she says the child if from the PC but it's not listed (obviously cuz the whole thing makes no sense^^) on the fathered children stats.
 	
@@ -2982,7 +2982,7 @@ So basically, the transformer fetish actually reduces the cost of enchantments b
 	Brittany's scene seems to end after her orgasm. Not sure if intended or not.
 	
 	Not sure if intended, but I cannot get to a second page of options when having sex wit the three Harpies.  I think this has also happened with other fights, but I most noticed it here.
-		At some point after they take off their cloths—I think... can't be sure—the second page of options opens up.
+		At some point after they take off their cloths-I think... can't be sure-the second page of options opens up.
 
 	How do you feel about offspring genders? There's quite an array available, but they only ever pick from two. It's a very small change to switch them to using the same system used for generic NPCs.
 	
@@ -3091,7 +3091,7 @@ So basically, the transformer fetish actually reduces the cost of enchantments b
 
 
 	
-	If you lose your character's virginity to their/someone's else tail, any kind of it - vaginal, anal or oral - then in your character's description (phone→selfie) you will have this sentence:
+	If you lose your character's virginity to their/someone's else tail, any kind of it - vaginal, anal or oral - then in your character's description (phone->selfie) you will have this sentence:
 You lost your anal virginity to.
 The first time you performed oral was to.
 It lacks something before the period.
@@ -3862,7 +3862,7 @@ When you defeat them you will get the option to "reclaim" giving you back only i
 	Known issues related to inventory that I'm not gonna fix:
 	
 	Pluralization bugs
-	-- "You hand over all of your A dye-brush to Ralph in exchange for ¤ 287." Yeahhh that's item names and pluralization hell
+	-- "You hand over all of your A dye-brush to Ralph in exchange for 287." Yeahhh that's item names and pluralization hell
 	
 	
 	Flavour text in-game says it is custom to kiss a slave for one last time before enslavement, since kissing a slave is considered taboo
@@ -4662,7 +4662,7 @@ Also noticed the Stop partner self action option disappears.
 	AI:
 		1. An enemy with the Dominant personality just shouted Dirty Talk at me. Not even finger sucking or anything else, just that.
 	
-		Even after giving permission, the NPC doesn’t help with stripping of clothing. They don’t even take their own clothes off. Related to this, NPCs are still not taking off their bottoms generally speaking, not related to the permission.
+		Even after giving permission, the NPC doesn't help with stripping of clothing. They don't even take their own clothes off. Related to this, NPCs are still not taking off their bottoms generally speaking, not related to the permission.
 	
 	
 	
@@ -4865,7 +4865,7 @@ Also noticed the Stop partner self action option disappears.
 	
 	Add flavour text to explore action
 	
-	In Lilaya’s climax scene: that scene states that she pulls herself off the PC’s cock, but the game doesn’t reflect.
+	In Lilaya's climax scene: that scene states that she pulls herself off the PC's cock, but the game doesn't reflect.
 	
 	
 	-------------

--- a/src/com/lilithsthrone/utils/Pathing.java
+++ b/src/com/lilithsthrone/utils/Pathing.java
@@ -35,12 +35,12 @@ public class Pathing {
 		 * 
 		 * b) Switch it to the closed list.
 		 * 
-		 * c) For each of the 8 squares adjacent to this current square �
+		 * c) For each of the 8 squares adjacent to this current square:
 		 * 
 		 * i) If it is not walkable or if it is on the closed list, ignore it.
 		 * Otherwise do the following.
 		 * 
-		 * ii) If it isn�t on the open list, add it to the open list. Make the
+		 * ii) If it isn't on the open list, add it to the open list. Make the
 		 * current square the parent of this square. Record the F, G, and H
 		 * costs of the square.
 		 * 

--- a/src/com/lilithsthrone/utils/Util.java
+++ b/src/com/lilithsthrone/utils/Util.java
@@ -310,7 +310,7 @@ public class Util {
 			case ESCAPE:
 				return "Esc";
 			case EURO_SIGN:
-				return "€";
+				return "&euro;"; // €
 			case EXCLAMATION_MARK:
 				return "!";
 			case GREATER:
@@ -362,7 +362,7 @@ public class Util {
 			case PLUS:
 				return "+";
 			case POUND:
-				return "£";
+				return "&pound;"; // £
 			case POWER:
 				return "^";
 			case QUOTE:


### PR DESCRIPTION
This a big, fast pass to make the following changes:
 - Smart qoutes -> simple quotes
 - Accented characters/symbols -> html/xml entities (e.g. &eacute;)
 - En/em dashes -> simple dashes
 - Ashley's height uses the standard npc.height... parser

Since this was a bulk job, I also converted all the .txt files too; this might be useful
if copy/pasting from those files, or it might be overkill.

For reference, the command I used to locate the above potential issues is:
	`grep --color -n -P -r "[^\x00-\x7e]" --exclude="*.png" res/ src/`
...which on my system now returns only bugs.txt (it's the BOM, this is fine), and the
two currency symbols I left as comments.