### PR TITLE
Adjust the display of subspecies lists in the Encyclopedia.

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/PhoneDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/PhoneDialogue.java
@@ -53,7 +53,7 @@ import com.lilithsthrone.utils.WeaponRarityComparator;
 /**
  * @since 0.1.0
  * @version 0.1.99
- * @author Innoxia
+ * @author Innoxia, tukaima
  */
 public class PhoneDialogue {
 
@@ -1734,19 +1734,10 @@ public class PhoneDialogue {
 										+ "<td>-</td>"
 									+ "</tr>");
 						
-						for(Subspecies sub : Subspecies.values()) {
-							if(sub.getRace()==race) {
-								raceSB.append(
-										"<tr>"
-											+"<th>Subspecies:</th>"
-											+ "<th><b style='color:"+Femininity.valueOf(racialBody.getFemaleFemininity()).getColour().toWebHexString()+";'>"+Util.capitaliseSentence(sub.getSingularFemaleName())+"</b></th>"
-											+ "<th><b style='color:"+Femininity.valueOf(racialBody.getMaleFemininity()).getColour().toWebHexString()+";'>"+Util.capitaliseSentence(sub.getSingularMaleName())+"</b></th>"
-										+ "</tr>");
-							}
-						}
-						
 						raceSB.append("</table>"
-								+ "</div>");
+								+ "</div>"
+								+ "<details>"
+								+ "<summary>Subspecies</summary>");
 						
 						for(Subspecies sub : Subspecies.values()) {
 							if(sub.getRace()==race) {
@@ -1763,8 +1754,8 @@ public class PhoneDialogue {
 						}
 						
 						
-						raceSB.append(
-								"<h6>"+Util.capitaliseSentence(race.getName())+" Lore</h6>"
+						raceSB.append("</details>"
+								+ "<h6>"+Util.capitaliseSentence(race.getName())+" Lore</h6>"
 									+race.getBasicDescription()
 									+ (Main.getProperties().isAdvancedRaceKnowledgeDiscovered(race)
 										?race.getAdvancedDescription()


### PR DESCRIPTION
Currently, subspecies names/info are displayed in two separate lists in the Encyclopedia. The first is contained within the same "frame" as all the other text, and the other in the average stats display.

The former has been hidden underneath an HTML details element, so that the player is not greeted with ten thousand rows of text when they open the Slime page (and any future race entries which have a similar amount of subspecies).

The latter is superfluous, so it has been removed; the second Subspecies display shares no information that is not already available in the first. You could make a case for it being easier to read through, but that's about it.