### PR TITLE
Fix for export error with nulls in booksRead

### DIFF
--- a/src/com/lilithsthrone/game/character/PlayerCharacter.java
+++ b/src/com/lilithsthrone/game/character/PlayerCharacter.java
@@ -117,7 +117,9 @@ public class PlayerCharacter extends GameCharacter implements XMLSaving {
 		Element innerElement = doc.createElement("booksRead");
 		playerSpecific.appendChild(innerElement);
 		for(AbstractItemType book : booksRead) {
-			CharacterUtils.createXMLElementWithValue(doc, innerElement, "book", book.getId());
+			if(book != null) {
+				CharacterUtils.createXMLElementWithValue(doc, innerElement, "book", book.getId());
+			}
 		}
 		
 		Element charactersEncounteredElement = doc.createElement("charactersEncountered");


### PR DESCRIPTION
This simply skips over any nulls that might get into booksRead, stopping them from blocking export. It doesn't address why nulls might be getting into booksRead to begin with, just stops them from doing the damage if they do.