### PR TITLE
Fix for Breast.setSize

### DIFF
--- a/src/com/lilithsthrone/game/character/body/Breast.java
+++ b/src/com/lilithsthrone/game/character/body/Breast.java
@@ -510,6 +510,10 @@ public class Breast implements BodyPartInterface, Serializable {
 		int oldSize = this.size;
 		this.size = Math.max(0, Math.min(size, CupSize.getMaximumCupSize().getMeasurement()));
 		int sizeChange = this.size - oldSize;
+		if(owner==null) {
+			this.size = size;
+			return "";
+		}
 		
 		if (sizeChange == 0) {
 			if(owner.isPlayer()) {


### PR DESCRIPTION
This allows Breast.setSize to accept a null value for the owner parameter, in a similar manner to how Ear.setType and Tail.setType work.