### PR TITLE
Generic orgasm denial

### DIFF
--- a/src/com/lilithsthrone/game/sex/SexFlags.java
+++ b/src/com/lilithsthrone/game/sex/SexFlags.java
@@ -22,6 +22,7 @@ public class SexFlags implements Serializable {
 	mutualOrgasmsAllowed,
 	playerPreparedForOrgasm,
 	playerGrewDemonicCock,
+	playerDeniedPartner,
 	
 	// Position requests:
 	requestedCowgirl,
@@ -72,6 +73,7 @@ public class SexFlags implements Serializable {
 		playerPreparedForOrgasm = false;
 		
 		playerGrewDemonicCock = false;
+		playerDeniedPartner = false;
 		
 		resetRequests();
 		

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -2433,7 +2433,7 @@ public class GenericOrgasms {
 
 		@Override
 		public String getActionDescription() {
-			return "You can feel that [npc.name] is fast approaching [npc.her] orgasm. Don't let [npc.her] have it.";
+			return "You can feel that [npc.name] is fast approaching [npc.her] orgasm. Don't let [npc.herHim] have it.";
 		}
 
 		@Override

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -3218,5 +3218,47 @@ public class GenericOrgasms {
 			return null; 
 		}
 	};
+	
+	public static final SexAction PARTNER_GENERIC_ORGASM_DENIED = new SexAction(
+			SexActionType.PARTNER_ORGASM_NO_AROUSAL_RESET,
+			ArousalIncrease.NEGATIVE_MAJOR,
+			ArousalIncrease.TWO_LOW,
+			CorruptionLevel.ZERO_PURE,
+			null,
+			null,
+			SexParticipantType.MISC) {
+		
+		@Override
+		public boolean isBaseRequirementsMet() {
+			return SexFlags.playerDeniedPartner;
+		}
+		
+		@Override
+		public SexActionPriority getPriority() {
+			return SexActionPriority.UNIQUE_MAX;
+		}
+		
+		@Override
+		public String getActionTitle() {
+			return "Denied!";
+		}
+		
+		@Override
+		public String getActionDescription() {
+			return "You were denied at the last moment!";
+		}
+		
+		@Override
+		public String getDescription() {
+			return UtilText.parse(Sex.getActivePartner(),
+					"[npc.speech(Noooo! I was so close!)] [npc.name] wails in dismay.");
+		}
+		
+		@Override
+		public void applyEffects() {
+			SexFlags.playerDeniedPartner = false;
+			SexFlags.playerPreparedForOrgasm = false;
+		}
+	};
 
 }

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -2412,6 +2412,43 @@ public class GenericOrgasms {
 		}
 	};
 	
+	public static final SexAction PLAYER_PREPARE_DENY = new SexAction(
+			SexActionType.PLAYER_PREPARE_PARTNER_ORGASM,
+			ArousalIncrease.TWO_LOW,
+			ArousalIncrease.TWO_LOW,
+			CorruptionLevel.ZERO_PURE,
+			null,
+			null,
+			SexParticipantType.MISC) {
+		
+		@Override
+		public boolean isBaseRequirementsMet() {
+			return Sex.isDom(Main.game.getPlayer());
+		}
+		
+		@Override
+		public String getActionTitle() {
+			return "Deny";
+		}
+
+		@Override
+		public String getActionDescription() {
+			return "You can feel that [npc.name] is fast approaching [npc.her] orgasm. Don't let [npc.her] have it.";
+		}
+
+		@Override
+		public String getDescription() {
+			return UtilText.parse(Sex.getActivePartner(),
+					"Taking control of the situation, you hold [npc.name] quite still, only releasing [npc.herHim] once"
+							+ " [npc.she]'s lost a good portion of [npc.her] arousal.");
+		}
+		
+		@Override
+		public void applyEffects() {
+			SexFlags.playerDeniedPartner = true;
+		}
+	};
+	
 	// PARTNER
 	
 	public static final SexAction PARTNER_PREPARE = new SexAction(


### PR DESCRIPTION
This adds an action to deny an NPC's orgasm. The descriptions are basic and probably want expanding, but I'm pretty confident on the mechanics of it. I haven't added an action for NPCs to deny the player yet as that seems to work a bit differently.