### PR TITLE
Zero arousal changes from resisting actions

### DIFF
--- a/src/com/lilithsthrone/game/sex/sexActions/SexActionUtility.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/SexActionUtility.java
@@ -88,6 +88,16 @@ public class SexActionUtility {
 		}
 
 		@Override
+		public boolean isBaseRequirementsMet()
+		{
+			if(Sex.isDom(Main.game.getPlayer()))
+				return true;
+			if(Sex.isConsensual())
+				return true;
+			return false;
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Focus on calming yourself down, which lowers your arousal.";
 		}

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericActions.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericActions.java
@@ -247,7 +247,7 @@ public class GenericActions {
 			if(Main.game.getPlayer().hasFetish(Fetish.FETISH_NON_CON_SUB)) {
 				return ArousalIncrease.THREE_NORMAL;
 			}
-			return ArousalIncrease.NEGATIVE;
+			return ArousalIncrease.ZERO_NONE;
 		}
 		
 		@Override
@@ -883,7 +883,7 @@ public class GenericActions {
 			if(Sex.getActivePartner().hasFetish(Fetish.FETISH_NON_CON_SUB)) {
 				return ArousalIncrease.THREE_NORMAL;
 			}
-			return ArousalIncrease.NEGATIVE;
+			return ArousalIncrease.ZERO_NONE;
 		}
 		
 		@Override

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/PartnerTalk.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/PartnerTalk.java
@@ -44,6 +44,19 @@ public class PartnerTalk {
 		}
 		
 		@Override
