### PR TITLE
Brothel client fixes

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -1980,7 +1980,32 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 	public void setSexualOrientation(SexualOrientation sexualOrientation) {
 		this.sexualOrientation = sexualOrientation;
 	}
+	
+	public boolean isAttractedTo(GameCharacter character)
+	{
+		return isAttractedTo(character.getGender());
+	}
 
+	public boolean isAttractedTo(Gender gender)
+	{
+		switch(getSexualOrientation())
+		{
+			case AMBIPHILIC:
+				return true;
+			case ANDROPHILIC:
+				if(gender.isFeminine())
+					return false;
+				else
+					return true;
+			case GYNEPHILIC:
+				if(gender.isFeminine())
+					return true;
+				else
+					return false;
+			default:
+				return true;
+		}
+	}
 	
 	// Obedience:
 	

--- a/src/com/lilithsthrone/game/character/gender/Gender.java
+++ b/src/com/lilithsthrone/game/character/gender/Gender.java
@@ -1,5 +1,8 @@
 package com.lilithsthrone.game.character.gender;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.lilithsthrone.main.Main;
 import com.lilithsthrone.utils.Colour;
 
@@ -149,5 +152,92 @@ public enum Gender {
 
 	public GenderPreference getGenderPreferenceDefault() {
 		return genderPreferenceDefault;
+	}
+
+	public Gender toMasculine() {
+		Map<Gender, Gender> map = new HashMap<Gender, Gender>();
+		map.put(M_P_V_B_HERMAPHRODITE, M_P_V_B_HERMAPHRODITE);
+		map.put(M_P_V_HERMAPHRODITE, M_P_V_HERMAPHRODITE);
+		map.put(M_P_B_BUSTYBOY, M_P_B_BUSTYBOY);
+		map.put(M_P_MALE, M_P_MALE);
+		map.put(M_V_B_BUTCH, M_V_B_BUTCH);
+		map.put(M_V_CUNTBOY, M_V_CUNTBOY);
+		map.put(M_B_MANNEQUIN, M_B_MANNEQUIN);
+		map.put(M_MANNEQUIN, M_MANNEQUIN);
+		map.put(F_P_V_B_FUTANARI, M_P_V_B_HERMAPHRODITE);
+		map.put(F_P_V_FUTANARI, M_P_V_HERMAPHRODITE);
+		map.put(F_P_B_SHEMALE, M_P_B_BUSTYBOY);
+		map.put(F_P_TRAP, M_P_MALE);
+		map.put(F_V_B_FEMALE, M_V_B_BUTCH);
+		map.put(F_V_FEMALE, M_V_CUNTBOY);
+		map.put(F_B_DOLL, M_B_MANNEQUIN);
+		map.put(F_DOLL, M_MANNEQUIN);
+		map.put(N_P_V_B_HERMAPHRODITE, M_P_V_B_HERMAPHRODITE);
+		map.put(N_P_V_HERMAPHRODITE, M_P_V_HERMAPHRODITE);
+		map.put(N_P_B_SHEMALE, M_P_B_BUSTYBOY);
+		map.put(N_P_TRAP, M_P_MALE);
+		map.put(N_V_B_TOMBOY, M_V_B_BUTCH);
+		map.put(N_V_TOMBOY, M_V_CUNTBOY);
+		map.put(N_B_DOLL, M_B_MANNEQUIN);
+		map.put(N_NEUTER, M_MANNEQUIN);
+		return map.get(this);
+	}
+
+	public Gender toFeminine() {
+		Map<Gender, Gender> map = new HashMap<Gender, Gender>();
+		map.put(M_P_V_B_HERMAPHRODITE, F_P_V_B_FUTANARI);
+		map.put(M_P_V_HERMAPHRODITE, F_P_V_FUTANARI);
+		map.put(M_P_B_BUSTYBOY, F_P_B_SHEMALE);
+		map.put(M_P_MALE, F_P_TRAP);
+		map.put(M_V_B_BUTCH, F_V_B_FEMALE);
+		map.put(M_V_CUNTBOY, F_V_FEMALE);
+		map.put(M_B_MANNEQUIN, F_B_DOLL);
+		map.put(M_MANNEQUIN, F_DOLL);
+		map.put(F_P_V_B_FUTANARI, F_P_V_B_FUTANARI);
+		map.put(F_P_V_FUTANARI, F_P_V_FUTANARI);
+		map.put(F_P_B_SHEMALE, F_P_B_SHEMALE);
+		map.put(F_P_TRAP, F_P_TRAP);
+		map.put(F_V_B_FEMALE, F_V_B_FEMALE);
+		map.put(F_V_FEMALE, F_V_FEMALE);
+		map.put(F_B_DOLL, F_B_DOLL);
+		map.put(F_DOLL, F_DOLL);
+		map.put(N_P_V_B_HERMAPHRODITE, F_P_V_B_FUTANARI);
+		map.put(N_P_V_HERMAPHRODITE, F_P_V_FUTANARI);
+		map.put(N_P_B_SHEMALE, F_P_B_SHEMALE);
+		map.put(N_P_TRAP, F_P_TRAP);
+		map.put(N_V_B_TOMBOY, F_V_B_FEMALE);
+		map.put(N_V_TOMBOY, F_V_FEMALE);
+		map.put(N_B_DOLL, F_B_DOLL);
+		map.put(N_NEUTER, F_DOLL);
+		return map.get(this);
+	}
+
+	public Gender toAndrogynous() {
+		Map<Gender, Gender> map = new HashMap<Gender, Gender>();
+		map.put(M_P_V_B_HERMAPHRODITE, N_P_V_B_HERMAPHRODITE);
+		map.put(M_P_V_HERMAPHRODITE, N_P_V_HERMAPHRODITE);
+		map.put(M_P_B_BUSTYBOY, N_P_B_SHEMALE);
+		map.put(M_P_MALE, N_P_TRAP);
+		map.put(M_V_B_BUTCH, N_V_B_TOMBOY);
+		map.put(M_V_CUNTBOY, N_V_TOMBOY);
+		map.put(M_B_MANNEQUIN, N_B_DOLL);
+		map.put(M_MANNEQUIN, N_NEUTER);
+		map.put(F_P_V_B_FUTANARI, N_P_V_B_HERMAPHRODITE);
+		map.put(F_P_V_FUTANARI, N_P_V_HERMAPHRODITE);
+		map.put(F_P_B_SHEMALE, N_P_B_SHEMALE);
+		map.put(F_P_TRAP, N_P_TRAP);
+		map.put(F_V_B_FEMALE, N_V_B_TOMBOY);
+		map.put(F_V_FEMALE, N_V_TOMBOY);
+		map.put(F_B_DOLL, N_B_DOLL);
+		map.put(F_DOLL, N_NEUTER);
+		map.put(N_P_V_B_HERMAPHRODITE, N_P_V_B_HERMAPHRODITE);
+		map.put(N_P_V_HERMAPHRODITE, N_P_V_HERMAPHRODITE);
+		map.put(N_P_B_SHEMALE, N_P_B_SHEMALE);
+		map.put(N_P_TRAP, N_P_TRAP);
+		map.put(N_V_B_TOMBOY, N_V_B_TOMBOY);
+		map.put(N_V_TOMBOY, N_V_TOMBOY);
+		map.put(N_B_DOLL, N_B_DOLL);
+		map.put(N_NEUTER, N_NEUTER);
+		return map.get(this);
 	}
 }

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/RedLightDistrict.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/RedLightDistrict.java
@@ -3,8 +3,10 @@ package com.lilithsthrone.game.dialogue.places.dominion;
 import java.util.List;
 
 import com.lilithsthrone.game.Weather;
