### PR TITLE
Refactor GenericOrgasms.isGenericPartnerCumTargetRequirementsMet

### DIFF
--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -49,14 +49,16 @@ public class GenericOrgasms {
 	}
 
 	private static boolean isGenericPartnerCumTargetRequirementsMet() {
-		return Sex.getActivePartner().hasPenis()
-				&& Sex.getActivePartner().isCoverableAreaExposed(CoverableArea.PENIS)
-				&& !Sex.getActivePartner().isWearingCondom()
-				&& (isActiveNPCObeyingPlayer()
-						?(!SexFlags.playerRequestedCreampie
-								&& !Sex.getCharactersBeingPenetratedBy(Sex.getActivePartner(), PenetrationType.PENIS).isEmpty()
-								&& Sex.getCharactersBeingPenetratedBy(Sex.getActivePartner(), PenetrationType.PENIS).get(0).isPlayer())
-						:true);
+		if(!Sex.getActivePartner().hasPenis())
+			return false;
+		if(!Sex.getActivePartner().isCoverableAreaExposed(CoverableArea.PENIS))
+			return false;
+		if(Sex.getActivePartner().isWearingCondom())
+			return false;
+		if(isActiveNPCObeyingPlayer()
+				&& SexFlags.playerRequestedCreampie)
+			return false;
+		return true;
 	}
 	
 	private static String getPositionPreparation(GameCharacter characterOrgasming) {


### PR DESCRIPTION
This refactors the GenericOrgasms.isGenericPartnerCumTargetRequirementsMet method, hopefully making clearer what it's doing, but more importantly removing the requirement that the partner be penetrating the player. This should fix the bug where, if the NPC is not penetrating the player, they have no cum actions and fall back to the PARTNER_ORGASM_GENERIC action, which always uses the first available cum target (rather than a random one), and also doesn't apply the dirty effect properly to either the player, or themselves if using my new cum targets from #208.