### PR TITLE
Add various modifiers to makeup coverings

### DIFF
--- a/src/com/lilithsthrone/game/character/body/Body.java
+++ b/src/com/lilithsthrone/game/character/body/Body.java
@@ -1693,9 +1693,9 @@ public class Body implements Serializable, XMLSaving {
 		}
 		if(owner.getEyeShadow().getPrimaryColour()!=Colour.COVERING_NONE) {
 			if(owner.isPlayer()) {
-				sb.append(" You're wearing a tasteful amount of "+owner.getEyeShadow().getColourDescriptor(true, false)+" eye shadow.");
+				sb.append(" You're wearing a tasteful amount of "+owner.getEyeShadow().getFullDescription(owner, true)+".");
 			} else {
-				sb.append(" [npc.She]'s wearing a tasteful amount of "+owner.getEyeShadow().getColourDescriptor(true, false)+" eye shadow.");
+				sb.append(" [npc.She]'s wearing a tasteful amount of "+owner.getEyeShadow().getFullDescription(owner, true)+".");
 			}
 		}
 		
@@ -1917,7 +1917,7 @@ public class Body implements Serializable, XMLSaving {
 		if (owner.isPlayer()) {
 			sb.append(" You have [pc.lipSize], [pc.mouthColourPrimary(true)] [pc.lips]");
 			if(owner.getLipstick().getPrimaryColour()!=Colour.COVERING_NONE) {
-				sb.append((owner.isPiercedLip()?", which have been pierced, and":", which")+" are currently covered in "+owner.getLipstick().getColourDescriptor(true, false)+" lipstick.");
+				sb.append((owner.isPiercedLip()?", which have been pierced, and":", which")+" are currently covered in "+owner.getLipstick().getFullDescription(owner, true)+".");
 			} else {
 				sb.append((owner.isPiercedLip()?", which have been pierced.":"."));
 			}
@@ -1925,7 +1925,7 @@ public class Body implements Serializable, XMLSaving {
 		} else {
 			sb.append(" [npc.She] has [npc.lipSize], [npc.mouthColourPrimary(true)] [pc.lips]");
 			if(owner.getLipstick().getPrimaryColour()!=Colour.COVERING_NONE) {
-				sb.append((owner.isPiercedLip()?", which have been pierced, and":", which")+" are currently covered in "+owner.getLipstick().getColourDescriptor(true, false)+" lipstick.");
+				sb.append((owner.isPiercedLip()?", which have been pierced, and":", which")+" are currently covered in "+owner.getLipstick().getFullDescription(owner, true)+".");
 			} else {
 				sb.append((owner.isPiercedLip()?", which have been pierced.":"."));
 			}

--- a/src/com/lilithsthrone/game/character/body/types/BodyCoveringType.java
+++ b/src/com/lilithsthrone/game/character/body/types/BodyCoveringType.java
@@ -1227,7 +1227,9 @@ public enum BodyCoveringType {
 			"eye shadow",
 			"eye shadow",
 			Util.newArrayListOfValues(
-					new ListValue<CoveringModifier>(CoveringModifier.MAKEUP)),
+					new ListValue<CoveringModifier>(CoveringModifier.MATTE),
+					new ListValue<CoveringModifier>(CoveringModifier.SPARKLY),
+					new ListValue<CoveringModifier>(CoveringModifier.METALLIC)),
 			null,
 			Util.newArrayListOfValues(
 					new ListValue<CoveringPattern>(CoveringPattern.NONE)),
@@ -1259,7 +1261,10 @@ public enum BodyCoveringType {
 			"lipstick",
 			"lipstick",
 			Util.newArrayListOfValues(
-					new ListValue<CoveringModifier>(CoveringModifier.MAKEUP)),
+					new ListValue<CoveringModifier>(CoveringModifier.GLOSSY),
+					new ListValue<CoveringModifier>(CoveringModifier.MATTE),
+					new ListValue<CoveringModifier>(CoveringModifier.SPARKLY),
+					new ListValue<CoveringModifier>(CoveringModifier.METALLIC)),
 			null,
 			Util.newArrayListOfValues(
 					new ListValue<CoveringPattern>(CoveringPattern.NONE)),
@@ -1310,7 +1315,9 @@ public enum BodyCoveringType {
 			"nail polish",
 			"nail polish",
 			Util.newArrayListOfValues(
-					new ListValue<CoveringModifier>(CoveringModifier.SMOOTH)),
+					new ListValue<CoveringModifier>(CoveringModifier.SMOOTH),
+					new ListValue<CoveringModifier>(CoveringModifier.SPARKLY),
+					new ListValue<CoveringModifier>(CoveringModifier.METALLIC)),
 			null,
 			Util.newArrayListOfValues(
 					new ListValue<CoveringPattern>(CoveringPattern.NONE)),
@@ -1361,7 +1368,9 @@ public enum BodyCoveringType {
 			"nail polish",
 			"nail polish",
 			Util.newArrayListOfValues(
-					new ListValue<CoveringModifier>(CoveringModifier.SMOOTH)),
+					new ListValue<CoveringModifier>(CoveringModifier.SMOOTH),
+					new ListValue<CoveringModifier>(CoveringModifier.SPARKLY),
+					new ListValue<CoveringModifier>(CoveringModifier.METALLIC)),
 			null,
 			Util.newArrayListOfValues(
 					new ListValue<CoveringPattern>(CoveringPattern.NONE)),

--- a/src/com/lilithsthrone/game/character/body/valueEnums/CoveringModifier.java
+++ b/src/com/lilithsthrone/game/character/body/valueEnums/CoveringModifier.java
@@ -10,6 +10,10 @@ public enum CoveringModifier {
 	EYE("eye"),
 	FLUID("fluid"),
 	MAKEUP("makeup"),
+	GLOSSY("glossy"),
+	MATTE("matte"),
+	SPARKLY("sparkly"),
+	METALLIC("metallic"),
 	
 	SHORT("short"),
 	SILKEN("silken"),


### PR DESCRIPTION
Adds a number of modifiers to some makeup types, and enables their use in the description pages. I'm not an expert on makeup, so there might be more that could be added.