### PR TITLE
Enchantment effect translate for old saves

### DIFF
--- a/src/com/lilithsthrone/game/inventory/item/ItemEffect.java
+++ b/src/com/lilithsthrone/game/inventory/item/ItemEffect.java
@@ -96,10 +96,12 @@ public class ItemEffect implements Serializable, XMLSaving {
 		{
 			case "ATTRIBUTE_STRENGTH":
 			case "ATTRIBUTE_FITNESS":
-				itemEffectType = "ATTRIBUTE_PHYSIQUE";
+			case "ATTRIBUTE_PHYSIQUE":
+				itemEffectType = "MAJOR_PHYSIQUE";
 				break;
 			case "ATTRIBUTE_INTELLIGENCE":
-				itemEffectType = "ATTRIBUTE_ARCANE";
+			case "ATTRIBUTE_ARCANE":
+				itemEffectType = "MAJOR_ARCANE";
 				break;
 		}
 		ItemEffect ie = new ItemEffect(

--- a/src/com/lilithsthrone/game/inventory/item/ItemEffect.java
+++ b/src/com/lilithsthrone/game/inventory/item/ItemEffect.java
@@ -91,8 +91,18 @@ public class ItemEffect implements Serializable, XMLSaving {
 	}
 	
 	public static ItemEffect loadFromXML(Element parentElement, Document doc) {
+		String itemEffectType = parentElement.getAttribute("itemEffectType");
+		switch(itemEffectType)
+		{
+			case "ATTRIBUTE_STRENGTH":
+				itemEffectType = "ATTRIBUTE_PHYSIQUE";
+				break;
+			case "ATTRIBUTE_INTELLIGENCE":
+				itemEffectType = "ATTRIBUTE_ARCANE";
+				break;
+		}
 		ItemEffect ie = new ItemEffect(
-				ItemEffectType.valueOf(parentElement.getAttribute("itemEffectType")),
+				ItemEffectType.valueOf(itemEffectType),
 				(parentElement.getAttribute("primaryModifier").equals("null")?null:TFModifier.valueOf(parentElement.getAttribute("primaryModifier"))),
 				(parentElement.getAttribute("secondaryModifier").equals("null")?null:TFModifier.valueOf(parentElement.getAttribute("secondaryModifier"))),
 				(parentElement.getAttribute("potency").equals("null")?null:TFPotency.valueOf(parentElement.getAttribute("potency"))),

--- a/src/com/lilithsthrone/game/inventory/item/ItemEffect.java
+++ b/src/com/lilithsthrone/game/inventory/item/ItemEffect.java
@@ -95,6 +95,7 @@ public class ItemEffect implements Serializable, XMLSaving {
 		switch(itemEffectType)
 		{
 			case "ATTRIBUTE_STRENGTH":
+			case "ATTRIBUTE_FITNESS":
 				itemEffectType = "ATTRIBUTE_PHYSIQUE";
 				break;
 			case "ATTRIBUTE_INTELLIGENCE":


### PR DESCRIPTION
This just adds a check on importing ItemEffects to see if they refer to strength, fitness, or intelligence, and if so translate that to physique or arcane as appropriate. With this, players with saves from before the change should hopefully keep any potions they had made.