### PR TITLE
Renames Dobermann-morphs

### DIFF
--- a/src/com/lilithsthrone/game/character/race/Subspecies.java
+++ b/src/com/lilithsthrone/game/character/race/Subspecies.java
@@ -201,8 +201,8 @@ public enum Subspecies {
 			},
 	
 	DOG_MORPH_DOBERMANN("raceDogMorphDobermann",
-			"dobermorph",
-			"dobermorphs",
+			"dobermann",
+			"dobermanns",
 			"dobermann",
 			"dobermann",
 			"dobermanns",

--- a/src/com/lilithsthrone/game/character/race/Subspecies.java
+++ b/src/com/lilithsthrone/game/character/race/Subspecies.java
@@ -201,8 +201,8 @@ public enum Subspecies {
 			},
 	
 	DOG_MORPH_DOBERMANN("raceDogMorphDobermann",
-			"dobermann-morph",
-			"dobermann-morphs",
+			"dobermorph",
+			"dobermorphs",
 			"dobermann",
 			"dobermann",
 			"dobermanns",


### PR DESCRIPTION
Changes the morph name to Dobermorphs, well keeping the pronoun as dobermann. This would only effect the times when you see them in battles, or are going for the subspecies your self. This was suggested by Jimmythehand 3/21/18 at about 12:31pm EST