### PR TITLE
Rework harpy body selection

### DIFF
--- a/src/com/lilithsthrone/game/character/npc/dominion/HarpyNestsAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/HarpyNestsAttacker.java
@@ -65,10 +65,18 @@ public class HarpyNestsAttacker extends NPC {
 			
 			
 			// RACE & NAME:
-			if(gender.isFeminine()) {
-				setBody(Gender.F_V_B_FEMALE, RacialBody.HARPY, RaceStage.LESSER);
+			if(this.hasPenis()) {
+				if(this.hasBreasts()) {
+					setBody(Gender.F_P_B_SHEMALE, RacialBody.HARPY, RaceStage.LESSER);
+				} else {
+					setBody(Gender.F_P_TRAP, RacialBody.HARPY, RaceStage.LESSER);
+				}
 			} else {
-				setBody(Gender.F_P_TRAP, RacialBody.HARPY, RaceStage.LESSER);
+				if(this.hasBreasts()) {
+					setBody(Gender.F_V_B_FEMALE, RacialBody.HARPY, RaceStage.LESSER);
+				} else {
+					setBody(Gender.F_V_FEMALE, RacialBody.HARPY, RaceStage.LESSER);
+				}
 			}
 	
 			setName(Name.getRandomTriplet(Race.HARPY));


### PR DESCRIPTION
Curious how harpy generation works, I discovered it's determined solely by femininity - this produced the situation where a player could set their gender preferences to 100% shemales or traps, and harpies would all generate as female. This doesn't seem right, if a player has a preference for cocks, they should _get_ cocks. This will fix that issue.