### PR TITLE
Saveable recipes for enchanting

### DIFF
--- a/src/com/lilithsthrone/controller/MainController.java
+++ b/src/com/lilithsthrone/controller/MainController.java
@@ -762,6 +762,17 @@ public class MainController implements Initializable {
 								}
 							}
 						}
+						if(Main.game.getCurrentDialogueNode() == EnchantmentDialogue.ENCHANTMENT_SAVE_LOAD){
+							if((boolean) Main.mainController.getWebEngine().executeScript("document.getElementById('new_save_name') === document.activeElement")) {
+								allowInput = false;
+								if (event.getCode() == KeyCode.ENTER) {
+									enterConsumed = true;
+									Main.mainController.getWebEngine().executeScript("document.getElementById('hiddenPField').innerHTML=document.getElementById('new_save_name').value;");
+									EnchantmentDialogue.saveEnchant(Main.mainController.getWebEngine().getDocument().getElementById("hiddenPField").getTextContent(), false);
+									Main.game.setContent(new Response("Save", "", Main.game.getCurrentDialogueNode()));
+								}
+							}
+						}
 						if(Main.game.getCurrentDialogueNode() == SlaveryManagementDialogue.SLAVE_MANAGEMENT_INSPECT
 								|| Main.game.getCurrentDialogueNode() == SlaveryManagementDialogue.SLAVE_MANAGEMENT_JOBS
 								|| Main.game.getCurrentDialogueNode() == SlaveryManagementDialogue.SLAVE_MANAGEMENT_PERMISSIONS){
@@ -5145,6 +5156,88 @@ public class MainController implements Initializable {
 						addEventListener(document, id, "mouseenter", el, false);
 					}
 				}
+			}
+		}
+		
+		// Save/load enchantment:
+		if (Main.game.getCurrentDialogueNode() == EnchantmentDialogue.ENCHANTMENT_SAVE_LOAD) {
+			for (File f : EnchantmentDialogue.getSavedEnchants()) {
+				id = "overwrite_saved_" + f.getName().substring(0, f.getName().lastIndexOf('.'));
+				if (((EventTarget) document.getElementById(id)) != null) {
+					((EventTarget) document.getElementById(id)).addEventListener("click", e -> {
+						
+						if(!Main.getProperties().overwriteWarning || EnchantmentDialogue.overwriteConfirmationName.equals(f.getName())) {
+							EnchantmentDialogue.overwriteConfirmationName = "";
+							EnchantmentDialogue.saveEnchant(f.getName().substring(0, f.getName().lastIndexOf('.')), true);
+						} else {
+							EnchantmentDialogue.overwriteConfirmationName = f.getName();
+							EnchantmentDialogue.loadConfirmationName = "";
+							EnchantmentDialogue.deleteConfirmationName = "";
+							Main.game.setContent(new Response("Save/Load", "Open the save/load game window.", EnchantmentDialogue.ENCHANTMENT_MENU));
+						}
+						
+					}, false);
+
+					addEventListener(document, id, "mousemove", moveTooltipListener, false);
+					addEventListener(document, id, "mouseleave", hideTooltipListener, false);
+					TooltipInformationEventListener el2 = new TooltipInformationEventListener().setInformation("Overwrite", "");
+					addEventListener(document, id, "mouseenter", el2, false);
+				}
+				id = "load_saved_" + f.getName().substring(0, f.getName().lastIndexOf('.'));
+				if (((EventTarget) document.getElementById(id)) != null) {
+					((EventTarget) document.getElementById(id)).addEventListener("click", e -> {
+						
+						if(!Main.getProperties().overwriteWarning || EnchantmentDialogue.loadConfirmationName.equals(f.getName())) {
+							EnchantmentDialogue.loadConfirmationName = "";
+							EnchantmentDialogue.loadEnchant(f.getName().substring(0, f.getName().lastIndexOf('.')));
+						} else {
+							EnchantmentDialogue.overwriteConfirmationName = "";
+							EnchantmentDialogue.loadConfirmationName = f.getName();
+							EnchantmentDialogue.deleteConfirmationName = "";
+							Main.game.setContent(new Response("Save/Load", "Open the save/load game window.", EnchantmentDialogue.ENCHANTMENT_MENU));
+						}
+						
+					}, false);
+
+					addEventListener(document, id, "mousemove", moveTooltipListener, false);
+					addEventListener(document, id, "mouseleave", hideTooltipListener, false);
+					TooltipInformationEventListener el2 = new TooltipInformationEventListener().setInformation("Load", "");
+					addEventListener(document, id, "mouseenter", el2, false);
+				}
+				id = "delete_saved_" + f.getName().substring(0, f.getName().lastIndexOf('.'));
+				if (((EventTarget) document.getElementById(id)) != null) {
+					((EventTarget) document.getElementById(id)).addEventListener("click", e -> {
+						
+						if(!Main.getProperties().overwriteWarning || EnchantmentDialogue.deleteConfirmationName.equals(f.getName())) {
+							EnchantmentDialogue.deleteConfirmationName = "";
+							EnchantmentDialogue.deleteEnchant(f.getName().substring(0, f.getName().lastIndexOf('.')));
+						} else {
+							EnchantmentDialogue.overwriteConfirmationName = "";
+							EnchantmentDialogue.loadConfirmationName = "";
+							EnchantmentDialogue.deleteConfirmationName = f.getName();
+							Main.game.setContent(new Response("Save/Load", "Open the save/load game window.", EnchantmentDialogue.ENCHANTMENT_MENU));
+						}
+						
+					}, false);
+
+					addEventListener(document, id, "mousemove", moveTooltipListener, false);
+					addEventListener(document, id, "mouseleave", hideTooltipListener, false);
+					TooltipInformationEventListener el2 = new TooltipInformationEventListener().setInformation("Delete", "");
+					addEventListener(document, id, "mouseenter", el2, false);
+				}
+			}
+			id = "new_saved";
+			if (((EventTarget) document.getElementById(id)) != null) {
+				((EventTarget) document.getElementById(id)).addEventListener("click", e -> {
+					Main.mainController.getWebEngine().executeScript("document.getElementById('hiddenPField').innerHTML=document.getElementById('new_save_name').value;");
+					EnchantmentDialogue.saveEnchant(Main.mainController.getWebEngine().getDocument().getElementById("hiddenPField").getTextContent(), false);
+					
+				}, false);
+
+				addEventListener(document, id, "mousemove", moveTooltipListener, false);
+				addEventListener(document, id, "mouseleave", hideTooltipListener, false);
+				TooltipInformationEventListener el2 = new TooltipInformationEventListener().setInformation("Save", "");
+				addEventListener(document, id, "mouseenter", el2, false);
 			}
 		}
 		

