### PR TITLE
Fix inserted bimbo/sex/muffled/drunk words breaking capitalisation

### DIFF
--- a/src/com/lilithsthrone/utils/Util.java
+++ b/src/com/lilithsthrone/utils/Util.java
@@ -538,9 +538,9 @@ public class Util {
 	 * Determine whether a given string contains sentence-ending punctuation
 	 *
 	 * @param text
-	 * 						text to check whether
+	 *            text to check whether
 	 * @return
-	 * 						boolean, whether the text contains a period, exlamation or question mark
+	 *            boolean, whether the text contains a period, exlamation or question mark
 	 */
 	private static boolean isEndOfSentence(String text) {
 		return endOfSentence.matcher(text.substring(text.length()-1)).matches();
@@ -550,16 +550,16 @@ public class Util {
 	 * Inserts words randomly into a sentence.</br>
 	 *
 	 * @param sentence
-	 *						sentence to insert words into
+	 *            sentence to insert words into
 	 * @param frequency
-	 *						how often words are inserted. 1/frequency is the probability of inserting a word
+	 *            how often words are inserted. 1/frequency is the probability of inserting a word
 	 * @param inserts
-	 *						list of strings to insert into. These are appended to the end of words, so ensure
-	 *						any whitespace wanted is put before the insert. A space separates the next word
+	 *            list of strings to insert into. These are appended to the end of words, so ensure
+	 *            any whitespace wanted is put before the insert. A space separates the next word
 	 * @param middle
-	 *						boolean, whether to avoid inserting at the start/end of a sentence
+	 *            boolean, whether to avoid inserting at the start/end of a sentence
 	 * @return
-	 *						modified sentence
+	 *            modified sentence
 	 */
 	private static String insertIntoSentences(String sentence, int frequency, String[] inserts, boolean middle) {
 		splitSentence = sentence.split(" ");
@@ -616,12 +616,12 @@ public class Util {
 	 * Used in conjunction with addStutter(): "L-Like, How far is it t-to the, like, town hall?"
 	 *
 	 * @param sentence
-	 *						sentence to apply bimbo modifications
+	 *            sentence to apply bimbo modifications
 	 * @param frequency
-	 *						of bimbo interjections (i.e. 4 would be 1 in 4 words have a
-	 *						bimbo interjection)
+	 *            of bimbo interjections (i.e. 4 would be 1 in 4 words have a
+	 *            bimbo interjection)
 	 * @return
-	 *						modified sentence
+	 *            modified sentence
 	 */
 	public static String addBimbo(String sentence, int frequency) {
 		sentence = insertIntoSentences(sentence, frequency, bimboWords);
@@ -657,11 +657,11 @@ public class Util {
 	 * "How ~Mrph~ far is it ~Mmm~ to the town ~Mrph~ hall?"</br>
 	 *
 	 * @param sentence
-	 *						sentence to apply muffles
+	 *            sentence to apply muffles
 	 * @param frequency
-	 *						of muffled words (i.e. 4 would be 1 in 4 words are muffled)
+	 *            of muffled words (i.e. 4 would be 1 in 4 words are muffled)
 	 * @return
-	 *						modified sentence
+	 *            modified sentence
 	 */
 	public static String addMuffle(String sentence, int frequency) {
 		return insertIntoSentences(sentence, frequency, muffledSounds);
@@ -675,11 +675,11 @@ public class Util {
 	 * "How ~Aah!~ far is it ~Mmm!~ to the town ~Aah!~ hall?"</br>
 	 *
 	 * @param sentence
-	 *						sentence to apply sexy modifications
+	 *            sentence to apply sexy modifications
 	 * @param frequency
-	 *						of sex sounds (i.e. 4 would be 1 in 4 words are sexy)
+	 *            of sex sounds (i.e. 4 would be 1 in 4 words are sexy)
 	 * @return
-	 *						modified sentence
+	 *            modified sentence
 	 */
 	public static String addSexSounds(String sentence, int frequency) {
 		return insertIntoSentences(sentence, frequency, sexSounds);
@@ -693,11 +693,11 @@ public class Util {
 	 * "How ~Hic!~ far is it ~Hic!~ to the town ~Hic!~ hall?"</br>
 	 *
 	 * @param sentence
-	 *						sentence to apply sexy modifications
+	 *            sentence to apply sexy modifications
 	 * @param frequency
-	 *						of drunk sounds (i.e. 4 would be 1 in 4 words are drunk)
+	 *            of drunk sounds (i.e. 4 would be 1 in 4 words are drunk)
 	 * @return
-	 *						modified sentence
+	 *            modified sentence
 	 */
 	public static String addDrunkSlur(String sentence, int frequency) {
 		return insertIntoSentences(sentence, frequency, drunkSounds, false)

--- a/src/com/lilithsthrone/utils/Util.java
+++ b/src/com/lilithsthrone/utils/Util.java
@@ -562,23 +562,22 @@ public class Util {
 		for (int i = 0; i < wordsToBimbofy; i++) {
 			offset = random.nextInt(frequency);
 			offset = ((i * frequency + offset) >= splitSentence.length ? splitSentence.length - 1 : (i * frequency + offset));
-			if (offset != 0) {
-				// If previous word didn't end with punctuation:
-				if (splitSentence[offset - 1].charAt(splitSentence[offset - 1].length() - 1) != '.' && splitSentence[offset - 1].charAt(splitSentence[offset - 1].length() - 1) != '!'
-						&& splitSentence[offset - 1].charAt(splitSentence[offset - 1].length() - 1) != '?') {
-					// Add a comma to the end of the previous word:
-					if (splitSentence[offset - 1].charAt(splitSentence[offset - 1].length() - 1) != ',')
-						splitSentence[offset - 1] = splitSentence[offset - 1] + ",";
-					// Add the bimbo part to this word:
-					splitSentence[offset] = bimboWords[random.nextInt(bimboWords.length)] + splitSentence[offset];
-				} else {
-					// Previous word ended with punctuation, so the bimbo word needs to be capitalised:
-					splitSentence[offset] = capitaliseSentence(bimboWords[random.nextInt(bimboWords.length)]) + splitSentence[offset];
-				}
-			} else {
-				// This is the first word in the sentence, so capitalise the bimbo part of it:
-				splitSentence[offset] = capitaliseSentence(bimboWords[random.nextInt(bimboWords.length)]) + splitSentence[offset];
+			char prev = splitSentence[offset - 1].charAt(-1);
+
+			// Add a comma if the last word wasn't wasn't punctuation
+			if (".!?,".indexOf(prev) < 0) {
+				splitSentence[offset - 1] = splitSentence[offset - 1] + ",";
 			}
+
+			// Decapitalise the current word if it was originally the start of a sentence and isn't all caps
+			if (offset == 0 || offset > 0 && ".!?".indexOf(splitSentence[offset -1]) >= 0
+					&& splitSentence[offset] != splitSentence[offset].toUpperCase()) {
+				splitSentence[offset] = splitSentence[offset].toLowerCase();
+			}
+
+			// Add the bimbo part to this word, capitalise if at the beginning of string or a sentence
+			String word = bimboWords[random.nextInt(bimboWords.length)];
+			splitSentence[offset] = ((offset == 0 || ".!?".indexOf(prev) >= 0) ? capitaliseSentence(word) : word) + splitSentence[offset];
 
 			// for(int j=0; j<frequency && ((i*frequency
 			// +j)<splitSentence.length);j++)

--- a/src/com/lilithsthrone/utils/Util.java
+++ b/src/com/lilithsthrone/utils/Util.java
@@ -532,82 +532,6 @@ public class Util {
 		return utilitiesStringBuilder.toString();
 	}
 
-	private static String[] bimboWords = new String[] { "like, ", "like, ", "like, ", "um, ", "uh, ", "ah, " };
-	/**
-	 * Turns a normal sentence into the kind of thing a Bimbo would come out with.
-	 * Can be safely used in conjunction with addStutter.
-	 * If using addStutter after using addBimbo, bimbo words can also become stuttered.</br>
-	 * Example: "How far is it to the town hall?"</br>
-	 * "How, like, far is it to the town, uh, hall and stuff?"</br>
-	 * "How far is, like, it to the, um, town hall and stuff?"</br>
-	 * "Like, How far is it to the, like, town hall?"</br>
-	 * Used in conjunction with addStutter(): "L-Like, How far is it t-to the, like, town hall?"
-	 * 
-	 * @param sentence
-	 *            sentence to apply bimbo modifications
-	 * @param frequency
-	 *            of bimbo interjections (i.e. 4 would be 1 in 4 words have a
-	 *            bimbo interjection)
-	 * @return
-	 *            modified sentence
-	 */
-	public static String addBimbo(String sentence, int frequency) {
-		splitSentence = sentence.split(" ");
-		utilitiesStringBuilder.setLength(0);
-
-		// 1 in "frequency" words are bimbo interjections, with a minimum of 1.
-		int wordsToBimbofy = splitSentence.length / frequency + 1;
-
-		int offset = 0;
-		for (int i = 0; i < wordsToBimbofy; i++) {
-			offset = random.nextInt(frequency);
-			offset = ((i * frequency + offset) >= splitSentence.length ? splitSentence.length - 1 : (i * frequency + offset));
-			char prev = splitSentence[offset - 1].charAt(splitSentence[offset - 1].length() - 1);
-
-			// Add a comma if the last word wasn't wasn't punctuation
-			if (".!?,".indexOf(prev) < 0) {
-				splitSentence[offset - 1] = splitSentence[offset - 1] + ",";
-			}
-
-			// Decapitalise the current word if it was originally the start of a sentence
-			if (".!?".indexOf(prev) >= 0 && offset < splitSentence.length
-					&& splitSentence[offset] != splitSentence[offset].toUpperCase()) {
-				splitSentence[offset] = splitSentence[offset].toLowerCase();
-			}
-
-			// Add the bimbo part to this word, capitalise if at the beginning of string or a sentence
-			String word = bimboWords[random.nextInt(bimboWords.length)];
-			splitSentence[offset] = ((offset == 0 || ".!?".indexOf(prev) >= 0) ? capitaliseSentence(word) : word) + splitSentence[offset];
-
-			// for(int j=0; j<frequency && ((i*frequency
-			// +j)<splitSentence.length);j++)
-			// sb.append(splitSentence[i*frequency +j]+" ");
-		}
-		for (String word : splitSentence)
-			utilitiesStringBuilder.append(word + " ");
-		utilitiesStringBuilder.deleteCharAt(utilitiesStringBuilder.length() - 1);
-
-		// 1/3 chance of having a bimbo sentence ending:
-		if(!sentence.endsWith("~") && !sentence.endsWith("-")) {
-			switch (random.nextInt(6)) {
-				case 0:
-					char end = utilitiesStringBuilder.charAt(utilitiesStringBuilder.length() - 1);
-					utilitiesStringBuilder.deleteCharAt(utilitiesStringBuilder.length() - 1);
-					utilitiesStringBuilder.append(" and stuff");
-					utilitiesStringBuilder.append(end);
-					break;
-				case 1:
-					utilitiesStringBuilder.deleteCharAt(utilitiesStringBuilder.length() - 1);
-					utilitiesStringBuilder.append(", y'know?");
-					break;
-				default:
-					break;
-			}
-		}
-
-		return utilitiesStringBuilder.toString();
-	}
-
 	/**
 	 * Inserts words randomly into a sentence.</br>
 	 * 
@@ -648,6 +572,51 @@ public class Util {
 
 		return utilitiesStringBuilder.toString();
   }
+
+	private static String[] bimboWords = new String[] { "like, ", "like, ", "like, ", "um, ", "uh, ", "ah, " };
+	/**
+	 * Turns a normal sentence into the kind of thing a Bimbo would come out with.
+	 * Can be safely used in conjunction with addStutter.
+	 * If using addStutter after using addBimbo, bimbo words can also become stuttered.</br>
+	 * Example: "How far is it to the town hall?"</br>
+	 * "How, like, far is it to the town, uh, hall and stuff?"</br>
+	 * "How far is, like, it to the, um, town hall and stuff?"</br>
+	 * "Like, How far is it to the, like, town hall?"</br>
+	 * Used in conjunction with addStutter(): "L-Like, How far is it t-to the, like, town hall?"
+	 * 
+	 * @param sentence
+	 *            sentence to apply bimbo modifications
+	 * @param frequency
+	 *            of bimbo interjections (i.e. 4 would be 1 in 4 words have a
+	 *            bimbo interjection)
+	 * @return
+	 *            modified sentence
+	 */
+	public static String addBimbo(String sentence, int frequency) {
+		sentence = insertIntoSentence(sentence, frequency, bimboWords);
+		utilitiesStringBuilder.setLength(0);
+		utilitiesStringBuilder.append(sentence);
+
+		// 1/3 chance of having a bimbo sentence ending:
+		if(!sentence.endsWith("~") && !sentence.endsWith("-")) {
+			switch (random.nextInt(6)) {
+				case 0:
+					char end = utilitiesStringBuilder.charAt(utilitiesStringBuilder.length() - 1);
+					utilitiesStringBuilder.deleteCharAt(utilitiesStringBuilder.length() - 1);
+					utilitiesStringBuilder.append(" and stuff");
+					utilitiesStringBuilder.append(end);
+					break;
+				case 1:
+					utilitiesStringBuilder.deleteCharAt(utilitiesStringBuilder.length() - 1);
+					utilitiesStringBuilder.append(", y'know?");
+					break;
+				default:
+					break;
+			}
+		}
+
+		return utilitiesStringBuilder.toString();
+	}
 
 	private static String[] muffledSounds = new String[] { "~Mrph~ ", "~Mmm~ ", "~Mrmm~ " };
 	/**

--- a/src/com/lilithsthrone/utils/Util.java
+++ b/src/com/lilithsthrone/utils/Util.java
@@ -562,15 +562,15 @@ public class Util {
 		for (int i = 0; i < wordsToBimbofy; i++) {
 			offset = random.nextInt(frequency);
 			offset = ((i * frequency + offset) >= splitSentence.length ? splitSentence.length - 1 : (i * frequency + offset));
-			char prev = splitSentence[offset - 1].charAt(-1);
+			char prev = splitSentence[offset - 1].charAt(splitSentence[offset - 1].length() - 1);
 
 			// Add a comma if the last word wasn't wasn't punctuation
 			if (".!?,".indexOf(prev) < 0) {
 				splitSentence[offset - 1] = splitSentence[offset - 1] + ",";
 			}
 
-			// Decapitalise the current word if it was originally the start of a sentence and isn't all caps
-			if (offset == 0 || offset > 0 && ".!?".indexOf(splitSentence[offset -1]) >= 0
+			// Decapitalise the current word if it was originally the start of a sentence
+			if (".!?".indexOf(prev) >= 0 && offset < splitSentence.length
 					&& splitSentence[offset] != splitSentence[offset].toUpperCase()) {
 				splitSentence[offset] = splitSentence[offset].toLowerCase();
 			}
@@ -608,6 +608,47 @@ public class Util {
 		return utilitiesStringBuilder.toString();
 	}
 
+	/**
+	 * Inserts words randomly into a sentence.</br>
+	 * 
+	 * @param sentence
+	 *            sentence to insert words into
+	 * @param frequency
+	 *            how often words are inserted. 1/frequency is the probability of inserting a word
+   * @param inserts
+   *            list of strings to insert into
+	 * @return
+	 *            modified sentence
+	 */
+  private static String insertIntoSentence(String sentence, int frequency, String[] inserts) {
+		splitSentence = sentence.split(" ");
+		utilitiesStringBuilder.setLength(0);
+
+		// 1 in "frequency" words are muffled interjections, with a minimum of 1.
+		int wordsToInsert = splitSentence.length / frequency + 1;
+
+		int offset = 0;
+		for (int i = 0; i < wordsToInsert; i++) {
+			offset = random.nextInt(frequency);
+			offset = ((i * frequency + offset) >= splitSentence.length ? splitSentence.length - 1 : (i * frequency + offset));
+
+			// Decapitalise the current word if it was originally the start of a sentence and isn't all caps
+			if (offset == 0 || offset > 0 && ".!?".indexOf(splitSentence[offset -1]) >= 0
+					&& splitSentence[offset] != splitSentence[offset].toUpperCase()) {
+				splitSentence[offset] = splitSentence[offset].toLowerCase();
+			}
+			
+			// Add the insert to this word:
+			splitSentence[offset] = inserts[random.nextInt(inserts.length)] + splitSentence[offset];
+			
+		}
+		for (String word : splitSentence)
+			utilitiesStringBuilder.append(word + " ");
+		utilitiesStringBuilder.deleteCharAt(utilitiesStringBuilder.length() - 1);
+
+		return utilitiesStringBuilder.toString();
+  }
+
 	private static String[] muffledSounds = new String[] { "~Mrph~ ", "~Mmm~ ", "~Mrmm~ " };
 	/**
 	 * Turns a normal sentence into a muffled sentence.</br>
@@ -623,26 +664,7 @@ public class Util {
 	 *            modified sentence
 	 */
 	public static String addMuffle(String sentence, int frequency) {
-		splitSentence = sentence.split(" ");
-		utilitiesStringBuilder.setLength(0);
-
-		// 1 in "frequency" words are muffled interjections, with a minimum of 1.
-		int wordsToMuffle = splitSentence.length / frequency + 1;
-
-		int offset = 0;
-		for (int i = 0; i < wordsToMuffle; i++) {
-			offset = random.nextInt(frequency);
-			offset = ((i * frequency + offset) >= splitSentence.length ? splitSentence.length - 1 : (i * frequency + offset));
-			
-			// Add the muffled sound to this word:
-			splitSentence[offset] = muffledSounds[random.nextInt(muffledSounds.length)] + splitSentence[offset];
-			
-		}
-		for (String word : splitSentence)
-			utilitiesStringBuilder.append(word + " ");
-		utilitiesStringBuilder.deleteCharAt(utilitiesStringBuilder.length() - 1);
-
-		return utilitiesStringBuilder.toString();
+		return insertIntoSentence(sentence, frequency, muffledSounds);
 	}
 	
 	private static String[] sexSounds = new String[] { "~Aah!~ ", "~Mmm!~ " };
@@ -660,26 +682,7 @@ public class Util {
 	 *            modified sentence
 	 */
 	public static String addSexSounds(String sentence, int frequency) {
-		splitSentence = sentence.split(" ");
-		utilitiesStringBuilder.setLength(0);
-
-		// 1 in "frequency" words are sexy interjections, with a minimum of 1.
-		int wordsToMuffle = splitSentence.length / frequency + 1;
-
-		int offset = 0;
-		for (int i = 0; i < wordsToMuffle; i++) {
-			offset = random.nextInt(frequency);
-			offset = ((i * frequency + offset) >= splitSentence.length ? splitSentence.length - 1 : (i * frequency + offset));
-			
-			// Add the sexy sound to this word:
-			splitSentence[offset] = sexSounds[random.nextInt(sexSounds.length)] + splitSentence[offset];
-			
-		}
-		for (String word : splitSentence)
-			utilitiesStringBuilder.append(word + " ");
-		utilitiesStringBuilder.deleteCharAt(utilitiesStringBuilder.length() - 1);
-
-		return utilitiesStringBuilder.toString();
+		return insertIntoSentence(sentence, frequency, sexSounds);
 	}
 
 	private static String[] drunkSounds = new String[] { "~Hic!~ " };
@@ -697,27 +700,12 @@ public class Util {
 	 *            modified sentence
 	 */
 	public static String addDrunkSlur(String sentence, int frequency) {
-		splitSentence = sentence.split(" ");
-		utilitiesStringBuilder.setLength(0);
-
-		// 1 in "frequency" words are sexy interjections, with a minimum of 1.
-		int wordsToMuffle = splitSentence.length / frequency + 1;
-
-		int offset = 0;
-		for (int i = 0; i < wordsToMuffle; i++) {
-			offset = random.nextInt(frequency);
-			offset = ((i * frequency + offset) >= splitSentence.length ? splitSentence.length - 1 : (i * frequency + offset));
-			
-			// Add the sexy sound to this word:
-			splitSentence[offset] = drunkSounds[random.nextInt(drunkSounds.length)] + splitSentence[offset];
-			
-		}
-		for (String word : splitSentence) {
-			utilitiesStringBuilder.append(word + " ");
-		}
-		utilitiesStringBuilder.deleteCharAt(utilitiesStringBuilder.length() - 1);
-		
-		return utilitiesStringBuilder.toString().replaceAll("Hi ", "Heeey ").replaceAll("yes", "yesh").replaceAll("is", "ish").replaceAll("So", "Sho").replaceAll("so", "sho");
+		return insertIntoSentence(sentence, frequency, drunkSounds)
+			.replaceAll("Hi ", "Heeey ")
+			.replaceAll("yes", "yesh")
+			.replaceAll("is", "ish")
+			.replaceAll("So", "Sho")
+			.replaceAll("so", "sho");
 	}
 
 	/**


### PR DESCRIPTION
I simplified down some of the logic and added a single method `insertIntoSentence` that does most of the stuff that's repeated in those other methods.
When words are inserted at the beginning of sentences it now lowercases the following word that was originally the start of the sentence.
An edge case I'm not sure how to deal with is if sentences start with names or titles (like your nickname).

Edit: Maybe a simpler method to avoid unwanted decaps would be to avoid inserting into the start of a sentence entirely? If correcting caps is wanted, this seems like the only reasonable way to ensure correctness.