### PR TITLE
Remove translation of INTELLIGENCE to MAJOR_ARCANE

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -940,9 +940,6 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 					if(e.getAttribute("type").equals("CORRUPTION")) {
 						character.setAttribute(Attribute.MAJOR_CORRUPTION, Float.valueOf(e.getAttribute("value")), false);
 						
-					} else if(e.getAttribute("type").equals("INTELLIGENCE")) {
-						character.setAttribute(Attribute.MAJOR_ARCANE, Float.valueOf(e.getAttribute("value")), false);
-						
 					} else if(e.getAttribute("type").equals("STRENGTH") || e.getAttribute("type").equals("MAJOR_STRENGTH")) {
 						character.setAttribute(Attribute.MAJOR_PHYSIQUE, Float.valueOf(e.getAttribute("value")), false);
 						


### PR DESCRIPTION
When importing from saves from before the attribute renames, intelligence really shouldn't be translated to arcane; doing this gives all imported characters arcane ability, which the majority of them shouldn't have.