### PR TITLE
BodyMaterial expansion, parser commands

### DIFF
--- a/src/com/lilithsthrone/game/character/body/valueEnums/BodyMaterial.java
+++ b/src/com/lilithsthrone/game/character/body/valueEnums/BodyMaterial.java
@@ -28,9 +28,13 @@ public enum BodyMaterial {
 			"nails", "hard",
 			"keratin", "keratinous",
 			Colour.BASE_PINK_LIGHT),
+	
 	SLIME("slime", Colour.RACE_SLIME),
-	FIRE("fire", Colour.BASE_ORANGE),
-	ICE("ice", Colour.BASE_BLUE_LIGHT),
+	
+	FIRE("fire", "burning", Colour.BASE_ORANGE),
+	
+	ICE("ice", "icy", Colour.BASE_BLUE_LIGHT),
+	
 	RUBBER("rubber", Colour.BASE_BLACK);
 
 	private String name;

--- a/src/com/lilithsthrone/game/character/body/valueEnums/BodyMaterial.java
+++ b/src/com/lilithsthrone/game/character/body/valueEnums/BodyMaterial.java
@@ -5,28 +5,329 @@ import com.lilithsthrone.utils.Colour;
 /**
  * @since 0.1.83
  * @version 0.2.1
- * @author Innoxia
+ * @author Innoxia, tukaima
  */
 public enum BodyMaterial {
 
-	FLESH("flesh", Colour.BASE_PINK_LIGHT),
+	FLESH(	"flesh",
+			"skin", "fleshy",
+			"skin", "fleshy",
+			"flesh", "fleshy",
+			"flesh", "fleshy",
+			"hair", "hairy",
+			"hair", "hairy",
+			"hair", "hairy",
+			"fur", "furry",
+			"fur", "furry",
+			"feathers", "feathered",
+			"feathers", "feathered",
+			"scales", "scaled",
+			"scales", "scaled",
+			"shell", "shelled",
+			"shell", "shelled",
+			"nails", "hard",
+			"keratin", "keratinous",
+			Colour.BASE_PINK_LIGHT),
 	SLIME("slime", Colour.RACE_SLIME),
 	FIRE("fire", Colour.BASE_ORANGE),
 	ICE("ice", Colour.BASE_BLUE_LIGHT),
 	RUBBER("rubber", Colour.BASE_BLACK);
-	
-	private String descriptor;
+
+	private String name;
+	private String skinNoun; private String skinAdj;
+	private String skinAltNoun; private String skinAltAdj;
+	private String orificeNoun; private String orificeAdj;
+	private String orificeAltNoun; private String orificeAltAdj;
+	private	String hairNoun; private String hairAdj;
+	private	String hairBodyNoun; private String hairBodyAdj;
+	private String hairAltNoun; private String hairAltAdj;
+	private	String furNoun; private String furAdj;
+	private String furAltNoun; private String furAltAdj;
+	private	String featherNoun; private String featherAdj;
+	private String featherAltNoun; private String featherAltAdj;
+	private	String scaleNoun; private String scaleAdj;
+	private String scaleAltNoun; private String scaleAltAdj;
+	private	String shellNoun; private String shellAdj;
+	private String shellAltNoun; private String shellAltAdj;
+	private	String keratinNoun; private String keratinAdj;
+	private String keratinAltNoun; private String keratinAltAdj;
 	private Colour colour;
-	
-	private BodyMaterial(String descriptor, Colour colour) {
-		this.descriptor = descriptor;
+
+	private BodyMaterial(String name,
+			String skinNoun, String skinAdj,
+			String skinAltNoun, String skinAltAdj,
+			String orificeNoun, String orificeAdj,
+			String orificeAltNoun, String orificeAltAdj,
+			String hairNoun, String hairAdj,
+			String hairBodyNoun, String hairBodyAdj,
+			String hairAltNoun, String hairAltAdj,
+			String furNoun, String furAdj,
+			String furAltNoun, String furAltAdj,
+			String featherNoun, String featherAdj,
+			String featherAltNoun, String featherAltAdj,
+			String scaleNoun, String scaleAdj,
+			String scaleAltNoun, String scaleAltAdj,
+			String shellNoun, String shellAdj,
+			String shellAltNoun, String shellAltAdj,
+			String keratinNoun, String keratinAdj,
+			String keratinAltNoun, String keratinAltAdj,
+			Colour colour) {
+		this.name = name;
+		this.skinNoun = skinNoun;
+		this.skinAdj = skinAdj;
+		this.skinAltNoun = skinAltNoun;
+		this.skinAltAdj = skinAltAdj;
+		this.orificeNoun = orificeNoun;
+		this.orificeAdj = orificeAdj;
+		this.orificeAltNoun = orificeAltNoun;
+		this.orificeAltAdj = orificeAltAdj;
+		this.hairNoun = hairNoun;
+		this.hairAdj = hairAdj;
+		this.hairBodyNoun = hairBodyNoun;
+		this.hairBodyAdj = hairBodyAdj;
+		this.hairAltNoun = hairAltNoun;
+		this.hairAltAdj = hairAltAdj;
+		this.furNoun = furNoun;
+		this.furAdj = furAdj;
+		this.furAltNoun = furAltNoun;
+		this.furAltAdj = furAltAdj;
+		this.featherNoun = featherNoun;
+		this.featherAdj = featherAdj;
+		this.featherAltNoun = featherAltNoun;
+		this.featherAltAdj = featherAltAdj;
+		this.scaleNoun = scaleNoun;
+		this.scaleAdj = scaleAdj;
+		this.scaleAltNoun = scaleAltNoun;
+		this.scaleAltAdj = scaleAltAdj;
+		this.shellNoun = shellNoun;
+		this.shellAdj = shellAdj;
+		this.shellAltNoun = shellAltNoun;
+		this.shellAltAdj = shellAltAdj;
+		this.keratinNoun = keratinNoun;
+		this.keratinAdj = keratinAdj;
+		this.keratinAltNoun = keratinAltNoun;
+		this.keratinAltAdj = keratinAltAdj;
+		this.colour = colour;
+	}
+
+	private BodyMaterial(String noun, String adjective, Colour colour) {
+		this.name = noun;
+		this.skinNoun = noun;
+		this.skinAdj = adjective;
+		this.skinAltNoun = noun;
+		this.skinAltAdj = adjective;
+		this.orificeNoun = noun;
+		this.orificeAdj = adjective;
+		this.orificeAltNoun = noun;
+		this.orificeAltAdj = adjective;
+		this.hairNoun = noun;
+		this.hairAdj = adjective;
+		this.hairBodyNoun = noun;
+		this.hairBodyAdj = adjective;
+		this.hairAltNoun = noun;
+		this.hairAltAdj = adjective;
+		this.furNoun = noun;
+		this.furAdj = adjective;
+		this.furAltNoun = noun;
+		this.furAltAdj = adjective;
+		this.featherNoun = noun;
+		this.featherAdj = adjective;
+		this.featherAltNoun = noun;
+		this.featherAltAdj = adjective;
+		this.scaleNoun = noun;
+		this.scaleAdj = adjective;
+		this.scaleAltNoun = noun;
+		this.scaleAltAdj = adjective;
+		this.shellNoun = noun;
+		this.shellAdj = adjective;
+		this.shellAltNoun = noun;
+		this.shellAltAdj = adjective;
+		this.keratinNoun = noun;
+		this.keratinAdj = adjective;
+		this.keratinAltNoun = noun;
+		this.keratinAltAdj = adjective;
+		this.colour = colour;
+	}
+
+	private BodyMaterial(String noun, Colour colour) {
+		this.name = noun;
+		this.skinNoun = noun;
+		this.skinAdj = noun;
+		this.skinAltNoun = noun;
+		this.skinAltAdj = noun;
+		this.orificeNoun = noun;
+		this.orificeAdj = noun;
+		this.orificeAltNoun = noun;
+		this.orificeAltAdj = noun;
+		this.hairNoun = noun;
+		this.hairAdj = noun;
+		this.hairBodyNoun = noun;
+		this.hairBodyAdj = noun;
+		this.hairAltNoun = noun;
+		this.hairAltAdj = noun;
+		this.furNoun = noun;
+		this.furAdj = noun;
+		this.furAltNoun = noun;
+		this.furAltAdj = noun;
+		this.featherNoun = noun;
+		this.featherAdj = noun;
+		this.featherAltNoun = noun;
+		this.featherAltAdj = noun;
+		this.scaleNoun = noun;
+		this.scaleAdj = noun;
+		this.scaleAltNoun = noun;
+		this.scaleAltAdj = noun;
+		this.shellNoun = noun;
+		this.shellAdj = noun;
+		this.shellAltNoun = noun;
+		this.shellAltAdj = noun;
+		this.keratinNoun = noun;
+		this.keratinAdj = noun;
+		this.keratinAltNoun = noun;
+		this.keratinAltAdj = noun;
 		this.colour = colour;
 	}
 
 	public String getName() {
-		return descriptor;
+		return name;
+	}
+
+	public String getSkinNoun() {
+		return skinNoun;
 	}
 	
+	public String getSkinAdj() {
+		return skinAdj;
+	}
+	
+	public String getSkinAltNoun() {
+		return skinAltNoun;
+	}
+	
+	public String getSkinAltAdj() {
+		return skinAltAdj;
+	}
+	
+	public String getOrificeNoun() {
+		return orificeNoun;
+	}
+	
+	public String getOrificeAdj() {
+		return orificeAdj;
+	}
+	
+	public String getOrificeAltNoun() {
+		return orificeAltNoun;
+	}
+	
+	public String getOrificeAltAdj() {
+		return orificeAltAdj;
+	}
+
+	public String getHairNoun() {
+		return hairNoun;
+	}
+	
+	public String getHairAdj() {
+		return hairAdj;
+	}
+	
+	public String getHairBodyNoun() {
+		return hairBodyNoun;
+	}
+	
+	public String getHairBodyAdj() {
+		return hairBodyAdj;
+	}
+	
+	public String getHairAltNoun() {
+		return hairAltNoun;
+	}
+	
+	public String getHairAltAdj() {
+		return hairAltAdj;
+	}
+	
+	public String getFurNoun() {
+		return furNoun;
+	}
+	
+	public String getFurAdj() {
+		return furAdj;
+	}
+	
+	public String getFurAltNoun() {
+		return furAltNoun;
+	}
+	
+	public String getFurAltAdj() {
+		return furAltAdj;
+	}
+	
+	public String getFeatherNoun() {
+		return featherNoun;
+	}
+	
+	public String getFeatherAdj() {
+		return featherAdj;
+	}
+	
+	public String getFeatherAltNoun() {
+		return featherAltNoun;
+	}
+	
+	public String getFeatherAltAdj() {
+		return featherAltAdj;
+	}
+	
+	public String getScaleNoun() {
+		return scaleNoun;
+	}
+	
+	public String getScaleAdj() {
+		return scaleAdj;
+	}
+	
+	public String getScaleAltNoun() {
+		return scaleAltNoun;
+	}
+	
+	public String getScaleAltAdj() {
+		return scaleAltAdj;
+	}
+	
+	public String getShellNoun() {
+		return shellNoun;
+	}
+	
+	public String getShellAdj() {
+		return shellAdj;
+	}
+	
+	public String getShellAltNoun() {
+		return shellAltNoun;
+	}
+	
+	public String getShellAltAdj() {
+		return shellAltAdj;
+	}
+	
+	public String getKeratinNoun() {
+		return keratinNoun;
+	}
+	
+	public String getKeratinAdj() {
+		return keratinAdj;
+	}
+	
+	public String getKeratinAltNoun() {
+		return keratinAltNoun;
+	}
+	
+	public String getKeratinAltAdj() {
+		return keratinAltAdj;
+	}
+
 	public Colour getColour() {
 		return colour;
 	}

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -1110,6 +1110,55 @@ public class UtilText {
 		
 		commandsList.add(new ParserCommand(
 				Util.newArrayListOfValues(
+						new ListValue<>("bodyMaterialCovering")),
+				true,
+				true,
+				"covering type",//TODO
+				"Returns a descriptor based on the character's BodyMaterial and the chosen covering type. Functionality and arguments are temporary."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				switch (arguments) {
+					case ("skinNoun"): return character.getBodyMaterial().getSkinNoun();
+					case ("skinAdj"): return character.getBodyMaterial().getSkinAdj();
+					case ("skinAltNoun"): return character.getBodyMaterial().getSkinAltNoun();
+					case ("skinAltAdj"): return character.getBodyMaterial().getSkinAltAdj();
+					case ("orificeNoun"): return character.getBodyMaterial().getOrificeNoun();
+					case ("orificeAdj"): return character.getBodyMaterial().getOrificeAdj();
+					case ("orificeAltNoun"): return character.getBodyMaterial().getOrificeAltNoun();
+					case ("orificeAltAdj"): return character.getBodyMaterial().getOrificeAltAdj();
+					case ("hairNoun"): return character.getBodyMaterial().getHairNoun();
+					case ("hairAdj"): return character.getBodyMaterial().getHairAdj();
+					case ("hairBodyNoun"): return character.getBodyMaterial().getHairBodyNoun();
+					case ("hairBodyAdj"): return character.getBodyMaterial().getHairBodyAdj();
+					case ("hairAltNoun"): return character.getBodyMaterial().getHairAltNoun();
+					case ("hairAltAdj"): return character.getBodyMaterial().getHairAltAdj();
+					case ("furNoun"): return character.getBodyMaterial().getFurNoun();
+					case ("furAdj"): return character.getBodyMaterial().getFurAdj();
+					case ("furAltNoun"): return character.getBodyMaterial().getFurAltNoun();
+					case ("furAltAdj"): return character.getBodyMaterial().getFurAltAdj();
+					case ("featherNoun"): return character.getBodyMaterial().getFeatherNoun();
+					case ("featherAdj"): return character.getBodyMaterial().getFeatherAdj();
+					case ("featherAltNoun"): return character.getBodyMaterial().getFeatherAltNoun();
+					case ("featherAltAdj"): return character.getBodyMaterial().getFeatherAltAdj();
+					case ("scaleNoun"): return character.getBodyMaterial().getScaleNoun();
+					case ("scaleAdj"): return character.getBodyMaterial().getScaleAdj();
+					case ("scaleAltNoun"): return character.getBodyMaterial().getScaleAltNoun();
+					case ("scaleAltAdj"): return character.getBodyMaterial().getScaleAltAdj();
+					case ("shellNoun"): return character.getBodyMaterial().getShellNoun();
+					case ("shellAdj"): return character.getBodyMaterial().getShellAdj();
+					case ("shellAltNoun"): return character.getBodyMaterial().getShellAltNoun();
+					case ("shellAltAdj"): return character.getBodyMaterial().getShellAltAdj();
+					case ("keratinNoun"): return character.getBodyMaterial().getKeratinNoun();
+					case ("keratinAdj"): return character.getBodyMaterial().getKeratinAdj();
+					case ("keratinAltNoun"): return character.getBodyMaterial().getKeratinAltNoun();
+					case ("keratinAltAdj"): return character.getBodyMaterial().getKeratinAltAdj();
+					case ("name"): default: return character.getBodyMaterial().getName();
+				}
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
 						new ListValue<>("height")),
 				true,
 				true,

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -1055,6 +1055,471 @@ public class UtilText {
 		
 		commandsList.add(new ParserCommand(
 				Util.newArrayListOfValues(
+						new ListValue<>("materialName")),
+				true,
+				true,
+				"",
+				"Returns the name of the character's BodyMaterial."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getName();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialSkin")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's skin."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getSkinNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialSkinAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's skin."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getSkinAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialSkinAlt")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's skin on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getSkinAltNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialSkinAltAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's skin on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getSkinAltAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialOrifice")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the material lining the character's orifices."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getOrificeNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialOrificeAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the material lining the character's orifices."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getOrificeAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialOrificeAlt")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the material lining the character's orifices on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getOrificeAltNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialOrificeAltAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the material lining the character's orifices on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getOrificeAltAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialHair")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's hair."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getHairNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialHairAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's hair."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getHairAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialHairBody"),
+						new ListValue<>("materialBodyHair")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's body hair."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getHairBodyNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialHairBodyAdjective"),
+						new ListValue<>("materialBodyHairAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's body hair."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getHairBodyAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialHairAlt")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's Hair on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getHairAltNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialHairAltAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's hair on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getHairAltAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialFur")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's fur."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getFurNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialFurAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's fur."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getFurAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialFurAlt")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's fur on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getFurAltNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialFurAltAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's fur on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getFurAltAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialFeather"),
+						new ListValue<>("materialFeathers")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's feathers."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getFeatherNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialFeatherAdjective"),
+						new ListValue<>("materialFeathersAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's feathers."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getFeatherAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialFeatherAlt"),
+						new ListValue<>("materialFeathersAlt")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's feathers on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getFeatherAltNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialFeatherAltAdjective"),
+						new ListValue<>("materialFeathersAltAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's fur on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getFeatherAltAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialScale"),
+						new ListValue<>("materialScales")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's scales."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getScaleNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialScaleAdjective"),
+						new ListValue<>("materialScalesAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's scales."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getScaleAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialScaleAlt"),
+						new ListValue<>("materialScalesAlt")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's scales on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getScaleAltNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialScaleAltAdjective"),
+						new ListValue<>("materialScalesAltAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's scales on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getScaleAltAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialShell")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's shell."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getShellNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialShellAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's shell."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getShellAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialShellAlt")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's shell on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getShellAltNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialShellAltAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's shell on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getShellAltAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialKeratin")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's keratin."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getKeratinNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialKeratinAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's keratin."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getKeratinAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialKeratinAlt")),
+				true,
+				true,
+				"",
+				"Returns a descriptor of the character's keratin on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getKeratinAltNoun();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						new ListValue<>("materialKeratinAltAdjective")),
+				true,
+				true,
+				"",
+				"Returns an adjectival descriptor of the character's keratin on nonhumanoid body parts."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				return character.getBodyMaterial().getKeratinAltAdj();
+			}
+		});
+		
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
 						new ListValue<>("femininity"),
 						new ListValue<>("fem"),
 						new ListValue<>("masculinity"),
@@ -1105,55 +1570,6 @@ public class UtilText {
 			@Override
 			public String parse(String command, String arguments, String target) {
 				return character.getBodyShape().getName(false);
-			}
-		});
-		
-		commandsList.add(new ParserCommand(
-				Util.newArrayListOfValues(
-						new ListValue<>("bodyMaterialCovering")),
-				true,
-				true,
-				"covering type",//TODO
-				"Returns a descriptor based on the character's BodyMaterial and the chosen covering type. Functionality and arguments are temporary."){
-			@Override
-			public String parse(String command, String arguments, String target) {
-				switch (arguments) {
-					case ("skinNoun"): return character.getBodyMaterial().getSkinNoun();
-					case ("skinAdj"): return character.getBodyMaterial().getSkinAdj();
-					case ("skinAltNoun"): return character.getBodyMaterial().getSkinAltNoun();
-					case ("skinAltAdj"): return character.getBodyMaterial().getSkinAltAdj();
-					case ("orificeNoun"): return character.getBodyMaterial().getOrificeNoun();
-					case ("orificeAdj"): return character.getBodyMaterial().getOrificeAdj();
-					case ("orificeAltNoun"): return character.getBodyMaterial().getOrificeAltNoun();
-					case ("orificeAltAdj"): return character.getBodyMaterial().getOrificeAltAdj();
-					case ("hairNoun"): return character.getBodyMaterial().getHairNoun();
-					case ("hairAdj"): return character.getBodyMaterial().getHairAdj();
-					case ("hairBodyNoun"): return character.getBodyMaterial().getHairBodyNoun();
-					case ("hairBodyAdj"): return character.getBodyMaterial().getHairBodyAdj();
-					case ("hairAltNoun"): return character.getBodyMaterial().getHairAltNoun();
-					case ("hairAltAdj"): return character.getBodyMaterial().getHairAltAdj();
-					case ("furNoun"): return character.getBodyMaterial().getFurNoun();
-					case ("furAdj"): return character.getBodyMaterial().getFurAdj();
-					case ("furAltNoun"): return character.getBodyMaterial().getFurAltNoun();
-					case ("furAltAdj"): return character.getBodyMaterial().getFurAltAdj();
-					case ("featherNoun"): return character.getBodyMaterial().getFeatherNoun();
-					case ("featherAdj"): return character.getBodyMaterial().getFeatherAdj();
-					case ("featherAltNoun"): return character.getBodyMaterial().getFeatherAltNoun();
-					case ("featherAltAdj"): return character.getBodyMaterial().getFeatherAltAdj();
-					case ("scaleNoun"): return character.getBodyMaterial().getScaleNoun();
-					case ("scaleAdj"): return character.getBodyMaterial().getScaleAdj();
-					case ("scaleAltNoun"): return character.getBodyMaterial().getScaleAltNoun();
-					case ("scaleAltAdj"): return character.getBodyMaterial().getScaleAltAdj();
-					case ("shellNoun"): return character.getBodyMaterial().getShellNoun();
-					case ("shellAdj"): return character.getBodyMaterial().getShellAdj();
-					case ("shellAltNoun"): return character.getBodyMaterial().getShellAltNoun();
-					case ("shellAltAdj"): return character.getBodyMaterial().getShellAltAdj();
-					case ("keratinNoun"): return character.getBodyMaterial().getKeratinNoun();
-					case ("keratinAdj"): return character.getBodyMaterial().getKeratinAdj();
-					case ("keratinAltNoun"): return character.getBodyMaterial().getKeratinAltNoun();
-					case ("keratinAltAdj"): return character.getBodyMaterial().getKeratinAltAdj();
-					case ("name"): default: return character.getBodyMaterial().getName();
-				}
 			}
 		});
 		


### PR DESCRIPTION
This expands BodyMaterials so that they can have more than one descriptor, and adds parser functionality to refer to a character's BodyMaterial and its parts. Several of the BodyMaterials have been edited to fit with this new functionality.

If one descriptor is provided, BodyMaterials act as before. This applies to slime and rubber, currently.
If two descriptors are provided, BodyMaterials can have a noun and an adjective as descriptors. This applies to fire and ice, currently.
Otherwise, a noun and an adjective are expected for each of the following:

- Skin on humanoid body parts
- Skin on nonhumanoid body parts
- Internal flesh of orifices on humanoid body parts
- Internal flesh of orifices on nonhumanoid body parts
- Hair on top of the head (Ponytails, hime cuts, etc.)
- Hair on humanoid body parts (Nature trail, armpit hair, etc.)
- Hair on nonhumanoid body parts (Arachne lower body)
- Fur on humanoid body parts (Face, arms)
- Fur on nonhumanoid body parts (Tails, taur bodies)
- Feathers on humanoid body parts (Harpy face)
- Feathers on nonhumanoid body parts (Angel wings)
- Scales on humanoid body parts (Reptilian arms, head, etc.)
- Scales on nonhumanoid body parts (Gator tail, dragon wings)
- Shell on humanoid body parts (Insect arms, head, etc.)
- Shell on nonhumanoid body parts (Insect thorax/tails)
- Keratin on humanoid body parts (Nails)
- Keratin on nonhumanoid body parts (Claws, horns)