### PR TITLE
Add check for new potion enchantments

### DIFF
--- a/src/com/lilithsthrone/game/inventory/item/AbstractItem.java
+++ b/src/com/lilithsthrone/game/inventory/item/AbstractItem.java
@@ -89,8 +89,8 @@ public abstract class AbstractItem extends AbstractCoreItem implements Serializa
 				ItemEffect itemEffect = ItemEffect.loadFromXML(e, doc);
 				if(itemEffect == null) {
 					System.err.println("Warning: Failed to import ItemEffect");
+					effectsToBeAdded.add(itemEffect);
 				}
-				effectsToBeAdded.add(itemEffect);
 			}
 			item.setItemEffects(effectsToBeAdded);
 			

--- a/src/com/lilithsthrone/game/inventory/item/AbstractItem.java
+++ b/src/com/lilithsthrone/game/inventory/item/AbstractItem.java
@@ -86,7 +86,11 @@ public abstract class AbstractItem extends AbstractCoreItem implements Serializa
 			Element element = (Element)parentElement.getElementsByTagName("itemEffects").item(0);
 			for(int i=0; i<element.getElementsByTagName("effect").getLength(); i++){
 				Element e = ((Element)element.getElementsByTagName("effect").item(i));
-				effectsToBeAdded.add(ItemEffect.loadFromXML(e, doc));
+				ItemEffect itemEffect = ItemEffect.loadFromXML(e, doc);
+				if(itemEffect == null) {
+					System.err.println("Warning: Failed to import ItemEffect");
+				}
+				effectsToBeAdded.add(itemEffect);
 			}
 			item.setItemEffects(effectsToBeAdded);
 			

--- a/src/com/lilithsthrone/game/inventory/item/AbstractItem.java
+++ b/src/com/lilithsthrone/game/inventory/item/AbstractItem.java
@@ -89,6 +89,8 @@ public abstract class AbstractItem extends AbstractCoreItem implements Serializa
 				ItemEffect itemEffect = ItemEffect.loadFromXML(e, doc);
 				if(itemEffect == null) {
 					System.err.println("Warning: Failed to import ItemEffect");
+				}
+				else {
 					effectsToBeAdded.add(itemEffect);
 				}
 			}

--- a/src/com/lilithsthrone/game/inventory/item/ItemEffect.java
+++ b/src/com/lilithsthrone/game/inventory/item/ItemEffect.java
@@ -102,6 +102,12 @@ public class ItemEffect implements Serializable, XMLSaving {
 				itemEffectType = "ATTRIBUTE_ARCANE";
 				break;
 		}
+		switch(parentElement.getAttribute("primaryModifier"))
+		{
+			case "DAMAGE_ATTACK":
+			case "RESISTANCE_ATTACK":
+				return null;
+		}
 		ItemEffect ie = new ItemEffect(
 				ItemEffectType.valueOf(itemEffectType),
 				(parentElement.getAttribute("primaryModifier").equals("null")?null:TFModifier.valueOf(parentElement.getAttribute("primaryModifier"))),


### PR DESCRIPTION
Test for the damage/resistance stat for attacks when importing potions. I don't think this has an equivalent in the new versions, so these effects are simply dropped.