+import com.lilithsthrone.game.character.SexualOrientation;
 import com.lilithsthrone.game.character.fetishes.Fetish;
 import com.lilithsthrone.game.character.fetishes.FetishDesire;
+import com.lilithsthrone.game.character.gender.Gender;
 import com.lilithsthrone.game.character.gender.GenderPreference;
 import com.lilithsthrone.game.character.npc.GenericSexualPartner;
 import com.lilithsthrone.game.character.npc.NPC;
@@ -386,9 +388,28 @@ public class RedLightDistrict {
 					return new Response("Sell body (Sub)", "Wait around for a client to show up...", ANGELS_KISS_SELL_SELF_SUB){
 						@Override
 						public void effects() {
-							NPC npc = new GenericSexualPartner(GenderPreference.getGenderFromUserPreferences(), Main.game.getPlayer().getWorldLocation(), Main.game.getPlayer().getLocation(), false);
+							Gender gender = GenderPreference.getGenderFromUserPreferences();
+							if(!Main.game.getPlayer().isAttractedTo(gender))
+							{
+								switch(Main.game.getPlayer().getSexualOrientation())
+								{
+									case ANDROPHILIC:
+										gender = gender.toMasculine();
+										break;
+									case GYNEPHILIC:
+										gender = gender.toFeminine();
+										break;
+									default:
+										break;
+								}
+							}
+							NPC npc = new GenericSexualPartner(gender, Main.game.getPlayer().getWorldLocation(), Main.game.getPlayer().getLocation(), false);
 							npc.removeFetish(Fetish.FETISH_SUBMISSIVE);
 							npc.setFetishDesire(Fetish.FETISH_DOMINANT, FetishDesire.THREE_LIKE);
+							if(!npc.isAttractedTo(Main.game.getPlayer()))
+							{
+								npc.setSexualOrientation(SexualOrientation.AMBIPHILIC);
+							}
 							try {
 								Main.game.addNPC(npc, false);
 								Main.game.setActiveNPC(npc);
@@ -402,9 +423,28 @@ public class RedLightDistrict {
 					return new Response("Sell body (Dom)", "Wait around for a client to show up...", ANGELS_KISS_SELL_SELF_DOM){
 						@Override
 						public void effects() {
-							NPC npc = new GenericSexualPartner(GenderPreference.getGenderFromUserPreferences(), Main.game.getPlayer().getWorldLocation(), Main.game.getPlayer().getLocation(), false);
+							Gender gender = GenderPreference.getGenderFromUserPreferences();
+							if(!Main.game.getPlayer().isAttractedTo(gender))
+							{
+								switch(Main.game.getPlayer().getSexualOrientation())
+								{
+									case ANDROPHILIC:
+										gender = gender.toMasculine();
+										break;
+									case GYNEPHILIC:
+										gender = gender.toFeminine();
+										break;
+									default:
+										break;
+								}
+							}
+							NPC npc = new GenericSexualPartner(gender, Main.game.getPlayer().getWorldLocation(), Main.game.getPlayer().getLocation(), false);
 							npc.removeFetish(Fetish.FETISH_DOMINANT);
 							npc.setFetishDesire(Fetish.FETISH_SUBMISSIVE, FetishDesire.THREE_LIKE);
+							if(!npc.isAttractedTo(Main.game.getPlayer()))
+							{
+								npc.setSexualOrientation(SexualOrientation.AMBIPHILIC);
+							}
 							try {
 								Main.game.addNPC(npc, false);
 								Main.game.setActiveNPC(npc);


### PR DESCRIPTION
This fixes #354 and #355, ensuring that whenever the PC sells themselves in the brothel, they will get a client of the right gender and orientation. May produce some strange results as it currently converts genders directly; for example, it will convert a F_V_B_FEMALE into a M_V_B_BUTCH, which may not be desired. Includes #356 as these methods are needed for it to work.