### PR TITLE
Fix for spell cost reduction giving negative costs

### DIFF
--- a/src/com/lilithsthrone/game/combat/Spell.java
+++ b/src/com/lilithsthrone/game/combat/Spell.java
@@ -692,7 +692,7 @@ public enum Spell {
 	public float getModifiedCost(GameCharacter caster) {
 		float calculatedCost = spellCost;
 		
-		calculatedCost *= Math.pow(3, caster.getAttributeValue(Attribute.SPELL_COST_MODIFIER) / -50f);
+		calculatedCost *= Math.pow(3, caster.getAttributeValue(Attribute.SPELL_COST_MODIFIER) / -100f);
 		
 		// Round float value to nearest 1 decimal place:
 		calculatedCost = (Math.round(calculatedCost*10))/10f;

--- a/src/com/lilithsthrone/game/combat/Spell.java
+++ b/src/com/lilithsthrone/game/combat/Spell.java
@@ -692,7 +692,7 @@ public enum Spell {
 	public float getModifiedCost(GameCharacter caster) {
 		float calculatedCost = spellCost;
 		
-		calculatedCost *= ((100 - caster.getAttributeValue(Attribute.SPELL_COST_MODIFIER)) / 100f);
+		calculatedCost *= Math.pow(3, caster.getAttributeValue(Attribute.SPELL_COST_MODIFIER) / -50f);
 		
 		// Round float value to nearest 1 decimal place:
 		calculatedCost = (Math.round(calculatedCost*10))/10f;


### PR DESCRIPTION
This is my idea to stop very high spell efficiency from _gaining_ aura from casting spells. Rather than a linear function, it uses an exponential function, so instead of spells being free at 100 efficiency, they cost 33%, and rather than costing _minus_ 100% at 200 efficiency, they cost 11% of nominal. Theoretically, the cost should never reach zero, although of course with rounding this will happen eventually (a cost 100 spell would reach zero at 692 efficiency, for example).
This also causes costs to _increase_ exponentially as efficiency goes negative, of course. If this isn't desired, a simple if(efficiency < 0) check could restore linear behaviour for that case.