### PR TITLE
Fix for loading the game advancing time

### DIFF
--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -1552,6 +1552,10 @@ public class Game implements Serializable, XMLSaving {
 		setContent(response, true, null, null);
 	}
 	
+	public void setContent(Response response, boolean allowTimeProgress) {
+		setContent(response, allowTimeProgress, null, null);
+	}
+	
 	public void setContent(Response response, Colour colour, String messageText) {
 		setContent(response, true, colour, messageText);
 	}

--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -662,7 +662,7 @@ public class Game implements Serializable, XMLSaving {
 		
 		DialogueNodeOld startingDialogueNode = Main.game.getPlayerCell().getPlace().getDialogue(false);
 		Main.game.addEvent(new EventLogEntry(Main.game.getMinutesPassed(), "[style.colourGood(Game loaded)]", "data/saves/"+name+".xml"), false);
-		Main.game.setContent(new Response(startingDialogueNode.getLabel(), startingDialogueNode.getDescription(), startingDialogueNode));
+		Main.game.setContent(new Response(startingDialogueNode.getLabel(), startingDialogueNode.getDescription(), startingDialogueNode), false);
 		
 		newGame.endTurn(0);
 	}


### PR DESCRIPTION
Previously, loading the game would advance time from the point the game was saved.