### PR TITLE
Fix for importing potions

### DIFF
--- a/src/com/lilithsthrone/game/inventory/item/ItemEffect.java
+++ b/src/com/lilithsthrone/game/inventory/item/ItemEffect.java
@@ -96,12 +96,10 @@ public class ItemEffect implements Serializable, XMLSaving {
 		{
 			case "ATTRIBUTE_STRENGTH":
 			case "ATTRIBUTE_FITNESS":
-			case "ATTRIBUTE_PHYSIQUE":
-				itemEffectType = "MAJOR_PHYSIQUE";
+				itemEffectType = "ATTRIBUTE_PHYSIQUE";
 				break;
 			case "ATTRIBUTE_INTELLIGENCE":
-			case "ATTRIBUTE_ARCANE":
-				itemEffectType = "MAJOR_ARCANE";
+				itemEffectType = "ATTRIBUTE_ARCANE";
 				break;
 		}
 		ItemEffect ie = new ItemEffect(


### PR DESCRIPTION
It is Attribute.MAJOR_ARCANE, but ItemEffectType.MAJOR_ARCANE doesn't exist. Potions still use ATTRIBUTE_ARCANE for the itemEffectType field.