--- a/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
@@ -693,16 +693,21 @@ public class EnchantmentDialogue {
 						if(itemEffect == null)
 						{
 							System.err.println("Warning: Failed to import ItemEffect");
+							continue;
 						}
-						else if(ingredient.getEnchantmentEffect() != itemEffect.getItemEffectType())
+						if(!ingredient.getEnchantmentEffect().getPrimaryModifiers().contains(itemEffect.getPrimaryModifier()))
 						{
 							Main.game.flashMessage(Colour.GENERIC_BAD, "Enchantment is not valid for ingredient");
 							return;
 						}
-						else
+						TFModifier primaryMod = itemEffect.getPrimaryModifier();
+						if(!ingredient.getEnchantmentEffect().getSecondaryModifiers(primaryMod).contains(itemEffect.getSecondaryModifier()))
 						{
-							effectsToBeAdded.add(itemEffect);
+							Main.game.flashMessage(Colour.GENERIC_BAD, "Enchantment is not valid for ingredient");
+							return;
 						}
+						itemEffect.setItemEffectType(ingredient.getEnchantmentEffect());
+						effectsToBeAdded.add(itemEffect);
 					}
 					effects = effectsToBeAdded;
 					Main.game.setContent(new Response("Save", "", EnchantmentDialogue.ENCHANTMENT_MENU));

--- a/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
@@ -663,7 +663,7 @@ public class EnchantmentDialogue {
 		} catch (TransformerException tfe) {
 			tfe.printStackTrace();
 		}
-		Main.game.setContent(new Response("Save", "", Main.game.getCurrentDialogueNode()));
+		Main.game.setContent(new Response("Save", "", EnchantmentDialogue.ENCHANTMENT_MENU));
 	}
 
 	public static void loadEnchant(String name)
@@ -705,6 +705,7 @@ public class EnchantmentDialogue {
 						}
 					}
 					effects = effectsToBeAdded;
+					Main.game.setContent(new Response("Save", "", EnchantmentDialogue.ENCHANTMENT_MENU));
 				}
 				catch(Exception e)
 				{
@@ -735,5 +736,4 @@ public class EnchantmentDialogue {
 			Main.game.flashMessage(Colour.GENERIC_BAD, "File not found...");
 		}
 	}
-	
 }


### PR DESCRIPTION
As discussed in #283, this adds a screen to the enchanting UI where you can save/load the current list of enchanting effects to files. There is one issue, since the effect type must match between the item type being enchanted and the item type in the file, you can't load a potion saved using the "Sexual" type potion when enchanting a "Corruptive" type potion, as these are technically different ItemEffectTypes even though all effects a "Sexual" type potion can have, a "Corruptive" type potion can _also_ have. Likewise, a transformation potion saved using a cow-morph item can't be loaded to enchant a dog-morph item even if you aren't using any cow-specific effects. I'll be looking at ways to fix this soon, I hope.