### PR TITLE
BUGFIX: Fix Lilaya Geisha submissive sex

### DIFF
--- a/src/com/lilithsthrone/game/character/npc/dominion/Lilaya.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Lilaya.java
@@ -183,6 +183,14 @@ public class Lilaya extends NPC {
 	public boolean isUnique() {
 		return true;
 	}
+	
+	// Prevent issues with Geisha Lilaya immediately
+	// backing out of submissive sex
+	
+	@Override
+	public boolean isAttractedTo(GameCharacter character) {
+		return true;
+	}
 
 	@Override
 	public List<Artwork> getArtworkList() {


### PR DESCRIPTION
This fixes the bug introduced in commit 7f723ab where Lilaya will immediately bail out of Geisha submissive sex. The simplest solution seemed to be overriding her isAttractedTo() method to always return true.

No new graphical assets are required, this is simply a bugfix.

Change has been tested on 0.2.3.1. Lilaya no longer bails out due to not having the incest fetish.

@Innoxia: I think you'll want to grab this one for sure before the next release.

Fixes issue #360 