+		public ArousalIncrease getArousalGainSelf()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionTitle() {
 			switch(Sex.getSexPace(Sex.getActivePartner())) {
 				case DOM_GENTLE:

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/PlayerTalk.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/PlayerTalk.java
@@ -46,6 +46,19 @@ public class PlayerTalk {
 				return CorruptionLevel.ONE_VANILLA;
 			}
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainSelf()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerFingerNipple.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerFingerNipple.java
@@ -45,6 +45,19 @@ public class PartnerFingerNipple {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
+		@Override
 		public String getDescription() {
 			if(!Main.game.getPlayer().isCoverableAreaExposed(CoverableArea.NIPPLES)){
 
@@ -1050,6 +1063,19 @@ public class PartnerFingerNipple {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
+		@Override
 		public String getDescription() {
 			if(!Main.game.getPlayer().isCoverableAreaExposed(CoverableArea.NIPPLES)){
 
@@ -1314,6 +1340,19 @@ public class PartnerFingerNipple {
 					&& Sex.getSexPace(Main.game.getPlayer())!=SexPace.SUB_RESISTING;
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
 		@Override
 		public String getDescription() {
 			UtilText.nodeContentSB.setLength(0);

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerFingerVagina.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerFingerVagina.java
@@ -1018,6 +1018,19 @@ public class PartnerFingerVagina {
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -1058,6 +1071,19 @@ public class PartnerFingerVagina {
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -1097,6 +1123,19 @@ public class PartnerFingerVagina {
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
 		}
 		
 		@Override
@@ -1276,6 +1315,19 @@ public class PartnerFingerVagina {
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return Sex.isConsensual() || Sex.isDom(Main.game.getPlayer()); // Player can only stop in consensual sex or if they're the dom.
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
 		}
 		
 		@Override

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerPenisAss.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerPenisAss.java
@@ -49,6 +49,19 @@ public class PartnerPenisAss {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getDescription() {
 				
 			UtilText.nodeContentSB.setLength(0);
@@ -218,6 +231,19 @@ public class PartnerPenisAss {
 			// Partner can't penetrate if you're already fucking them, due to physical limitations. (I mean, if you're facing opposite ways and lying on top of each other, it might be possible, but that position will be special.)
 			return Sex.isPenetrationTypeFree(Main.game.getPlayer(), PenetrationType.PENIS);
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -325,6 +351,19 @@ public class PartnerPenisAss {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
+		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
 		}
@@ -387,6 +426,19 @@ public class PartnerPenisAss {
 			return "Continue fucking [pc.name]'s ass cheeks.";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
@@ -451,6 +503,19 @@ public class PartnerPenisAss {
 			return "Roughly fuck [pc.name]'s ass cheeks.";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
@@ -1052,7 +1117,7 @@ public class PartnerPenisAss {
 	
 	public static final SexAction PLAYER_FUCKED_ANALLY_SUB_RESIST = new SexAction(
 			SexActionType.PLAYER,
-			ArousalIncrease.TWO_LOW,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.FOUR_HIGH,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.PENIS,

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerPenisBreasts.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerPenisBreasts.java
@@ -39,6 +39,19 @@ public class PartnerPenisBreasts {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
+		@Override
 		public boolean isBaseRequirementsMet() {
 			return Sex.getSexPace(Sex.getActivePartner())!=SexPace.SUB_RESISTING
 					&& Sex.getActivePartner().getPenisRawSizeValue()>=6
@@ -265,6 +278,19 @@ public class PartnerPenisBreasts {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.FOUR_HIGH;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			if(Main.game.getPlayer().isBreastFuckablePaizuri()) {
 				return "Sink your [npc.cock+] between [pc.name]'s [pc.breasts+] and start fucking them.";
@@ -481,6 +507,19 @@ public class PartnerPenisBreasts {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.FOUR_HIGH;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			if(Main.game.getPlayer().isBreastFuckablePaizuri()) {
 				return "Gently fuck [pc.name]'s [pc.breasts+].";
@@ -594,6 +633,19 @@ public class PartnerPenisBreasts {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.FOUR_HIGH;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			if(Main.game.getPlayer().isBreastFuckablePaizuri()) {
 				return "Continue fucking your [pc.breasts+].";
@@ -706,6 +758,19 @@ public class PartnerPenisBreasts {
 			}
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.FOUR_HIGH;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			if(Main.game.getPlayer().isBreastFuckablePaizuri()) {
@@ -1808,7 +1873,7 @@ public class PartnerPenisBreasts {
 	
 	public static final SexAction PLAYER_FUCKED_SUB_RESIST = new SexAction(
 			SexActionType.PLAYER,
-			ArousalIncrease.FOUR_HIGH,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.TWO_LOW,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.PENIS,

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerPenisMouth.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerPenisMouth.java
@@ -60,6 +60,19 @@ public class PartnerPenisMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.ONE_MINIMUM;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Pull your [npc.cock] out of [pc.name]'s mouth and slap [pc.her] face with it.";
 		}
@@ -126,6 +139,19 @@ public class PartnerPenisMouth {
 			return "Balls focus";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.ONE_MINIMUM;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			return "Force [pc.name] to pay some attention to your [npc.balls+].";
@@ -482,6 +508,19 @@ public class PartnerPenisMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Slide your [npc.cock+] into [pc.name]'s mouth.";
 		}
@@ -635,6 +674,19 @@ public class PartnerPenisMouth {
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -695,6 +747,19 @@ public class PartnerPenisMouth {
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -754,6 +819,19 @@ public class PartnerPenisMouth {
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
 		}
 		
 		@Override
@@ -887,7 +965,7 @@ public class PartnerPenisMouth {
 	
 	public static final SexAction PARTNER_BLOWJOB_SUB_RESISTING = new SexAction(
 			SexActionType.PARTNER,
-			ArousalIncrease.ONE_MINIMUM,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.TWO_LOW,
 			CorruptionLevel.ONE_VANILLA,
 			PenetrationType.PENIS,
@@ -1446,7 +1524,7 @@ public class PartnerPenisMouth {
 	
 	public static final SexAction PLAYER_BLOWJOB_SUB_RESIST = new SexAction(
 			SexActionType.PLAYER,
-			ArousalIncrease.ONE_MINIMUM,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.TWO_LOW,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.PENIS,

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerPenisThighs.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerPenisThighs.java
@@ -40,6 +40,19 @@ public class PartnerPenisThighs {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Slide your [npc.cock+] between [pc.name]'s thighs.";
 		}
@@ -141,6 +154,19 @@ public class PartnerPenisThighs {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
 		}
@@ -201,6 +227,19 @@ public class PartnerPenisThighs {
 			return "Continue fucking [npc.her] thighs.";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
@@ -263,6 +302,19 @@ public class PartnerPenisThighs {
 			return "Roughly fuck [npc.her] thighs.";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
@@ -856,7 +908,7 @@ public class PartnerPenisThighs {
 	
 	public static final SexAction PLAYER_THIGH_SEX_SUB_RESIST = new SexAction(
 			SexActionType.PLAYER,
-			ArousalIncrease.TWO_LOW,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.THREE_NORMAL,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.PENIS,

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerTongueAnus.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerTongueAnus.java
@@ -300,7 +300,7 @@ public class PartnerTongueAnus {
 	
 	public static final SexAction PARTNER_ANILINGUS_SUB_RESISTING = new SexAction(
 			SexActionType.PARTNER,
-			ArousalIncrease.THREE_NORMAL,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.TWO_LOW,
 			CorruptionLevel.THREE_DIRTY,
 			PenetrationType.TONGUE,
@@ -565,6 +565,19 @@ public class PartnerTongueAnus {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Get [npc.name] to start licking your [pc.asshole+].";
 		}
@@ -675,6 +688,19 @@ public class PartnerTongueAnus {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Gently enjoy [npc.name]'s [npc.tongue+] in your [pc.asshole+].";
 		}
@@ -734,6 +760,19 @@ public class PartnerTongueAnus {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Enjoy [npc.name]'s [npc.tongue+] in your [pc.asshole+].";
 		}
@@ -792,6 +831,19 @@ public class PartnerTongueAnus {
 			return "Rough anilingus";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			return "Grind your [pc.asshole+] down against [npc.name]'s [npc.tongue+].";

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerTongueBreasts.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerTongueBreasts.java
@@ -34,6 +34,19 @@ public class PartnerTongueBreasts {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Plant a series of kisses on [pc.name]'s exposed [pc.breasts].";
 		}

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerTongueMouth.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerTongueMouth.java
@@ -38,6 +38,19 @@ public class PartnerTongueMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Press your [npc.lips] against [pc.name]'s mouth and start making out with [pc.herHim].";
 		}
@@ -200,6 +213,19 @@ public class PartnerTongueMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Gently kiss [pc.name].";
 		}
@@ -276,6 +302,19 @@ public class PartnerTongueMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
 		}
@@ -342,6 +381,19 @@ public class PartnerTongueMouth {
 			return "Rough snog";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			return "Roughly snog [pc.name].";
@@ -600,6 +652,19 @@ public class PartnerTongueMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Gently kiss [npc.name].";
 		}
@@ -665,6 +730,19 @@ public class PartnerTongueMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
 		}
@@ -720,6 +798,19 @@ public class PartnerTongueMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Roughly snog [npc.name].";
 		}
@@ -768,7 +859,7 @@ public class PartnerTongueMouth {
 	
 	public static final SexAction PLAYER_KISS_SUB_RESIST = new SexAction(
 			SexActionType.PLAYER,
-			ArousalIncrease.TWO_LOW,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.TWO_LOW,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.TONGUE,

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerTongueNipple.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerTongueNipple.java
@@ -150,6 +150,19 @@ public class PartnerTongueNipple {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public boolean isBaseRequirementsMet() {
 			return Sex.getSexPace(Main.game.getPlayer())!=SexPace.SUB_RESISTING
 					&& Main.game.getPlayer().getBreastRawStoredMilkValue()>0;

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerTongueVagina.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPartner/PartnerTongueVagina.java
@@ -35,6 +35,19 @@ public class PartnerTongueVagina {
 		public boolean isBaseRequirementsMet() {
 			return Sex.getSexPace(Main.game.getPlayer())!=SexPace.SUB_RESISTING;
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -658,6 +671,19 @@ public class PartnerTongueVagina {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Try to pull your [npc.tongue] out of [pc.name]'s [pc.pussy+].";
 		}
@@ -919,6 +945,19 @@ public class PartnerTongueVagina {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Get [npc.name] to start licking your [pc.pussy+].";
 		}
@@ -1077,6 +1116,19 @@ public class PartnerTongueVagina {
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -1136,6 +1188,19 @@ public class PartnerTongueVagina {
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -1194,6 +1259,19 @@ public class PartnerTongueVagina {
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
 		}
 		
 		@Override

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerFingerAnus.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerFingerAnus.java
@@ -502,6 +502,19 @@ public class PlayerFingerAnus {
 		public boolean isBaseRequirementsMet() {
 			return Sex.isConsensual() || !Sex.isDom(Main.game.getPlayer()); // Partner can only start fingering in consensual sex or if they're the dom.
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -603,6 +616,19 @@ public class PlayerFingerAnus {
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -643,6 +669,19 @@ public class PlayerFingerAnus {
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -682,6 +721,19 @@ public class PlayerFingerAnus {
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
 		}
 		
 		@Override

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerFingerNipple.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerFingerNipple.java
@@ -35,6 +35,19 @@ public class PlayerFingerNipple {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Reach up and start groping [npc.name]'s [npc.breasts+].";
 		}
@@ -984,6 +997,19 @@ public class PlayerFingerNipple {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Force [pc.name] to start groping your [npc.breasts+].";
 		}
@@ -1250,6 +1276,19 @@ public class PlayerFingerNipple {
 			return "Get milked";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			return "";

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerFingerVagina.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerFingerVagina.java
@@ -940,6 +940,19 @@ public class PlayerFingerVagina {
 		public boolean isBaseRequirementsMet() {
 			return Sex.isConsensual() || !Sex.isDom(Main.game.getPlayer()); // Partner can only start fingering in consensual sex or if they're the dom.
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -1048,6 +1061,19 @@ public class PlayerFingerVagina {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Gently enjoy [pc.name]'s [pc.fingers+] in your [npc.pussy+].";
 		}
@@ -1080,6 +1106,19 @@ public class PlayerFingerVagina {
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
 		}
 		
 		@Override
@@ -1121,6 +1160,19 @@ public class PlayerFingerVagina {
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
 		}
 		
 		@Override

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerPenisAss.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerPenisAss.java
@@ -40,6 +40,19 @@ public class PlayerPenisAss {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Push [npc.name]'s ass cheeks together and tease your [pc.cockHead+] over the cleft.";
 		}
@@ -217,6 +230,19 @@ public class PlayerPenisAss {
 			// You can't penetrate if your partner is already fucking you, due to physical limitations. (I mean, if you're facing opposite ways and lying on top of each other, it might be possible, but that position will be special.)
 			return Sex.isPenetrationTypeFree(Sex.getActivePartner(), PenetrationType.PENIS) && (Sex.isDom(Main.game.getPlayer()) || Sex.isSubHasEqualControl());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -322,6 +348,19 @@ public class PlayerPenisAss {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
+		@Override
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
 		}
@@ -376,6 +415,19 @@ public class PlayerPenisAss {
 			return "Normal hotdogging";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			return "Continue fucking [npc.name]'s ass cheeks.";
@@ -447,7 +499,19 @@ public class PlayerPenisAss {
 			return Sex.isDom(Main.game.getPlayer());
 		}
 
-
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
 		@Override
 		public String getDescription() {
 
@@ -1024,7 +1088,7 @@ public class PlayerPenisAss {
 	
 	public static final SexAction PARTNER_FUCKED_ANALLY_SUB_RESIST = new SexAction(
 			SexActionType.PARTNER,
-			ArousalIncrease.TWO_LOW,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.FOUR_HIGH,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.PENIS,

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerPenisBreasts.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerPenisBreasts.java
@@ -39,6 +39,19 @@ public class PlayerPenisBreasts {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.THREE_NORMAL;
+			}
+		}
+		
+		@Override
 		public boolean isBaseRequirementsMet() {
 			return Sex.getSexPace(Main.game.getPlayer())!=SexPace.SUB_RESISTING
 					&& Main.game.getPlayer().getPenisRawSizeValue()>=6
@@ -253,6 +266,19 @@ public class PlayerPenisBreasts {
 		public boolean isBaseRequirementsMet() {
 			return Sex.getPenetrationTypeInOrifice(Main.game.getPlayer(), OrificeType.ANUS) != PenetrationType.PENIS
 					&& Sex.getPenetrationTypeInOrifice(Main.game.getPlayer(), OrificeType.VAGINA) != PenetrationType.PENIS;
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.FOUR_HIGH;
+			}
 		}
 		
 		@Override
@@ -481,6 +507,19 @@ public class PlayerPenisBreasts {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.FOUR_HIGH;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			if(Sex.getActivePartner().isBreastFuckablePaizuri()) {
 				return "Gently fuck [npc.name]'s [npc.breasts+].";
@@ -593,6 +632,19 @@ public class PlayerPenisBreasts {
 			}
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.FOUR_HIGH;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			if(Sex.getActivePartner().isBreastFuckablePaizuri()) {
@@ -707,6 +759,19 @@ public class PlayerPenisBreasts {
 			}
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.FOUR_HIGH;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			if(Sex.getActivePartner().isBreastFuckablePaizuri()) {
@@ -1813,7 +1878,7 @@ public class PlayerPenisBreasts {
 	
 	public static final SexAction PARTNER_FUCKED_SUB_RESIST = new SexAction(
 			SexActionType.PARTNER,
-			ArousalIncrease.TWO_LOW,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.FOUR_HIGH,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.PENIS,

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerPenisMouth.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerPenisMouth.java
@@ -53,6 +53,19 @@ public class PlayerPenisMouth {
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.ONE_MINIMUM;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -123,6 +136,19 @@ public class PlayerPenisMouth {
 			return "Balls focus";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.ONE_MINIMUM;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			return "Force [npc.name] to pay some attention to your [pc.balls+].";
@@ -479,6 +505,19 @@ public class PlayerPenisMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Slide your [pc.cock+] into [npc.name]'s mouth.";
 		}
@@ -633,6 +672,19 @@ public class PlayerPenisMouth {
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -691,6 +743,19 @@ public class PlayerPenisMouth {
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -748,6 +813,19 @@ public class PlayerPenisMouth {
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return Sex.isDom(Main.game.getPlayer());
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
 		}
 		
 		@Override
@@ -1431,7 +1509,7 @@ public class PlayerPenisMouth {
 	
 	public static final SexAction PARTNER_BLOWJOB_SUB_RESIST = new SexAction(
 			SexActionType.PARTNER,
-			ArousalIncrease.ONE_MINIMUM,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.TWO_LOW,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.PENIS,

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerPenisThighs.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerPenisThighs.java
@@ -33,6 +33,19 @@ public class PlayerPenisThighs {
 			// You can't penetrate if your partner is already fucking you, due to physical limitations.
 			return Sex.isPenetrationTypeFree(Sex.getActivePartner(), PenetrationType.PENIS);
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -136,6 +149,19 @@ public class PlayerPenisThighs {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Gently fuck [npc.name]'s thighs.";
 		}
@@ -197,6 +223,19 @@ public class PlayerPenisThighs {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Continue fucking [npc.name]'s thighs.";
 		}
@@ -257,6 +296,19 @@ public class PlayerPenisThighs {
 			return "Rough thigh sex";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			return "Roughly fuck [npc.name]'s thighs.";
@@ -854,7 +906,7 @@ public class PlayerPenisThighs {
 	
 	public static final SexAction PARTNER_THIGH_SEX_SUB_RESIST = new SexAction(
 			SexActionType.PARTNER,
-			ArousalIncrease.TWO_LOW,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.THREE_NORMAL,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.PENIS,

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerTongueAnus.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerTongueAnus.java
@@ -312,7 +312,7 @@ public class PlayerTongueAnus {
 	
 	public static final SexAction PLAYER_ANILINGUS_SUB_RESISTING = new SexAction(
 			SexActionType.PLAYER,
-			ArousalIncrease.TWO_LOW,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.THREE_NORMAL,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.TONGUE,
@@ -577,6 +577,19 @@ public class PlayerTongueAnus {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getDescription() {
 			
 			UtilText.nodeContentSB.setLength(0);
@@ -677,6 +690,19 @@ public class PlayerTongueAnus {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Gently enjoy [pc.name]'s [pc.tongue+] in your [npc.asshole+].";
 		}
@@ -728,6 +754,19 @@ public class PlayerTongueAnus {
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
 		}
 		
 		@Override
@@ -787,6 +826,19 @@ public class PlayerTongueAnus {
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
 		}
 		
 		@Override

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerTongueBreasts.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerTongueBreasts.java
@@ -34,6 +34,19 @@ public class PlayerTongueBreasts {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Plant a series of kisses on [npc.name]'s exposed [npc.breasts].";
 		}

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerTongueMouth.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerTongueMouth.java
@@ -38,6 +38,19 @@ public class PlayerTongueMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Press your [pc.lips] against [npc.name]'s mouth and start making out with [npc.herHim].";
 		}
@@ -202,6 +215,19 @@ public class PlayerTongueMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Gently kiss [npc.name].";
 		}
@@ -274,6 +300,19 @@ public class PlayerTongueMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Continue kissing [npc.name].";
 		}
@@ -344,6 +383,19 @@ public class PlayerTongueMouth {
 			return "Rough snog";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Sex.getActivePartner())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			return "Roughly snog [npc.name].";
@@ -604,6 +656,19 @@ public class PlayerTongueMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Gently kiss [pc.name].";
 		}
@@ -663,6 +728,19 @@ public class PlayerTongueMouth {
 			return "Kiss [pc.herHim]";
 		}
 
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
 		@Override
 		public String getActionDescription() {
 			return "Continue kissing [pc.name].";
@@ -725,6 +803,19 @@ public class PlayerTongueMouth {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Roughly snog [pc.name].";
 		}
@@ -773,7 +864,7 @@ public class PlayerTongueMouth {
 	
 	public static final SexAction PARTNER_KISS_SUB_RESIST = new SexAction(
 			SexActionType.PARTNER,
-			ArousalIncrease.TWO_LOW,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.TWO_LOW,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.TONGUE,

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerTongueNipple.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerTongueNipple.java
@@ -145,6 +145,19 @@ public class PlayerTongueNipple {
 		}
 
 		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
+		
+		@Override
 		public String getActionDescription() {
 			return "Pull [pc.name]'s face into your [npc.breasts] and get [pc.herHim] to start drinking your [npc.milk].";
 		}

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerTongueVagina.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsPlayer/PlayerTongueVagina.java
@@ -35,6 +35,19 @@ public class PlayerTongueVagina {
 		public boolean isBaseRequirementsMet() {
 			return Sex.getSexPace(Sex.getActivePartner())!=SexPace.SUB_RESISTING;
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.FOUR_HIGH;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -635,7 +648,7 @@ public class PlayerTongueVagina {
 	
 	public static final SexAction PLAYER_CUNNILINGUS_SUB_RESISTING = new SexAction(
 			SexActionType.PLAYER,
-			ArousalIncrease.TWO_LOW,
+			ArousalIncrease.ZERO_NONE,
 			ArousalIncrease.THREE_NORMAL,
 			CorruptionLevel.ZERO_PURE,
 			PenetrationType.TONGUE,
@@ -904,6 +917,19 @@ public class PlayerTongueVagina {
 		public boolean isBaseRequirementsMet() {
 			return Sex.isConsensual() || !Sex.isDom(Main.game.getPlayer()); // Partner can only start cunnilingus in consensual sex or if they're the dom.
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -1067,6 +1093,19 @@ public class PlayerTongueVagina {
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -1126,6 +1165,19 @@ public class PlayerTongueVagina {
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
 		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
+		}
 		
 		@Override
 		public String getActionTitle() {
@@ -1184,6 +1236,19 @@ public class PlayerTongueVagina {
 		@Override
 		public boolean isBaseRequirementsMet() {
 			return !Sex.isDom(Main.game.getPlayer());
+		}
+
+		@Override
+		public ArousalIncrease getArousalGainTarget()
+		{
+			if(Sex.getSexPace(Main.game.getPlayer())==SexPace.SUB_RESISTING)
+			{
+				return ArousalIncrease.ZERO_NONE;
+			}
+			else
+			{
+				return ArousalIncrease.TWO_LOW;
+			}
 		}
 		
 		@Override


### PR DESCRIPTION
As discussed in #221, this sets all actions in the resisting pace that don't involve direct stimulation to have zero arousal gain. This prevents the standard "resist" action from making it virtually impossible to make an unwilling character cum. This also prevents the player from using the "Calm Down" action while being raped, for the same reason.