### PR TITLE
Punctuation fixes

### DIFF
--- a/res/txt/characters/dominion/nyan.xml
+++ b/res/txt/characters/dominion/nyan.xml
@@ -28,8 +28,8 @@
 	<htmlContent tag="NYAN_TALK"><![CDATA[
 	<p>
 		[pc.speech(I was wondering how your work's been going recently,)]
-		 you reply,
-		[pc.speech(your store looks as busy as ever today.)]
+		 you reply.
+		[pc.speech(Your store looks as busy as ever today.)]
 	</p>
 	<p>
 		[nyan.speech(W-Well, it's b-been going well, t-thank you,)]
@@ -42,8 +42,8 @@
 	<htmlContent tag="NYAN_TALK"><![CDATA[
 	<p>
 		[pc.speech(I just wanted to ask you how you cope with these arcane storms,)]
-		 you reply,
-		[pc.speech(they seem to be a real problem for all the people here in Dominion.)]
+		 you reply.
+		[pc.speech(They seem to be a real problem for all the people here in Dominion.)]
 	</p>
 	<p>
 		[nyan.speech(W-Well, I-I live in an a-apartment b-behind this store,)]
@@ -75,8 +75,8 @@
 	<htmlContent tag="NYAN_COMPLIMENT"><![CDATA[
 	<p>
 		[pc.speech(You know, you really do have beautiful eyes,)]
-		 you say, smiling at the pretty cat-girl,
-		 [pc.speech(they're such a gorgeous shade of blue.)]
+		 you say, smiling at the pretty cat-girl.
+		 [pc.speech(They're such a gorgeous shade of blue.)]
 	</p>
 	]]>
 	</htmlContent>
@@ -84,7 +84,7 @@
 	<htmlContent tag="NYAN_COMPLIMENT"><![CDATA[
 	<p>
 		[pc.speech(Your hair looks really good today,)]
-		 you say, smiling at the pretty cat-girl,
+		 you say, smiling at the pretty cat-girl.
 		 [pc.speech(I really love what you do with it.)]
 	</p>
 	]]>
@@ -93,8 +93,8 @@
 	<htmlContent tag="NYAN_COMPLIMENT"><![CDATA[
 	<p>
 		[pc.speech(I really love your outfit,)]
-		 you say, smiling at the pretty cat-girl,
-		 [pc.speech(that blouse suits you so well.)]
+		 you say, smiling at the pretty cat-girl.
+		 [pc.speech(That blouse suits you so well.)]
 	</p>
 	]]>
 	</htmlContent>
@@ -163,8 +163,8 @@
 	<htmlContent tag="NYAN_KISS"><![CDATA[
 	<p>
 		[nyan.speech(Ah, [pc.name],)]
-		 Nyan sighs, looking longingly into your eyes,
-		 [nyan.speech(what is it? Did you wan- <i>~Mmmm!~</i>)]
+		 Nyan sighs, looking longingly into your eyes.
+		 [nyan.speech(What is it? Did you wan- <i>~Mmmm!~</i>)]
 	</p>
 	<p>
 		Unable to resist any longer, you reach up and take hold of Nyan's head, before leaning in and pressing your lips against hers.
@@ -177,7 +177,7 @@
 	<htmlContent tag="NYAN_KISS"><![CDATA[
 	<p>
 		[nyan.speech([pc.Name]?)]
-		 Nyan asks, letting out a little sigh as she looks longingly into your eyes,
+		 Nyan asks, letting out a little sigh as she looks longingly into your eyes.
 		 [nyan.speech(Did you wan- <i>~Mmmm!~</i>)]
 	</p>
 	<p>
@@ -238,7 +238,7 @@
 	</p>
 	<p>
 		[nyan.speech(<i>~Mrph!~</i> Can't get caught here... <i>~Mmm!~</i>)]
-		 Nyan moans, reluctantly pulling away, before grabbing your [pc.hand] and leading you over to an unassuming door on the other side of the storeroom,
+		 Nyan moans, reluctantly pulling away, before grabbing your [pc.hand] and leading you over to an unassuming door on the other side of the storeroom.
 		 [nyan.speech(This is a back-entrance to my apartment... Hold on...)]
 		 The cat-girl excitedly unlocks the door before you, and, still holding on to your [pc.hand], pulls you into the room beyond.
 	</p>
@@ -286,7 +286,7 @@
 	</p>
 	<p>
 		Nyan gasps in shock, before tentatively reaching out and taking the box from you,
-		 [nyan.speech(O-Oh my goodness! I-I don't know what t-to say! T-Thank you s-so much [pc.name]!)]
+		 [nyan.speech(O-Oh my goodness! I-I don't know what t-to say! T-Thank you s-so much, [pc.name]!)]
 	</p>
 	<p>
 		You can't help but smile at Nyan's genuine reaction to the gift.
@@ -298,7 +298,7 @@
 	<htmlContent tag="NYAN_GIFT_PERFUME"><![CDATA[
 	<p>
 		You produce the bottle of perfume that you've bought for Nyan, smiling as you hold it out to her,
-		 [pc.speech(I got this for you Nyan!)]
+		 [pc.speech(I got this for you, Nyan!)]
 	</p>
 	<p>
 		The nervous cat-girl lets out an excited squeak in response,
@@ -306,8 +306,8 @@
 	</p>
 	<p>
 		[pc.speech(No, but I wanted to,)]
-		 you smile,
-		 [pc.speech(you really deserve it, what with how hard you work and everything!)]
+		 you smile.
+		 [pc.speech(You really deserve it, what with how hard you work and everything!)]
 	</p>
 	<p>
 		Nyan blushes as she takes the bottle from out of your [pc.hands],
@@ -324,11 +324,11 @@
 	<p>
 		From behind your back, you produce the bouquet of roses.
 		 Holding them out towards the nervous cat-girl, you smile,
-		 [pc.speech(I bought these for you Nyan, I hope you like them.)]
+		 [pc.speech(I bought these for you, Nyan. I hope you like them.)]
 	</p>
 	<p>
 		[nyan.speech(O-Oh m-my goodness!)]
-		 Nyan squeaks, her voice trembling with excitement,
+		 Nyan squeaks, her voice trembling with excitement.
 		 [nyan.speech(N-Nobody else h-has ever given m-me flowers before! T-Thank you so much!)]
 	</p>
 	<p>

--- a/res/txt/characters/dominion/nyan.xml
+++ b/res/txt/characters/dominion/nyan.xml
@@ -120,7 +120,7 @@
 
 	<htmlContent tag="NYAN_FLIRT"><![CDATA[
 	<p>
-		Playfully teasing her over the subject of which lingerie she likes the most, you soon manage to get the blushing cat-girl smiling and giggling as she light-heartedly smacks you on the [pc.arm],
+		Playfully teasing her over the subject of which lingerie she likes the most, you soon manage to get the blushing cat-girl smiling and giggling as she light-heartedly smacks you on the [pc.arm].
 		 [nyan.speech([pc.Name]! <i>~Hehe!~</i> Stop it!)]
 	</p>
 	]]>
@@ -254,7 +254,7 @@
 	<htmlContent tag="NYAN_END_SEX"><![CDATA[
 	<p>
 		You both lie there on the bed for a while, panting and sighing as you kiss and stroke one another.
-		 Eventually, however, Nyan remembers that she's supposed to be at work, and, planting one last passionate kiss on your lips, she stands up,
+		 Eventually, however, Nyan remembers that she's supposed to be at work, and, planting one last passionate kiss on your lips, she stands up.
 		 [nyan.speech(That was amazing...)]
 	</p>
 	<p>
@@ -267,7 +267,7 @@
 	<htmlContent tag="NYAN_END_SEX_NO_ORGASM"><![CDATA[
 	<p>
 		You both lie there on the bed for a while, panting and sighing as you kiss and stroke one another.
-		 Eventually, however, Nyan remembers that she's supposed to be at work, and, planting one last passionate kiss on your lips, she stands up,
+		 Eventually, however, Nyan remembers that she's supposed to be at work, and, planting one last passionate kiss on your lips, she stands up.
 		 [nyan.speech(That was... fun... b-but how about you let me orgasm next time...)]
 	</p>
 	<p>
@@ -281,11 +281,11 @@
 	
 	<htmlContent tag="NYAN_GIFT_CHOCOLATES"><![CDATA[
 	<p>
-		Producing the box of chocolates that you'd been hiding behind your back, you hold it out to Nyan,
+		Producing the box of chocolates that you'd been hiding behind your back, you hold it out to Nyan.
 		 [pc.speech(I got this for you, Nyan. I hope you like them!)]
 	</p>
 	<p>
-		Nyan gasps in shock, before tentatively reaching out and taking the box from you,
+		Nyan gasps in shock, before tentatively reaching out and taking the box from you.
 		 [nyan.speech(O-Oh my goodness! I-I don't know what t-to say! T-Thank you s-so much, [pc.name]!)]
 	</p>
 	<p>
@@ -297,20 +297,20 @@
 	
 	<htmlContent tag="NYAN_GIFT_PERFUME"><![CDATA[
 	<p>
-		You produce the bottle of perfume that you've bought for Nyan, smiling as you hold it out to her,
+		You produce the bottle of perfume that you've bought for Nyan, smiling as you hold it out to her.
 		 [pc.speech(I got this for you, Nyan!)]
 	</p>
 	<p>
-		The nervous cat-girl lets out an excited squeak in response,
+		The nervous cat-girl lets out an excited squeak in response.
 		 [nyan.speech([pc.Name]! Y-You didn't have to g-get me this!)]
 	</p>
 	<p>
-		[pc.speech(No, but I wanted to,)]
-		 you smile.
+		[pc.speech(No, but I wanted to.)]
+		 You smile.
 		 [pc.speech(You really deserve it, what with how hard you work and everything!)]
 	</p>
 	<p>
-		Nyan blushes as she takes the bottle from out of your [pc.hands],
+		Nyan blushes as she takes the bottle from out of your [pc.hands].
 		 [nyan.speech(T-Thank you s-so much!)]
 	</p>
 	<p>
@@ -323,7 +323,7 @@
 	<htmlContent tag="NYAN_GIFT_ROSES"><![CDATA[
 	<p>
 		From behind your back, you produce the bouquet of roses.
-		 Holding them out towards the nervous cat-girl, you smile,
+		 Holding them out towards the nervous cat-girl, you smile.
 		 [pc.speech(I bought these for you, Nyan. I hope you like them.)]
 	</p>
 	<p>
@@ -340,11 +340,11 @@
 	
 	<htmlContent tag="NYAN_GIFT_TEDDY_BEAR"><![CDATA[
 	<p>
-		Holding out the fluffy teddy bear, you smile at Nyan,
+		Holding out the fluffy teddy bear, you smile at Nyan.
 		 [pc.speech(Once I saw this, I couldn't resist buying it for you!)]
 	</p>
 	<p>
-		The delicate cat-girl lets out a delighted squeak as she sees the gift that you've bought for her,
+		The delicate cat-girl lets out a delighted squeak as she sees the gift that you've bought for her.
 		 [nyan.speech([pc.Name]! H-How did you know?! I-I love cuddly toys!)]
 	</p>
 	<p>

--- a/res/txt/places/dominion/shoppingArcade/clothingEmporium.xml
+++ b/res/txt/places/dominion/shoppingArcade/clothingEmporium.xml
@@ -21,13 +21,13 @@
 	</p>
 	<p>
 		Turning once more, this time in the direction that the timid voice came from, you find yourself face-to-face with a lesser cat-girl.
-		 As you look into her bright blue eyes, her cheeks instantly turn a deep shade of red, and she glances down at the floor and starts shuffling her feet, 
+		 As you look into her bright blue eyes, her cheeks instantly turn a deep shade of red, and she glances down at the floor and starts shuffling her feet. 
 		[nyan.speech(H-Hello... T-There's nobody else available, you see, s-so I thought maybe I could help. Oh, erm, I-I'm Nyan... I probably should have said that first... W-Welcome to my store...)]
 	</p>
 	<p>
 		If it wasn't for the fact that she's wearing a staff uniform, and has a little name tag pinned to her blouse reading 'Nyan; Store Manager', you're not sure if you would have believed that she's the store's owner.
 		 In an attempt to put the anxious cat-girl at ease, you ignore the fact that she's visibly trembling and explain your situation to her,
-		 [pc.speech(Pleased to meet you Nyan, it's an impressive place you've got here! I was having a little difficulty finding anything in amongst all these crowds, however...)]
+		 [pc.speech(Pleased to meet you, Nyan, it's an impressive place you've got here! I was having a little difficulty finding anything in amongst all these crowds, however...)]
 	</p>
 	<p>
 		[nyan.speech(O-Oh, sorry! E-Everything we have on display can also b-be found back in our stockroom. F-Follow me and I'll show you!)]
@@ -49,11 +49,11 @@
 		 [nyan.speech(A-Ah! H-Hello again!)]
 	</p>
 	<p>
-		You turn around to see Nyan looking down at her feet as she shuffles them about on the shop's laminate flooring,
-		 [pc.speech(Hi Nyan, how are y-)]
+		You turn around to see Nyan looking down at her feet as she shuffles them about on the shop's laminate flooring.
+		 [pc.speech(Hi, Nyan, how are y-)]
 	</p>
 	<p>
-		[nyan.speech(I-I'm fine! T-Thanks for asking,)] Nyan bursts out, interrupting you in her haste to answer,
+		[nyan.speech(I-I'm fine! T-Thanks for asking,)] Nyan bursts out, interrupting you in her haste to answer.
 		 [nyan.speech(I-I can show you the stockroom again if y-you'd like! F-Follow me!)]
 	</p>
 	<p>
@@ -72,11 +72,11 @@
 		 Wringing her hands and staring at her feet, something has quite clearly got her more worked up than usual, and you notice that she jumps a little as she sees you approach.
 	</p>
 	<p>
-		[pc.speech(What's wrong Nyan?)]
+		[pc.speech(What's wrong, Nyan?)]
 		 you ask.
 	</p>
 	<p>
-		[nyan.speech(O-Oh... well um...)] she says haltingly, [nyan.speech(Do y-you remember when w-we...you know...)] she blushes fiercely and says in a very quiet voice, [nyan.speech(Had s-sex...?)]
+		[nyan.speech(O-Oh... well um...)] she says haltingly. [nyan.speech(Do y-you remember when w-we...you know...)] She blushes fiercely and says in a very quiet voice, [nyan.speech(Had s-sex...?)]
 	</p>
 	<p>
 		You smile at the memory and nod.
@@ -88,15 +88,15 @@
 	<p>
 		After her outburst, she just stands there; eyes scrunched closed, trembling hands clenching her skirt, she seems to be waiting for an admonishment.
 		 Stepping forwards, you sweep her into your arms, wishing that you'd been able to record the surprised squeak that bursts out of her mouth.
-		 She blinks in surprise as you hold her close, before pulling back a little and staring at you with open mouthed shock,
+		 She blinks in surprise as you hold her close, before pulling back a little and staring at you with open-mouthed shock.
 		 [nyan.speech(W-W-What? You're not a-angry?)]
 	</p>
 	<p>
-		You hold her at arm's length for a moment, smiling as you shake your head,
+		You hold her at arm's length for a moment, smiling as you shake your head.
 		 [pc.speech(Why would I be angry? This is great news!)]
 	</p>
 	<p>
-		A visible tension seems to melt from her entire being as the nervous cat-girl cutely smiles back and snuggles into your [pc.arms],
+		A visible tension seems to melt from her entire being as the nervous cat-girl cutely smiles back and snuggles into your [pc.arms].
 		 [nyan.speech(W-Will you come b-by and visit from time to t-time?)]
 	</p>
 	<p>
@@ -115,7 +115,7 @@
 	</p>
 	<p>
 		Nyan's heels clatter across the laminate flooring as she hurries to retrieve a notepad that she uses to track what's currently in stock.
-		 Rushing back over to you, she fumbles with the little pad and almost drops it on the floor,
+		 Rushing back over to you, she fumbles with the little pad and almost drops it on the floor.
 		 [nyan.speech(A-Ah! S-Sorry, I don't usually interact with customers, s-so sorry if I'm a little unprofessional... A-Anyway, let me know what you'd like t-to see, and I'll show y-you what I've got in stock!)]
 	</p>
 	<p>
@@ -151,12 +151,12 @@
 	</p>
 	<p>
 		[nyan.speech(Ah! W-Well, erm, you see, ah, I-I used to, but then they said they wouldn't be offering any, a-and they'd already driven the others away, s-so I can't really get anything like that anymore,)]
-		 Nyan blurts out, tripping over her own words in her haste to offer an explanation,
-		  [nyan.speech(s-so I'm really sorry, b-but no...)]
+		 Nyan blurts out, tripping over her own words in her haste to offer an explanation.
+		  [nyan.speech(S-So I'm really sorry, b-but no...)]
 	</p>
 	<p>
 		[pc.speech(Slow down, Nyan,)]
-		 you say, trying to calm her down,
+		 you say, trying to calm her down.
 		 [pc.speech(I don't fully understand.
 		  Who are 'they', and who are these others that they drove away?)]
 	</p>
@@ -166,7 +166,7 @@
 		 As you stand there in silence, you take a moment to think about how miraculous it is, considering her extreme nervousness, for Nyan to have risen to the position of owning her own store.
 	</p>
 	<p>
-		After a minute or two, the cat-girl's breathing has slowed to a regular rate, and she opens her eyes and smiles,
+		After a minute or two, the cat-girl's breathing has slowed to a regular rate, and she opens her eyes and smiles.
 		 [nyan.speech(Sorry about that... I can get a little overwhelmed sometimes, and I have to perform those breathing exercises to avoid having a panic attack... I should be alright now...)]
 	</p>
 	<p>
@@ -180,13 +180,13 @@
 		 I used to stock enchanted clothing, you see, but all of the good suppliers were driven out of business by this new pair...)]
 	</p>
 	<p>
-		Nyan lets out a distressed sigh, and you can tell that the composure she gained from performing her breathing exercises is quickly starting to waver,
+		Nyan lets out a distressed sigh, and you can tell that the composure she gained from performing her breathing exercises is quickly starting to waver.
 		 [nyan.speech(I-It wasn't due to fair c-competition either; they i-intimidated and threatened everyone into l-leaving, and now, ah, I-I have no choice b-but to use them!
 		 I-I tried complaining to the enforcers, b-but t-they said the other s-suppliers were refusing t-to cooperate!
 		 I know they were threatened into s-silence! I-It's not fair!)]
 	</p>
 	<p>
-		Sensing that Nyan is on the verge of a panic attack, you decide that it would be best to drop the subject for the moment,
+		Sensing that Nyan is on the verge of a panic attack, you decide that it would be best to drop the subject for the moment.
 		 [pc.speech(Thank you for telling me about it, Nyan, but we should carry on looking at the clothing you've got in here, ok?)]
 	</p>
 	<p>
@@ -201,14 +201,14 @@
 		 Just as you'd hoped, the subject is one that she's very comfortable talking about, and after a little while she stops stuttering and begins to offer some clothing-related trivia of her own volition.
 	</p>
 	<p>
-		Eventually you decide that the time is right, and turn towards the nervous cat-girl with a disarming smile on your face,
+		Eventually you decide that the time is right, and turn towards the nervous cat-girl with a disarming smile on your face.
 		 [pc.speech(I was thinking about that problem with those suppliers that you were telling me about before.
 		  If you could tell me where these suppliers are, I'd be willing to go and talk to them on your behalf.
 		  I'm sure that I could convince them to let the others return.)]
 	</p>
 	<p>
 		[nyan.speech(Really? Y-You'd do that for me?)]
-		 Nyan replies, the steady tone that she'd been speaking in while talking about clothing instantly starting to give way to her nervousness again,
+		 Nyan replies, the steady tone that she'd been speaking in while talking about clothing instantly starting to give way to her nervousness again.
 		 [nyan.speech(I-I could o-offer a reward if you could convince them t-to let the others back. I-I could give you f-five thousand flames, a-and a discount on s-shopping here!)]
 	</p>
 	<p>
@@ -229,7 +229,7 @@
 	</p>
 	<p>
 		[nyan.speech(Mhmm,)]
-		 Nyan mumbles, blushing a little as she looks to the floor,
+		 Nyan mumbles, blushing a little as she looks to the floor.
 		 [nyan.speech(T-Thank you, [pc.name]... Y-You're so... k-kind...)]
 	</p>
 	]]>
@@ -237,12 +237,12 @@
 	
 	<htmlContent tag="NYAN_REPORT_BACK"><![CDATA[
 	<p>
-		Deciding that now's as good a time as any to report your success with the supplier problem, you turn to Nyan,
+		Deciding that now's as good a time as any to report your success with the supplier problem, you turn to Nyan.
 		 [pc.speech(I sorted out that problem with the suppliers for you.
 		 Wolfgang and Karl have agreed to let the other suppliers back, so you'll be able to stock enchanted clothing again.)]
 	</p>
 	<p>
-		An excited little squeak bursts out from between Nyan's lips, causing her to instinctively clasp her paw-like hands over her mouth,
+		An excited little squeak bursts out from between Nyan's lips, causing her to instinctively clasp her paw-like hands over her mouth.
 		 [nyan.speech(Eep! T-Thank you s-so much, [pc.name]!)]
 	</p>
 	<p>
@@ -257,23 +257,23 @@
 		 Perhaps once all this supplier business is taken care of, you could try to get to know her a little better.
 	</p>
 	<p>
-		Any further thoughts on the matter are interrupted, as Nyan suddenly returns, rushing up to you and thrusting a little wad of cash into your [pc.hands],
+		Any further thoughts on the matter are interrupted, as Nyan suddenly returns, rushing up to you and thrusting a little wad of cash into your [pc.hands].
 		 [nyan.speech(P-Please take this!)]
-		 she squeaks, before stepping back,
+		 she squeaks, before stepping back.
 		 [nyan.speech(A-And I c-can give y-you a t-twenty-five percent d-discount too!)]
 	</p>
 	<p>
 		[pc.speech(Thank you, Nyan,)]
-		 you reply, smiling,
+		 you reply, smiling.
 		 [pc.speech(I'm just happy to have helped!)]
 	</p>
 	<p>
 		[nyan.speech(I-I really a-appreciate it, [pc.name],)]
-		 Nyan stammers, looking at the ground,
+		 Nyan stammers, looking at the ground.
 		 [nyan.speech(I-I d-don't have a-a [pc.girlfriend] o-or anything...)]
 	</p>
 	<p>
-		This revelation comes out of nowhere, and as you prepare to respond, Nyan suddenly realises what she just said,
+		This revelation comes out of nowhere, and as you prepare to respond, Nyan suddenly realises what she just said.
 		 [nyan.speech(Eep! I-I mean, n-no, I-I meant that I-I don't have a-anyone I could have a-asked to help! I-I didn't mean, that is, I-I wasn't asking y-you, n-not that I w-wouldn't, b-but, aaaaaah!)]
 	</p>
 	<p>

--- a/res/txt/places/dominion/shoppingArcade/dreamLover.xml
+++ b/res/txt/places/dominion/shoppingArcade/dreamLover.xml
@@ -154,7 +154,7 @@
 	</p>
 	<p>
 		[Ashley.speech(It's like nobody cares for anybody but themselves. My good intentions went down the drain!)]
-		 they exclaim, slamming a fist down on the counter,
+		 they exclaim, slamming a fist down on the counter.
 		[Ashley.speech(So yeah, that's what's up with my 'attitude'. I just want to see my products be appreciated, but no! Well, if my customers don't care, then I won't either!)]
 	</p>
 	<p>

--- a/res/txt/places/dominion/shoppingArcade/suppliersDepot.xml
+++ b/res/txt/places/dominion/shoppingArcade/suppliersDepot.xml
@@ -112,7 +112,7 @@
 	
 	<htmlContent tag="RECEPTION_POPULATED_STAFF_DOOR_UNLOCKING"><![CDATA[
 	<p>
-		Wanting to pay [wolfgang.name] another visit, you approach the mouse-girl receptionist,
+		Wanting to pay [wolfgang.name] another visit, you approach the mouse-girl receptionist.
 		 [pc.speech(Hello, I was wondering if it would be possible to see [wolfgang.name].)]
 	</p>
 	<p>
@@ -203,8 +203,8 @@
 	</p>
 	<p>
 		Once again you find yourself standing before the pair of black-and-brown-furred greater dobermann-morphs, who both instantly push their chairs back and jump to their feet as you enter.
-		 [wolfgang.Name] smirks as he sees that it's you,
-		 [wolfgang.speech(Hello again [pc.name], what can we do for you this time?)]
+		 [wolfgang.Name] smirks as he sees that it's you.
+		 [wolfgang.speech(Hello again, [pc.name], what can we do for you this time?)]
 	</p>
 	]]>
 	</htmlContent>
@@ -228,7 +228,7 @@
 	</p>
 	<p>
 		[pc.speech(That attitude isn't going to get you far with me,)]
-		 you say, matching the dobermann's gaze as you step forwards,
+		 you say, matching the dobermann's gaze as you step forwards.
 		 [pc.speech(I assume you're Wolfgang?)]
 	</p>
 	<p>
@@ -318,17 +318,17 @@
 	</p>
 	<p>
 		[wolfgang.speech(Hah!)]
-		 Wolfgang exclaims,
+		 Wolfgang exclaims.
 		 [wolfgang.speech(And here I was getting worried that you had something on us!)]
 	</p>
 	<p>
 		[karl.speech(This has all been a huge waste of our time,)]
-		 Karl growls from the other side of the room,
+		 Karl growls from the other side of the room.
 		 [karl.speech(I want to know what you're going to offer us as compensation.)]
 	</p>
 	<p>
 		[wolfgang.speech(Good point Karl,)]
-		 Wolfgang snarls,
+		 Wolfgang snarls.
 		 [wolfgang.speech(I think five-hundred flames ought to do the trick. Or maybe you'd like to pay another way...)]
 	</p>
 	<p>
@@ -353,17 +353,17 @@
 	</p>
 	<p>
 		[wolfgang.speech(Hah!)]
-		 Wolfgang exclaims,
+		 Wolfgang exclaims.
 		 [wolfgang.speech(And here I was getting worried that you'd found some dirt on us!)]
 	</p>
 	<p>
 		[karl.speech(Yet again, this has all been a huge waste of our time,)]
-		 Karl growls from the other side of the room,
+		 Karl growls from the other side of the room.
 		 [karl.speech(I want to know what you're going to offer us as compensation.)]
 	</p>
 	<p>
 		[wolfgang.speech(Good point Karl,)]
-		 Wolfgang snarls,
+		 Wolfgang snarls.
 		 [wolfgang.speech(I think five-hundred flames ought to do the trick. Or maybe you'd like to pay another way...)]
 	</p>
 	<p>
@@ -374,7 +374,7 @@
 	
 	<htmlContent tag="OFFICE_PAID_OFF"><![CDATA[
 	<p>
-		Not wanting to get into a fight, and definitely not willing to offer your body to these thugs, you hand over five-hundred flames to Wolfgang,
+		Not wanting to get into a fight, and definitely not willing to offer your body to these thugs, you hand over five-hundred flames to Wolfgang.
 		 [pc.speech(There you go. I'll be leaving now.)]
 	</p>
 	<p>
@@ -388,18 +388,18 @@
 	
 	<htmlContent tag="OFFICE_ENFORCER_BLUFF"><![CDATA[
 	<p>
-		Deciding to make the most of the fact that Wolfgang has mistaken you for an Enforcer, you put on your most serious look as you stare him down,
+		Deciding to make the most of the fact that Wolfgang has mistaken you for an Enforcer, you put on your most serious look as you stare him down.
 		 [pc.speech(Did you really think you'd get away with openly intimidating and threatening the other suppliers?
 		 We couldn't act before due to a lack of witnesses who were willing to testify against you, but that's changed.)]
 	</p>
 	<p>
 		[wolfgang.speech(Bullshit!)]
-		 Wolfgang aggressively snaps, but as he speaks, you detect the faint hint of worry in his voice,
+		 Wolfgang aggressively snaps, but as he speaks, you detect the faint hint of worry in his voice.
 		 [wolfgang.speech(If you had anything on us, there'd be a lot more of you, and we'd be in cuffs already!)]
 	</p>
 	<p>
-		[pc.speech(That's very observant of you, but I'm afraid you've come to the wrong conclusion,)]
-		 you grin, encouraged to continue with your bluff by the slight wavering in Wolfgang's voice,
+		[pc.speech(That's very observant of you, but I'm afraid you've come to the wrong conclusion.)]
+		 You grin, encouraged to continue with your bluff by the slight wavering in Wolfgang's voice.
 		 [pc.speech(I'm alone because we thought it would work out better for everyone if I came to offer you a deal.
 		 In exchange for not arresting you both, you're going to agree to let the other suppliers move back in.
 		 We Enforcers don't have a problem with you two continuing to work out of here, but one more report about intimidation, blackmail, or assault, and you two can live out the rest of your days as slaves.
@@ -407,7 +407,7 @@
 	</p>
 	<p>
 		Despite their best efforts to maintain their composure, there's a noticeable look of worry in both of the dobermanns' eyes.
-		 It's obvious that they're guilty, and the threat of enslavement, combined with the offer of an easy way out, seems to be just enough to convince these thugs to give up,
+		 It's obvious that they're guilty, and the threat of enslavement, combined with the offer of an easy way out, seems to be just enough to convince these thugs to give up.
 		 [wolfgang.speech(So we just need to let the other suppliers back, and all this goes away?)]
 	</p>
 	<p>
@@ -421,8 +421,8 @@
 		 We'll let the other suppliers back, but this isn't an admission of guilt!)]
 	</p>
 	<p>
-		[pc.speech(Of course,)]
-		 you smile, thrilled that your bluff worked so perfectly,
+		[pc.speech(Of course.)]
+		 You smile, thrilled that your bluff worked so perfectly.
 		 [pc.speech(We Enforcers don't have much time on our hands these days, so as part of this deal, you two are going to contact the other suppliers, apologise to them, and tell them they can come back.)]
 	</p>
 	<p>
@@ -440,7 +440,7 @@
 	
 	<htmlContent tag="OFFICE_OFFER_BODY"><![CDATA[
 	<p>
-		Wanting to avoid a fight, and unwilling to hand over any of your money, you bite your [pc.lip] and allow your gaze to roam up and down over Wolfgang's powerful, muscular body,
+		Wanting to avoid a fight, and unwilling to hand over any of your money, you bite your [pc.lip] and allow your gaze to roam up and down over Wolfgang's powerful, muscular body.
 		 [pc.speech(I'm sure we can work something out...)]
 	</p>
 	<p>
@@ -468,7 +468,7 @@
 	
 	<htmlContent tag="OFFICE_ENFORCER_THANKS"><![CDATA[
 	<p>
-		Feeling more than a little turned-on at the thought of being fucked while wearing an Enforcer's uniform, you bite your [pc.lip] and allow your gaze to roam up and down over Wolfgang's powerful, muscular body,
+		Feeling more than a little turned-on at the thought of being fucked while wearing an Enforcer's uniform, you bite your [pc.lip] and allow your gaze to roam up and down over Wolfgang's powerful, muscular body.
 		 [pc.speech(Well, this all went a lot smoother than I was expecting. How about I show you boys how thankful I am for your cooperation...)]
 	</p>
 	<p>
@@ -482,7 +482,7 @@
 	</p>
 	<p>
 		[wolfgang.speech(That's fine with me,)]
-		 Wolfgang replies, stepping back a little and allowing Karl to push you down onto all-fours,
+		 Wolfgang replies, stepping back a little and allowing Karl to push you down onto all-fours.
 		 [wolfgang.speech(I wonder if [pc.she]'s going to be as tight as the last one...)]
 	</p>
 	<p>
@@ -527,7 +527,7 @@
 	<htmlContent tag="OFFICE_VICTORY_FUCK_THEM"><![CDATA[
 	<p>
 		The sight of these two dobermanns collapsed down before you is too much for you to resist.
-		 Deciding to have some fun, you step forwards, grinning,
+		 Deciding to have some fun, you step forwards, grinning.
 		 [pc.speech(Alright boys, unless you want to keep on fighting, you're going to get down on all fours and present yourselves to me!)]
 	</p>
 	<p>
@@ -536,7 +536,7 @@
 		 As they do this, the power of your arcane aura starts to overwhelm their initial reluctance, and by the time they're fully in position, you hear their concerned groans quickly turn into lewd panting.
 	</p>
 	<p>
-		Dropping down onto your knees behind them, you reach forwards and grope their asses, grinning to yourself as they respond by letting out a desperate whine,
+		Dropping down onto your knees behind them, you reach forwards and grope their asses, grinning to yourself as they respond by letting out a desperate whine.
 		 [pc.speech(Good boys! It's time to have some fun!)]
 	</p>
 	]]>
@@ -545,7 +545,7 @@
 	<htmlContent tag="OFFICE_VICTORY_SUB_FUCKED"><![CDATA[
 	<p>
 		The sight of these two dobermanns collapsed down before you is too much for you to resist.
-		 Deciding to have some fun, you step forwards, grinning,
+		 Deciding to have some fun, you step forwards, grinning.
 		 [pc.speech(Alright boys, seeing as you've both been so good and agreed to do as you're told, I think you deserve a little reward!)]
 	</p>
 	<p>
@@ -559,8 +559,8 @@
 	</p>
 	<p>
 		[wolfgang.speech(That's fine with me,)]
-		 Wolfgang replies, following his partner's lead as he shuffles forwards on his knees to position himself behind you,
-		 [wolfgang.speech(this is a pleasant surprise...)]
+		 Wolfgang replies, following his partner's lead as he shuffles forwards on his knees to position himself behind you.
+		 [wolfgang.speech(This is a pleasant surprise...)]
 	</p>
 	<p>
 		You look back and gasp as Wolfgang grabs hold of your [pc.hips+] and roughly pulls you into his groin.
@@ -572,7 +572,7 @@
 	</p>
 	<p>
 		[pc.speech(Good boys!)]
-		 you cry,
+		 you cry.
 		 [pc.speech(Don't hold back from having your fun now!)]
 	</p>
 	]]>
@@ -580,7 +580,7 @@
 	
 	<htmlContent tag="OFFICE_DEFEAT"><![CDATA[
 	<p>
-		Unable to continue fighting, you stagger back and collapse down onto a very shabby sofa,
+		Unable to continue fighting, you stagger back and collapse down onto a very shabby sofa.
 		 [pc.speech(No more! I-I can't go on!)]
 	</p>
 	<p>
@@ -603,7 +603,7 @@
 	
 	<htmlContent tag="OFFICE_PACIFIED_FUCK_THEM"><![CDATA[
 	<p>
-		The sight of the two big, strong dobermanns is too much for you to resist, and you feel your dominant side taking control as you step forwards, grinning,
+		The sight of the two big, strong dobermanns is too much for you to resist, and you feel your dominant side taking control as you step forwards, grinning.
 		 [pc.speech(I'm here to make sure that you boys are behaving. We wouldn't want there to be any trouble kicking off because of you two, now, would we?
 		 I think that , you're going to get down on all fours and present yourselves to me!)]
 	</p>
@@ -621,7 +621,7 @@
 		 As they do this, the power of your arcane aura starts to overwhelm their initial reluctance, and by the time they're fully in position, you hear their concerned groans quickly turn into lewd panting.
 	</p>
 	<p>
-		Dropping down onto your knees behind them, you reach forwards and grope their asses, grinning to yourself as they respond by letting out a desperate whine,
+		Dropping down onto your knees behind them, you reach forwards and grope their asses, grinning to yourself as they respond by letting out a desperate whine.
 		 [pc.speech(Good boys! It's time to have some fun!)]
 	</p>
 	]]>
@@ -629,11 +629,11 @@
 	
 	<htmlContent tag="OFFICE_PACIFIED_SUB_FUCKED"><![CDATA[
 	<p>
-		The sight of the two big, strong dobermanns is too much for you to resist, and you step forwards, grinning,
+		The sight of the two big, strong dobermanns is too much for you to resist, and you step forwards, grinning.
 		 [pc.speech(Alright boys, seeing as you've both been so good recently, I think you deserve a little reward!)]
 	</p>
 	<p>
-		Wolfgang and Karl both let out a hungry growl, grinning as you step forwards and drop down onto all fours before them,
+		Wolfgang and Karl both let out a hungry growl, grinning as you step forwards and drop down onto all fours before them.
 		 [pc.speech(I'll let you both decide which of you gets my mouth, and which of you gets to fuck me.)]
 	</p>
 	<p>
@@ -642,7 +642,7 @@
 	</p>
 	<p>
 		[wolfgang.speech(That's fine with me,)]
-		 Wolfgang replies, dropping to his knees to position himself behind you,
+		 Wolfgang replies, dropping to his knees to position himself behind you.
 		 [wolfgang.speech(this is a pleasant surprise...)]
 	</p>
 	<p>
@@ -655,7 +655,7 @@
 	</p>
 	<p>
 		[pc.speech(Good boys!)]
-		 you cry,
+		 you cry.
 		 [pc.speech(Don't hold back from having your fun now!)]
 	</p>
 	]]>
@@ -669,7 +669,7 @@
 	</p>
 	<p>
 		[wolfgang.speech(No, everything's fine here,)]
-		 Wolfgang responds,
+		 Wolfgang responds.
 		 [wolfgang.speech(We decided to drop the whole clothing supply thing, and just focus on security instead.
 		 It's a lot more fun this way...)]
 	</p><p>
@@ -681,11 +681,11 @@
 	
 	<htmlContent tag="AFTER_SEX_WILLING"><![CDATA[
 	<p>
-		Wolfgang steps back, sinking down onto a nearby sofa as he grins,
+		Wolfgang steps back, sinking down onto a nearby sofa as he grins.
 		 [wolfgang.speech(You're a good fuck, slut!)]
 	</p>
 	<p>
-		Karl likewise moves away from you, grabbing a bottle of Canine Crush and twisting off the cap as he grins,
+		Karl likewise moves away from you, grabbing a bottle of Canine Crush and twisting off the cap as he grins.
 		 [karl.speech(Come back any time you want another taste of my cock!)]
 	</p>
 	<p>
@@ -701,7 +701,7 @@
 	
 	<htmlContent tag="AFTER_SEX_WILLING_DOMMED_THEM"><![CDATA[
 	<p>
-		You step back, allowing Wolfgang and Karl to crawl away and collapse onto to a nearby sofa,
+		You step back, allowing Wolfgang and Karl to crawl away and collapse onto to a nearby sofa.
 		 [pc.speech(You two were pretty good fucks!)]
 	</p>
 	<p>
@@ -717,11 +717,11 @@
 	
 	<htmlContent tag="AFTER_SEX_WILLING_PACIFIED"><![CDATA[
 	<p>
-		Wolfgang steps back, sinking down onto a nearby sofa as he grins,
+		Wolfgang steps back, sinking down onto a nearby sofa as he grins.
 		 [wolfgang.speech(You're a good fuck, slut!)]
 	</p>
 	<p>
-		Karl likewise moves away from you, grabbing a bottle of Canine Crush and twisting off the cap as he grins,
+		Karl likewise moves away from you, grabbing a bottle of Canine Crush and twisting off the cap as he grins.
 		 [karl.speech(Come back any time you want another taste of my cock!)]
 	</p>
 	<p>
@@ -734,7 +734,7 @@
 	
 	<htmlContent tag="AFTER_SEX_WILLING_DOMMED_THEM_PACIFIED"><![CDATA[
 	<p>
-		You step back, allowing Wolfgang and Karl to crawl away and collapse onto to a nearby sofa,
+		You step back, allowing Wolfgang and Karl to crawl away and collapse onto to a nearby sofa.
 		 [pc.speech(Good boys! You two sure are good fucks!)]
 	</p>
 	<p>
@@ -747,11 +747,11 @@
 	
 	<htmlContent tag="AFTER_SEX_FUCKED"><![CDATA[
 	<p>
-		Wolfgang steps back, sinking down onto a nearby sofa as he grins,
+		Wolfgang steps back, sinking down onto a nearby sofa as he grins.
 		 [wolfgang.speech(You're a good fuck, slut!)]
 	</p>
 	<p>
-		Karl likewise moves away from you, grabbing a bottle of Canine Crush and twisting off the cap as he grins,
+		Karl likewise moves away from you, grabbing a bottle of Canine Crush and twisting off the cap as he grins.
 		 [karl.speech(Come back any time you want another taste of my cock!)]
 	</p>
 	<p>


### PR DESCRIPTION
Dialogue tags!
After looking it up, it seems the rules my old English teacher taught us still hold true. So, no commas for narration, dialogue tags that sit between two independent clauses end on a fullstop etc. [This thing](http://theeditorsblog.net/2010/12/08/punctuation-in-dialogue/) summarises it nicely.
The question is though what you constitute as a dialogue tag, people seem to argue about that. 
This is just my own opinion, but things like "he smiles" or "she frowns" are not tags, while "he laughs/growls/sighs" can be, depending on context. Like, you can laugh out words or growl them, but you can't smile a sentence. So anything that affects the words, the tone, intonation or pace, can be a tag. But it could also not be, if it is a separate action. That's just my two cents, there are enough people who are far stricter and just see "say", "ask" and their variations as dialogue tags.

I only went through the Nyan content, so this is what it would look like. Might have missed some stuff though, I'm a little rusty. Some cases are also ambiguous and would be correct either way. What are your thoughts on the matter?

Again, rules are all fine and dandy, but being consistent is most important. Nothing takes the reader easier out of the flow than jarring differences.

Ah, and in case you do decide to do it this way, lemme know. I can go through the rest of the game and quickly do the thing, so it doesn't look too jarring by being the only part with different punctuation.
Otherwise, just ignore it. Consistency above all else.