### PR TITLE
Typo fix

### DIFF
--- a/res/txt/places/dominion/redLightDistrict/angelsKiss.xml
+++ b/res/txt/places/dominion/redLightDistrict/angelsKiss.xml
@@ -192,7 +192,7 @@
 	<p>
 		[npc.Name] eagerly hands over the two-thousand flames, and, after taking the money and putting it to one side, you focus your attention on your new client.
 		 Leaning in to growl in [npc.her] ear, you [pc.moan],
-		 [pc.speech(It's time to show you how I fuck submissive little [npc.race]'s like you...)]
+		 [pc.speech(It's time to show you how I fuck submissive little [npc.races] like you...)]
 	</p>
 	]]>
 	</htmlContent>


### PR DESCRIPTION
You don't use an apostrophe for plurals, and you _certainly_ don't say "woman's" or "man's", which is happening currently.