### PR TITLE
Add cum targets for characters cumming on themselves

### DIFF
--- a/src/com/lilithsthrone/game/sex/OrgasmCumTarget.java
+++ b/src/com/lilithsthrone/game/sex/OrgasmCumTarget.java
@@ -19,7 +19,8 @@ public enum OrgasmCumTarget {
 	HAIR("into hair"),
 	STOMACH("onto stomach"),
 	LEGS("onto legs"),
-	BACK("over back");
+	BACK("over back"),
+	SELF_STOMACH("onto self stomach");
 	
 	private String name;
 

--- a/src/com/lilithsthrone/game/sex/OrgasmCumTarget.java
+++ b/src/com/lilithsthrone/game/sex/OrgasmCumTarget.java
@@ -20,7 +20,9 @@ public enum OrgasmCumTarget {
 	STOMACH("onto stomach"),
 	LEGS("onto legs"),
 	BACK("over back"),
-	SELF_STOMACH("onto self stomach");
+	SELF_STOMACH("onto self stomach"),
+	SELF_BREASTS("onto self breasts"),
+	SELF_FACE("onto self face");
 	
 	private String name;
 

--- a/src/com/lilithsthrone/game/sex/SexPositionSlot.java
+++ b/src/com/lilithsthrone/game/sex/SexPositionSlot.java
@@ -85,8 +85,8 @@ public enum SexPositionSlot {
 	
 	COWGIRL_ON_BACK("Cowgirl (on back)",
 			Util.newArrayListOfValues(
-					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
+					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
 	
 	COWGIRL_RIDING("Cowgirl (riding)",
@@ -154,9 +154,9 @@ public enum SexPositionSlot {
 	
 	CHAIR_BOTTOM("Sitting",
 			Util.newArrayListOfValues(
+					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.STOMACH),
 					new ListValue<>(OrgasmCumTarget.GROIN),
-					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
 	
 	/* Stocks */
@@ -187,9 +187,9 @@ public enum SexPositionSlot {
 	
 	MISSIONARY_ON_BACK("Lying on back",
 			Util.newArrayListOfValues(
+					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.STOMACH),
-					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
 	
 	MISSIONARY_KNEELING_BETWEEN_LEGS("Kneeling between legs",
@@ -269,9 +269,9 @@ public enum SexPositionSlot {
 	
 	MISSIONARY_ALTAR_LYING_ON_ALTAR("Lying on altar",
 			Util.newArrayListOfValues(
+					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.LEGS),
-					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
 
 	MISSIONARY_ALTAR_STANDING_BETWEEN_LEGS("Between legs",
@@ -290,9 +290,9 @@ public enum SexPositionSlot {
 	
 	MISSIONARY_ALTAR_SEALED_LYING_ON_ALTAR("Lying on altar",
 			Util.newArrayListOfValues(
+					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.LEGS),
-					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
 
 	MISSIONARY_ALTAR_SEALED_STANDING_BETWEEN_LEGS("Between legs",

--- a/src/com/lilithsthrone/game/sex/SexPositionSlot.java
+++ b/src/com/lilithsthrone/game/sex/SexPositionSlot.java
@@ -86,6 +86,8 @@ public enum SexPositionSlot {
 	COWGIRL_ON_BACK("Cowgirl (on back)",
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
+					new ListValue<>(OrgasmCumTarget.SELF_BREASTS),
+					new ListValue<>(OrgasmCumTarget.SELF_FACE),
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
 	
@@ -108,6 +110,7 @@ public enum SexPositionSlot {
 	SIXTY_NINE_BOTTOM("Sixty-nine (bottom)",
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
+					new ListValue<>(OrgasmCumTarget.SELF_BREASTS),
 					new ListValue<>(OrgasmCumTarget.FACE),
 					new ListValue<>(OrgasmCumTarget.BREASTS),
 					new ListValue<>(OrgasmCumTarget.HAIR),
@@ -155,6 +158,8 @@ public enum SexPositionSlot {
 	CHAIR_BOTTOM("Sitting",
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
+					new ListValue<>(OrgasmCumTarget.SELF_BREASTS),
+					new ListValue<>(OrgasmCumTarget.SELF_FACE),
 					new ListValue<>(OrgasmCumTarget.STOMACH),
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
@@ -188,6 +193,8 @@ public enum SexPositionSlot {
 	MISSIONARY_ON_BACK("Lying on back",
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
+					new ListValue<>(OrgasmCumTarget.SELF_BREASTS),
+					new ListValue<>(OrgasmCumTarget.SELF_FACE),
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.STOMACH),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
@@ -246,6 +253,8 @@ public enum SexPositionSlot {
 	MISSIONARY_DESK_SUB_VICKY("Lying on counter",
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
+					new ListValue<>(OrgasmCumTarget.SELF_BREASTS),
+					new ListValue<>(OrgasmCumTarget.SELF_FACE),
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.LEGS),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
@@ -270,6 +279,8 @@ public enum SexPositionSlot {
 	MISSIONARY_ALTAR_LYING_ON_ALTAR("Lying on altar",
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
+					new ListValue<>(OrgasmCumTarget.SELF_BREASTS),
+					new ListValue<>(OrgasmCumTarget.SELF_FACE),
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.LEGS),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
@@ -291,6 +302,8 @@ public enum SexPositionSlot {
 	MISSIONARY_ALTAR_SEALED_LYING_ON_ALTAR("Lying on altar",
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
+					new ListValue<>(OrgasmCumTarget.SELF_BREASTS),
+					new ListValue<>(OrgasmCumTarget.SELF_FACE),
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.LEGS),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),

--- a/src/com/lilithsthrone/game/sex/SexPositionSlot.java
+++ b/src/com/lilithsthrone/game/sex/SexPositionSlot.java
@@ -86,6 +86,7 @@ public enum SexPositionSlot {
 	COWGIRL_ON_BACK("Cowgirl (on back)",
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.GROIN),
+					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
 	
 	COWGIRL_RIDING("Cowgirl (riding)",
@@ -106,6 +107,7 @@ public enum SexPositionSlot {
 	
 	SIXTY_NINE_BOTTOM("Sixty-nine (bottom)",
 			Util.newArrayListOfValues(
+					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.FACE),
 					new ListValue<>(OrgasmCumTarget.BREASTS),
 					new ListValue<>(OrgasmCumTarget.HAIR),
@@ -153,7 +155,9 @@ public enum SexPositionSlot {
 	CHAIR_BOTTOM("Sitting",
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.STOMACH),
-					new ListValue<>(OrgasmCumTarget.GROIN))),
+					new ListValue<>(OrgasmCumTarget.GROIN),
+					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
+					new ListValue<>(OrgasmCumTarget.FLOOR))),
 	
 	/* Stocks */
 	
@@ -185,6 +189,7 @@ public enum SexPositionSlot {
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.STOMACH),
+					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
 	
 	MISSIONARY_KNEELING_BETWEEN_LEGS("Kneeling between legs",
@@ -240,6 +245,7 @@ public enum SexPositionSlot {
 	
 	MISSIONARY_DESK_SUB_VICKY("Lying on counter",
 			Util.newArrayListOfValues(
+					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.LEGS),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
@@ -265,6 +271,7 @@ public enum SexPositionSlot {
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.LEGS),
+					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
 
 	MISSIONARY_ALTAR_STANDING_BETWEEN_LEGS("Between legs",
@@ -285,6 +292,7 @@ public enum SexPositionSlot {
 			Util.newArrayListOfValues(
 					new ListValue<>(OrgasmCumTarget.GROIN),
 					new ListValue<>(OrgasmCumTarget.LEGS),
+					new ListValue<>(OrgasmCumTarget.SELF_STOMACH),
 					new ListValue<>(OrgasmCumTarget.FLOOR))),
 
 	MISSIONARY_ALTAR_SEALED_STANDING_BETWEEN_LEGS("Between legs",

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -1138,12 +1138,12 @@ public class GenericOrgasms {
 					} else {
 						if(characterOrgasming.isPlayer()) {
 							return UtilText.parse(characterOrgasming,
-									" all over your stomach."
-									+ " You can't help but let out [pc.a_moan] as you feel it running down over your [pc.skin].");
+									" all over your stomach. You can't help but let out [pc.a_moan] as you feel it running"
+											+ " down over your [pc.skin].");
 						} else {
 							return UtilText.parse(characterOrgasming,
-									" all over [npc.her] stomach."
-									+ " [npc.She] can't help but let out [npc.a_moan] as [npc.she] feels it running down over [npc.her] [npc.skin].");
+									" all over [npc.her] stomach. [npc.She] can't help but let out [npc.a_moan] as"
+											+ " [npc.she] feels it running down over [npc.her] [npc.skin].");
 							
 						}
 					}

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -1132,6 +1132,22 @@ public class GenericOrgasms {
 					}
 				case WALL:
 					return " all up the wall.";
+				case SELF_STOMACH:
+					target = characterOrgasming;
+					if (target.getHighestZLayerCoverableArea(CoverableArea.STOMACH)!=null) {
+						return getClothingCummedOnText(characterOrgasming, target, CoverableArea.STOMACH);
+					} else {
+						if(characterOrgasming.isPlayer()) {
+							return UtilText.parse(characterOrgasming,
+									" all over your stomach."
+									+ " You can't help but let out [pc.a_moan] as you feel it running down over your [pc.skin].");
+						} else {
+							return UtilText.parse(characterOrgasming,
+									" all over [npc.her] stomach."
+									+ " [npc.She] can't help but let out [npc.a_moan] as [npc.she] feels it running down over [npc.her] [npc.skin].");
+							
+						}
+					}
 			}
 			
 			// Continued description for cumming inside:
@@ -2057,6 +2073,50 @@ public class GenericOrgasms {
 		@Override
 		public List<CoverableArea> getAreasCummedOn(GameCharacter cumProvider, GameCharacter cumTarget) {
 			if(cumProvider.isPlayer() && cumTarget.equals(Sex.getTargetedPartner(Main.game.getPlayer()))) {
+				return Util.newArrayListOfValues(
+						new ListValue<>(CoverableArea.STOMACH));
+			}
+			return null; 
+		}
+	};
+	
+	public static final SexAction PLAYER_GENERIC_ORGASM_SELF_STOMACH = new SexAction(PLAYER_GENERIC_ORGASM_FLOOR) {
+
+		@Override
+		public boolean isBaseRequirementsMet() {
+			return Main.game.getPlayer().hasPenis()
+					&& Main.game.getPlayer().isCoverableAreaExposed(CoverableArea.PENIS)
+					&& !Main.game.getPlayer().isWearingCondom()
+					&& Sex.getSexPositionSlot(Main.game.getPlayer()).getAvailableCumTargets().contains(OrgasmCumTarget.SELF_STOMACH);
+		}
+		
+		@Override
+		public String getActionTitle() {
+			if(!Sex.getCharactersBeingPenetratedBy(Main.game.getPlayer(), PenetrationType.PENIS).isEmpty()) {
+				return "Pull out (own stomach)";
+			}
+			return "Cum on your stomach";
+		}
+
+		@Override
+		public String getActionDescription() {
+			return "You've reached your climax, and can't hold back your orgasm any longer. Direct your cum onto your stomach.";
+		}
+
+		@Override
+		public String getDescription() {
+			return getGenericOrgasmDescription(Main.game.getPlayer(), OrgasmCumTarget.SELF_STOMACH);
+		}
+
+		@Override
+		public void applyEffects() {
+			// Pull out:
+			PLAYER_GENERIC_ORGASM_FLOOR.applyEffects();
+		}
+
+		@Override
+		public List<CoverableArea> getAreasCummedOn(GameCharacter cumProvider, GameCharacter cumTarget) {
+			if(cumProvider.isPlayer() && cumTarget.isPlayer()) {
 				return Util.newArrayListOfValues(
 						new ListValue<>(CoverableArea.STOMACH));
 			}
@@ -3082,6 +3142,47 @@ public class GenericOrgasms {
 						new ListValue<>(CoverableArea.STOMACH));
 			}
 			return null; 
+		}
+	};
+	
+	public static final SexAction PARTNER_GENERIC_ORGASM_SELF_STOMACH = new SexAction(PARTNER_GENERIC_ORGASM_FLOOR) {
+
+		@Override
+		public boolean isBaseRequirementsMet() {
+			return isGenericPartnerCumTargetRequirementsMet() && Sex.getSexPositionSlot(Sex.getActivePartner()).getAvailableCumTargets().contains(OrgasmCumTarget.SELF_STOMACH);
+		}
+		
+		@Override
+		public String getActionTitle() {
+			if(!Sex.getCharactersBeingPenetratedBy(Sex.getActivePartner(), PenetrationType.PENIS).isEmpty()) {
+				return "Pull out (own stomach)";
+			}
+			return "Cum on your stomach";
+		}
+
+		@Override
+		public String getActionDescription() {
+			return "You've reached your climax, and can't hold back your orgasm any longer. Direct your cum onto your stomach.";
+		}
+
+		@Override
+		public String getDescription() {
+			return getGenericOrgasmDescription(Sex.getActivePartner(), OrgasmCumTarget.SELF_STOMACH);
+		}
+
+		@Override
+		public void applyEffects() {
+			// Pull out:
+			PARTNER_GENERIC_ORGASM_FLOOR.applyEffects();
+		}
+
+		@Override
+		public List<CoverableArea> getAreasCummedOn(GameCharacter cumProvider, GameCharacter cumTarget) {
+	//		if(cumTarget.equals(Sex.getActivePartner())) {
+				return Util.newArrayListOfValues(
+						new ListValue<>(CoverableArea.STOMACH));
+	//		}
+	//		return null; 
 		}
 	};
 	

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -3191,11 +3191,11 @@ public class GenericOrgasms {
 
 		@Override
 		public List<CoverableArea> getAreasCummedOn(GameCharacter cumProvider, GameCharacter cumTarget) {
-	//		if(cumTarget.equals(Sex.getActivePartner())) {
+			if(cumProvider == Sex.getActivePartner()) {
 				return Util.newArrayListOfValues(
 						new ListValue<>(CoverableArea.STOMACH));
-	//		}
-	//		return null; 
+			}
+			return null;
 		}
 	};
 	

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -3191,7 +3191,8 @@ public class GenericOrgasms {
 
 		@Override
 		public List<CoverableArea> getAreasCummedOn(GameCharacter cumProvider, GameCharacter cumTarget) {
-			if(cumProvider == Sex.getActivePartner()) {
+			if(cumProvider == Sex.getActivePartner()
+					&& cumTarget == Sex.getActivePartner()) {
 				return Util.newArrayListOfValues(
 						new ListValue<>(CoverableArea.STOMACH));
 			}

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -1133,9 +1133,8 @@ public class GenericOrgasms {
 				case WALL:
 					return " all up the wall.";
 				case SELF_STOMACH:
-					target = characterOrgasming;
-					if (target.getHighestZLayerCoverableArea(CoverableArea.STOMACH)!=null) {
-						return getClothingCummedOnText(characterOrgasming, target, CoverableArea.STOMACH);
+					if (characterOrgasming.getHighestZLayerCoverableArea(CoverableArea.STOMACH)!=null) {
+						return getClothingCummedOnText(characterOrgasming, CoverableArea.STOMACH);
 					} else {
 						if(characterOrgasming.isPlayer()) {
 							return UtilText.parse(characterOrgasming,
@@ -1352,6 +1351,20 @@ public class GenericOrgasms {
 					" all over your "+target.getHighestZLayerCoverableArea(area).getName()+"."
 					+ " [npc1.Name] grins as [npc1.her] [npc1.cum+] splatters onto your clothing, making a mess of your outfit.");
 		}
+	}
+
+	private static String getClothingCummedOnText(GameCharacter characterOrgasming, CoverableArea area) {
+			if(characterOrgasming.isPlayer()) {
+				return UtilText.parse(characterOrgasming,
+						" all over your "+characterOrgasming.getHighestZLayerCoverableArea(area).getName()+"."
+								+ " You give a lusty [pc.moan+] as your [pc.cum+] splatters onto your clothing,"
+								+ " making a mess of your outfit.");
+			} else {
+				return UtilText.parse(characterOrgasming,
+						" all over [npc.her] "+characterOrgasming.getHighestZLayerCoverableArea(area).getName()+"."
+								+ " [npc.She] give a lusty [npc.moan+] as [npc.her] [npc.cum+] splatters onto"
+								+ " [npc.her] clothing, making a mess of [npc.her] outfit.");
+			}
 	}
 	
 	private static String getInflationText(GameCharacter characterOrgasming, GameCharacter target, int cumAmount) {

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -1147,6 +1147,36 @@ public class GenericOrgasms {
 							
 						}
 					}
+				case SELF_BREASTS:
+					if (characterOrgasming.getHighestZLayerCoverableArea(CoverableArea.BREASTS)!=null) {
+						return getClothingCummedOnText(characterOrgasming, CoverableArea.BREASTS);
+					} else {
+						if(characterOrgasming.isPlayer()) {
+							return UtilText.parse(characterOrgasming,
+									" all over your [npc.breasts]. You can't help but let out [npc.a_moan] as you feel"
+											+ " it running down over your [npc.breastsSkin].");
+						} else {
+							return UtilText.parse(characterOrgasming,
+									" all over [npc.name]'s [npc.breasts]. [npc.She] can't help but let out [npc.a_moan]"
+											+ " as [npc.she] feels it running down over [npc.her] [npc.breastsSkin].");
+							
+						}
+					}
+				case SELF_FACE:
+					if (characterOrgasming.getHighestZLayerCoverableArea(CoverableArea.MOUTH)!=null) {
+						return getClothingCummedOnText(characterOrgasming, CoverableArea.MOUTH);
+					} else {
+						if(characterOrgasming.isPlayer()) {
+							return UtilText.parse(characterOrgasming,
+									" all over your [pc.face+]. You can't help but let out [pc.a_moan] as you feel it"
+											+ " running down over your [pc.faceSkin].");
+						} else {
+							return UtilText.parse(characterOrgasming,
+									" all over [npc.name]'s [npc.face+]. [npc.She] can't help but let out [npc.a_moan]"
+											+ " as [npc.she] feels it running down over [npc.her] [npc.faceSkin].");
+							
+						}
+					}
 			}
 			
 			// Continued description for cumming inside:
@@ -1960,6 +1990,50 @@ public class GenericOrgasms {
 			return null; 
 		}
 	};
+
+	public static final SexAction PLAYER_GENERIC_ORGASM_SELF_BREASTS = new SexAction(PLAYER_GENERIC_ORGASM_FLOOR) {
+
+		@Override
+		public boolean isBaseRequirementsMet() {
+			return Main.game.getPlayer().hasPenis()
+					&& Main.game.getPlayer().isCoverableAreaExposed(CoverableArea.PENIS)
+					&& !Main.game.getPlayer().isWearingCondom()
+					&& Sex.getSexPositionSlot(Main.game.getPlayer()).getAvailableCumTargets().contains(OrgasmCumTarget.SELF_BREASTS);
+		}
+		
+		@Override
+		public String getActionTitle() {
+			if(!Sex.getCharactersBeingPenetratedBy(Main.game.getPlayer(), PenetrationType.PENIS).isEmpty()) {
+				return "Pull out (own [pc.breasts])";
+			}
+			return "Cum on your [pc.breasts]";
+		}
+
+		@Override
+		public String getActionDescription() {
+			return "You've reached your climax, and can't hold back your orgasm any longer. Direct your cum onto your [pc.breasts+].";
+		}
+
+		@Override
+		public String getDescription() {
+			return getGenericOrgasmDescription(Main.game.getPlayer(), OrgasmCumTarget.SELF_BREASTS);
+		}
+
+		@Override
+		public void applyEffects() {
+			// Pull out:
+			PLAYER_GENERIC_ORGASM_FLOOR.applyEffects();
+		}
+
+		@Override
+		public List<CoverableArea> getAreasCummedOn(GameCharacter cumProvider, GameCharacter cumTarget) {
+			if(cumProvider.isPlayer() && cumTarget.isPlayer()) {
+				return Util.newArrayListOfValues(
+						new ListValue<>(CoverableArea.BREASTS));
+			}
+			return null; 
+		}
+	};
 	
 	public static final SexAction PLAYER_GENERIC_ORGASM_FACE = new SexAction(PLAYER_GENERIC_ORGASM_FLOOR) {
 
@@ -1998,6 +2072,50 @@ public class GenericOrgasms {
 		@Override
 		public List<CoverableArea> getAreasCummedOn(GameCharacter cumProvider, GameCharacter cumTarget) {
 			if(cumProvider.isPlayer() && cumTarget.equals(Sex.getTargetedPartner(Main.game.getPlayer()))) {
+				return Util.newArrayListOfValues(
+						new ListValue<>(CoverableArea.MOUTH));
+			}
+			return null; 
+		}
+	};
+
+	public static final SexAction PLAYER_GENERIC_ORGASM_SELF_FACE = new SexAction(PLAYER_GENERIC_ORGASM_FLOOR) {
+
+		@Override
+		public boolean isBaseRequirementsMet() {
+			return Main.game.getPlayer().hasPenis()
+					&& Main.game.getPlayer().isCoverableAreaExposed(CoverableArea.PENIS)
+					&& !Main.game.getPlayer().isWearingCondom()
+					&& Sex.getSexPositionSlot(Main.game.getPlayer()).getAvailableCumTargets().contains(OrgasmCumTarget.SELF_FACE);
+		}
+		
+		@Override
+		public String getActionTitle() {
+			if(!Sex.getCharactersBeingPenetratedBy(Main.game.getPlayer(), PenetrationType.PENIS).isEmpty()) {
+				return "Pull out (own [pc.face])";
+			}
+			return "Cum on your [pc.face]";
+		}
+
+		@Override
+		public String getActionDescription() {
+			return "You've reached your climax, and can't hold back your orgasm any longer. Direct your cum onto your [pc.face+].";
+		}
+
+		@Override
+		public String getDescription() {
+			return getGenericOrgasmDescription(Main.game.getPlayer(), OrgasmCumTarget.SELF_FACE);
+		}
+
+		@Override
+		public void applyEffects() {
+			// Pull out:
+			PLAYER_GENERIC_ORGASM_FLOOR.applyEffects();
+		}
+
+		@Override
+		public List<CoverableArea> getAreasCummedOn(GameCharacter cumProvider, GameCharacter cumTarget) {
+			if(cumProvider.isPlayer() && cumTarget.isPlayer()) {
 				return Util.newArrayListOfValues(
 						new ListValue<>(CoverableArea.MOUTH));
 			}
@@ -3034,6 +3152,48 @@ public class GenericOrgasms {
 			return null; 
 		}
 	};
+
+	public static final SexAction PARTNER_GENERIC_ORGASM_SELF_BREASTS = new SexAction(PARTNER_GENERIC_ORGASM_FLOOR) {
+
+		@Override
+		public boolean isBaseRequirementsMet() {
+			return isGenericPartnerCumTargetRequirementsMet() && Sex.getSexPositionSlot(Sex.getActivePartner()).getAvailableCumTargets().contains(OrgasmCumTarget.SELF_BREASTS);
+		}
+		
+		@Override
+		public String getActionTitle() {
+			if(!Sex.getCharactersBeingPenetratedBy(Sex.getActivePartner(), PenetrationType.PENIS).isEmpty()) {
+				return "Pull out (own [npc.breasts])";
+			}
+			return "Cum on your [npc.breasts]";
+		}
+
+		@Override
+		public String getActionDescription() {
+			return "You've reached your climax, and can't hold back your orgasm any longer. Direct your cum onto your [npc.breasts+].";
+		}
+
+		@Override
+		public String getDescription() {
+			return getGenericOrgasmDescription(Sex.getActivePartner(), OrgasmCumTarget.SELF_BREASTS);
+		}
+
+		@Override
+		public void applyEffects() {
+			// Pull out:
+			PARTNER_GENERIC_ORGASM_FLOOR.applyEffects();
+		}
+
+		@Override
+		public List<CoverableArea> getAreasCummedOn(GameCharacter cumProvider, GameCharacter cumTarget) {
+			if(cumProvider == Sex.getActivePartner()
+					&& cumTarget == Sex.getActivePartner()) {
+				return Util.newArrayListOfValues(
+						new ListValue<>(CoverableArea.BREASTS));
+			}
+			return null;
+		}
+	};
 	
 	public static final SexAction PARTNER_GENERIC_ORGASM_FACE = new SexAction(PARTNER_GENERIC_ORGASM_FLOOR) {
 
@@ -3073,6 +3233,48 @@ public class GenericOrgasms {
 						new ListValue<>(CoverableArea.MOUTH));
 			}
 			return null; 
+		}
+	};
+
+	public static final SexAction PARTNER_GENERIC_ORGASM_SELF_FACE = new SexAction(PARTNER_GENERIC_ORGASM_FLOOR) {
+
+		@Override
+		public boolean isBaseRequirementsMet() {
+			return isGenericPartnerCumTargetRequirementsMet() && Sex.getSexPositionSlot(Sex.getActivePartner()).getAvailableCumTargets().contains(OrgasmCumTarget.SELF_FACE);
+		}
+		
+		@Override
+		public String getActionTitle() {
+			if(!Sex.getCharactersBeingPenetratedBy(Sex.getActivePartner(), PenetrationType.PENIS).isEmpty()) {
+				return "Pull out (own [npc.face])";
+			}
+			return "Cum on your [npc.face]";
+		}
+
+		@Override
+		public String getActionDescription() {
+			return "You've reached your climax, and can't hold back your orgasm any longer. Direct your cum onto your [npc.face+].";
+		}
+
+		@Override
+		public String getDescription() {
+			return getGenericOrgasmDescription(Sex.getActivePartner(), OrgasmCumTarget.SELF_FACE);
+		}
+
+		@Override
+		public void applyEffects() {
+			// Pull out:
+			PARTNER_GENERIC_ORGASM_FLOOR.applyEffects();
+		}
+
+		@Override
+		public List<CoverableArea> getAreasCummedOn(GameCharacter cumProvider, GameCharacter cumTarget) {
+			if(cumProvider == Sex.getActivePartner()
+					&& cumTarget == Sex.getActivePartner()) {
+				return Util.newArrayListOfValues(
+						new ListValue<>(CoverableArea.MOUTH));
+			}
+			return null;
 		}
 	};
 	


### PR DESCRIPTION
This adds new cum targets for a character in a reclining position (the bottom in missionary or cowgirl, for example) to cum on themselves rather than on their partner or the floor.