### PR TITLE
BUGFIX: Correct save logic to write out personality entries properly.

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -546,15 +546,16 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 		CharacterUtils.createXMLElementWithValue(doc, characterCoreInfo, "version", Main.VERSION_NUMBER);
 		CharacterUtils.createXMLElementWithValue(doc, characterCoreInfo, "history", this.getHistory().toString());
 		
-		CharacterUtils.createXMLElementWithValue(doc, characterCoreInfo, "personality", this.getPersonality().toString());
+		// It looks like this was an erroneous line?
+		//CharacterUtils.createXMLElementWithValue(doc, characterCoreInfo, "personality", this.getPersonality().toString());
 		Element personalityElement = doc.createElement("personality");
 		characterCoreInfo.appendChild(personalityElement);
 		for(Entry<PersonalityTrait, PersonalityWeight> entry: getPersonality().entrySet()){
 			Element element = doc.createElement("personalityEntry");
 			personalityElement.appendChild(element);
 			
-			CharacterUtils.addAttribute(doc, personalityElement, "trait", entry.getKey().toString());
-			CharacterUtils.addAttribute(doc, personalityElement, "weight", entry.getValue().toString());
+			CharacterUtils.addAttribute(doc, element, "trait", entry.getKey().toString());
+			CharacterUtils.addAttribute(doc, element, "weight", entry.getValue().toString());
 		}
 		
 		CharacterUtils.createXMLElementWithValue(doc, characterCoreInfo, "sexualOrientation", this.getSexualOrientation().toString());


### PR DESCRIPTION
- What is the purpose of the pull request?
Corrects issue #372 for personality values not importing.

- Give a brief description of what you changed or added.
The actual problem was that the personality entries were not being written out properly. I changed it to write out the actual personality entries.

Note to @Innoxia: It probably wasn't necessary to comment out the line I did. If you were planning on using that entry for something, feel free to keep it (although I might rename it.)

- Are any new graphical assets required?
Nope

- Has this change been tested? If so, mention the version number that the test was based on.
Tested on 0.2.3.5.
