### PR TITLE
Addiction patch 2

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -8300,7 +8300,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 			}
 		}
 		
-		if(modifiers.contains(FluidModifier.ADDICTIVE)) {
+		if(modifiers.contains(FluidModifier.ADDICTIVE) && (this.getAddiction(fluid)==null)) {
 			addAddiction(new Addiction(fluid, Main.game.getMinutesPassed(), charactersFluid.getId()));
 			if(isPlayer()) {
 				fluidIngestionSB.append("<p>"
@@ -8315,7 +8315,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 						+ "</p>"));
 			}
 			
-		} else if(this.getAddiction(fluid)!=null) {
+		} else {
 			boolean curedWithdrawal = Main.game.getMinutesPassed()-this.getAddiction(fluid).getLastTimeSatisfied()>=24*60;
 			setLastTimeSatisfiedAddiction(fluid, Main.game.getMinutesPassed());
 			if(isPlayer()) {

--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -8315,7 +8315,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 						+ "</p>"));
 			}
 			
-		} else {
+		} else if(this.getAddiction(fluid)!=null) {
 			boolean curedWithdrawal = Main.game.getMinutesPassed()-this.getAddiction(fluid).getLastTimeSatisfied()>=24*60;
 			setLastTimeSatisfiedAddiction(fluid, Main.game.getMinutesPassed());
 			if(isPlayer()) {


### PR DESCRIPTION
This changes ingestFluids to only show the "new addiction" dialog if the ingesting character isn't already addicted to the fluid, and to otherwise always show the "satisfied craving" dialog if the ingesting character is addicted.

This makes it a little cleaner to use the addiction system, since before if you fed an addicted character with an addicting version of a fluid, it would show the "new addiction" dialog every time.