### PR TITLE
Remove modifiers during loading if the savefile explicitly mentions them as false

### DIFF
--- a/src/com/lilithsthrone/game/character/body/Body.java
+++ b/src/com/lilithsthrone/game/character/body/Body.java
@@ -2,6 +2,7 @@ package com.lilithsthrone.game.character.body;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -725,17 +726,10 @@ public class Body implements Serializable, XMLSaving {
 					+ "</br>bleached: "+importedAss.anus.bleached
 					+ "</br>assHair: "+importedAss.anus.assHair
 					+"</br>Modifiers:");
-			Element anusModifiers = (Element)anus.getElementsByTagName("anusModifiers").item(0);
-			
-			importedAss.anus.orificeAnus.orificeModifiers.clear();
-			for(OrificeModifier om : OrificeModifier.values()) {
-				if(Boolean.valueOf(anusModifiers.getAttribute(om.toString()))) {
-					importedAss.anus.orificeAnus.orificeModifiers.add(om);
-					CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":true");
-				} else {
-					CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":false");
-				}
-			}
+			Element anusModifiersElement = (Element)anus.getElementsByTagName("anusModifiers").item(0);
+			Collection<OrificeModifier> anusModifiers = importedAss.anus.orificeAnus.orificeModifiers;
+			anusModifiers.clear();
+			handleLoadingOfModifiers(OrificeModifier.values(), log, anusModifiersElement, anusModifiers);
 		}
 		
 
@@ -804,17 +798,11 @@ public class Body implements Serializable, XMLSaving {
 				+ "</br>areolaeShape: "+importedBreast.nipples.getAreolaeShape()
 				+"</br>Modifiers:");
 		
-		Element nippleModifiers = (Element)nipples.getElementsByTagName("nippleModifiers").item(0);
+		Element nippleModifiersElement = (Element)nipples.getElementsByTagName("nippleModifiers").item(0);
 		
-		importedBreast.nipples.orificeNipples.orificeModifiers.clear();
-		for(OrificeModifier om : OrificeModifier.values()) {
-			if(Boolean.valueOf(nippleModifiers.getAttribute(om.toString()))) {
-				importedBreast.nipples.orificeNipples.orificeModifiers.add(om);
-				CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":true");
-			} else {
-				CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":false");
-			}
-		}
+		Collection<OrificeModifier> nippleOrificeModifiers = importedBreast.nipples.orificeNipples.orificeModifiers;
+		nippleOrificeModifiers.clear();
+		handleLoadingOfModifiers(OrificeModifier.values(), log, nippleModifiersElement, nippleOrificeModifiers);
 		
 		CharacterUtils.appendToImportLog(log, "</br></br>Milk:");
 		
@@ -825,15 +813,9 @@ public class Body implements Serializable, XMLSaving {
 				" flavour: "+importedBreast.milk.getFlavour()
 				+ "</br>Modifiers:");
 		
-		Element milkModifiers = (Element)milk.getElementsByTagName("milkModifiers").item(0);
-		for(FluidModifier fm : FluidModifier.values()) {
-			if(Boolean.valueOf(milkModifiers.getAttribute(fm.toString()))) {
-				importedBreast.milk.fluidModifiers.add(fm);
-				CharacterUtils.appendToImportLog(log, "</br>"+fm.toString()+":true");
-			} else {
-				CharacterUtils.appendToImportLog(log, "</br>"+fm.toString()+":false");
-			}
-		}
+		Element milkModifiersElement = (Element)milk.getElementsByTagName("milkModifiers").item(0);
+		Collection<FluidModifier> milkFluidModifiers = importedBreast.milk.fluidModifiers;
+		handleLoadingOfModifiers(FluidModifier.values(), log, milkModifiersElement, milkFluidModifiers);
 
 		
 		// **************** Ear **************** //
@@ -926,17 +908,11 @@ public class Body implements Serializable, XMLSaving {
 				+ "</br>lipSize: "+importedFace.mouth.getLipSize()
 				+ "</br>Modifiers: ");
 			
-		Element mouthModifiers = (Element)mouth.getElementsByTagName("mouthModifiers").item(0);
+		Element mouthModifiersElement = (Element)mouth.getElementsByTagName("mouthModifiers").item(0);
 		
-		importedFace.mouth.orificeMouth.orificeModifiers.clear();
-		for(OrificeModifier om : OrificeModifier.values()) {
-			if(Boolean.valueOf(mouthModifiers.getAttribute(om.toString()))) {
-				importedFace.mouth.orificeMouth.orificeModifiers.add(om);
-				CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":true");
-			} else {
-				CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":false");
-			}
-		}
+		Collection<OrificeModifier> mouthOrificeModifiers = importedFace.mouth.orificeMouth.orificeModifiers;
+		mouthOrificeModifiers.clear();
+		handleLoadingOfModifiers(OrificeModifier.values(), log, mouthModifiersElement, mouthOrificeModifiers);
 
 		Element tongue = (Element)parentElement.getElementsByTagName("tongue").item(0);
 			importedFace.tongue.pierced = (Boolean.valueOf(tongue.getAttribute("piercedTongue")));
@@ -948,17 +924,11 @@ public class Body implements Serializable, XMLSaving {
 					+ "</br>tongueLength: "+importedFace.tongue.getTongueLength()
 					+ "</br>Modifiers: ");
 			
-			Element tongueModifiers = (Element)tongue.getElementsByTagName("tongueModifiers").item(0);
+			Element tongueModifiersElement = (Element)tongue.getElementsByTagName("tongueModifiers").item(0);
 			
-			importedFace.tongue.tongueModifiers.clear();
-			for(TongueModifier tm : TongueModifier.values()) {
-				if(Boolean.valueOf(tongueModifiers.getAttribute(tm.toString()))) {
-					importedFace.tongue.tongueModifiers.add(tm);
-					CharacterUtils.appendToImportLog(log, "</br>"+tm.toString()+":true");
-				} else {
-					CharacterUtils.appendToImportLog(log, "</br>"+tm.toString()+":false");
-				}
-			}
+			Collection<TongueModifier> tongueModifiers = importedFace.tongue.tongueModifiers;
+			tongueModifiers.clear();
+			handleLoadingOfModifiers(TongueModifier.values(), log, tongueModifiersElement, tongueModifiers);
 			
 			
 		// **************** Hair **************** //
@@ -1076,16 +1046,15 @@ public class Body implements Serializable, XMLSaving {
 				+ "</br>pierced: "+importedPenis.isPierced()
 				+ "</br>Penis Modifiers: ");
 		
-		Element penisModifiers = (Element)penis.getElementsByTagName("penisModifiers").item(0);
-		
-		importedPenis.penisModifiers.clear();
-		for(PenisModifier pm : PenisModifier.values()) {
-			if(penisModifiers != null && Boolean.valueOf(penisModifiers.getAttribute(pm.toString()))) {
-				importedPenis.penisModifiers.add(pm);
-				CharacterUtils.appendToImportLog(log, "</br>"+pm.toString()+":true");
-			} else {
+		Collection<PenisModifier> penisModifiers = importedPenis.penisModifiers;
+		penisModifiers.clear();
+		Element penisModifiersElement = (Element)penis.getElementsByTagName("penisModifiers").item(0);
+		if (penisModifiersElement == null) {
+			for (PenisModifier pm : PenisModifier.values()) {
 				CharacterUtils.appendToImportLog(log, "</br>"+pm.toString()+":false");
 			}
+		} else {
+			handleLoadingOfModifiers(PenisModifier.values(), log, penisModifiersElement, penisModifiers);
 		}
 		
 		importedPenis.orificeUrethra.elasticity = (Integer.valueOf(penis.getAttribute("elasticity")));
@@ -1106,17 +1075,11 @@ public class Body implements Serializable, XMLSaving {
 				+ "</br>virgin: "+importedPenis.orificeUrethra.isVirgin()
 				+ "</br>Urethra Modifiers:");
 		
-		Element urethraModifiers = (Element)penis.getElementsByTagName("urethraModifiers").item(0);
+		Element urethraModifiersElement = (Element)penis.getElementsByTagName("urethraModifiers").item(0);
 		
-		importedPenis.orificeUrethra.orificeModifiers.clear();
-		for(OrificeModifier om : OrificeModifier.values()) {
-			if(Boolean.valueOf(urethraModifiers.getAttribute(om.toString()))) {
-				importedPenis.orificeUrethra.orificeModifiers.add(om);
-				CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":true");
-			} else {
-				CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":false");
-			}
-		}
+		Collection<OrificeModifier> urethraOrificeModifiers = importedPenis.orificeUrethra.orificeModifiers;
+		urethraOrificeModifiers.clear();
+		handleLoadingOfModifiers(OrificeModifier.values(), log, urethraModifiersElement, urethraOrificeModifiers);
 		
 		importedPenis.testicle.internal = (Boolean.valueOf(testicles.getAttribute("internal")));
 		
@@ -1137,14 +1100,8 @@ public class Body implements Serializable, XMLSaving {
 				+ "</br>Modifiers:");
 		
 		Element cumModifiers = (Element)cum.getElementsByTagName("cumModifiers").item(0);
-		for(FluidModifier fm : FluidModifier.values()) {
-			if(Boolean.valueOf(cumModifiers.getAttribute(fm.toString()))) {
-				importedPenis.testicle.cum.fluidModifiers.add(fm);
-				CharacterUtils.appendToImportLog(log, "</br>"+fm.toString()+":true");
-			} else {
-				CharacterUtils.appendToImportLog(log, "</br>"+fm.toString()+":false");
-			}
-		}
+		List<FluidModifier> fluidModifiers = importedPenis.testicle.cum.fluidModifiers;
+		handleLoadingOfModifiers(FluidModifier.values(), log, cumModifiers, fluidModifiers);
 
 		
 		// **************** Skin **************** //
@@ -1220,16 +1177,10 @@ public class Body implements Serializable, XMLSaving {
 		
 		Element vaginaModifiers = (Element)vagina.getElementsByTagName("vaginaModifiers").item(0);
 		
-		importedVagina.orificeVagina.orificeModifiers.clear();
+		Collection<OrificeModifier> vaginaOrificeModifiers = importedVagina.orificeVagina.orificeModifiers;
+		vaginaOrificeModifiers.clear();
 		if(vaginaModifiers!=null) {
-			for(OrificeModifier om : OrificeModifier.values()) {
-				if(Boolean.valueOf(vaginaModifiers.getAttribute(om.toString()))) {
-					importedVagina.orificeVagina.orificeModifiers.add(om);
-					CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":true");
-				} else {
-					CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":false");
-				}
-			}
+			handleLoadingOfModifiers(OrificeModifier.values(), log, vaginaModifiers, vaginaOrificeModifiers);
 		}
 		
 		try {
@@ -1243,18 +1194,11 @@ public class Body implements Serializable, XMLSaving {
 				importedVagina.orificeUrethra.virgin = true;
 			}
 			
-			urethraModifiers = (Element)vagina.getElementsByTagName("urethraModifiers").item(0);
+			urethraModifiersElement = (Element)vagina.getElementsByTagName("urethraModifiers").item(0);
 			
-			importedVagina.orificeUrethra.orificeModifiers.clear();
-			for(OrificeModifier om : OrificeModifier.values()) {
-				if(Boolean.valueOf(urethraModifiers.getAttribute(om.toString()))) {
-					importedVagina.orificeUrethra.orificeModifiers.add(om);
-					CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":true");
-				} else {
-					CharacterUtils.appendToImportLog(log, "</br>"+om.toString()+":false");
-				}
-			}
-			
+			Collection<OrificeModifier> vaginaUrethraOrificeModifiers = importedVagina.orificeUrethra.orificeModifiers;
+			vaginaUrethraOrificeModifiers.clear();
+			handleLoadingOfModifiers(OrificeModifier.values(), log, urethraModifiersElement, vaginaUrethraOrificeModifiers);
 		} catch(Exception ex) {
 		}
 		
@@ -1267,16 +1211,9 @@ public class Body implements Serializable, XMLSaving {
 				" flavour: "+importedVagina.girlcum.getFlavour()
 				+ "</br>Modifiers:");
 		
-		Element girlcumModifiers = (Element)girlcum.getElementsByTagName("girlcumModifiers").item(0);
-		for(FluidModifier fm : FluidModifier.values()) {
-			if(Boolean.valueOf(girlcumModifiers.getAttribute(fm.toString()))) {
-				importedVagina.girlcum.fluidModifiers.add(fm);
-				CharacterUtils.appendToImportLog(log, "</br>"+fm.toString()+":true");
-			} else {
-				CharacterUtils.appendToImportLog(log, "</br>"+fm.toString()+":false");
-			}
-		}
-
+		Element girlcumModifiersElement = (Element)girlcum.getElementsByTagName("girlcumModifiers").item(0);
+		Collection<FluidModifier> girlcumFluidModifiers = importedVagina.girlcum.fluidModifiers;
+		handleLoadingOfModifiers(FluidModifier.values(), log, girlcumModifiersElement, girlcumFluidModifiers);
 		
 		// **************** Wing **************** //
 		
@@ -1384,6 +1321,23 @@ public class Body implements Serializable, XMLSaving {
 		body.calculateRace();
 		
 		return body;
+	}
+
+	private static <T extends Enum<T>> void handleLoadingOfModifiers(T[] enumValues, StringBuilder log, Element modifiersElement, Collection<T> modifiers) {
+		for(T enumValue : enumValues) {
+			String attributeValue = modifiersElement.getAttribute(enumValue.toString());
+			if(Boolean.valueOf(attributeValue)) {
+				if (!modifiers.contains(enumValue)) {
+					modifiers.add(enumValue);
+				}
+				CharacterUtils.appendToImportLog(log, "</br>"+enumValue.toString()+":true");
+			} else if (!attributeValue.isEmpty()) {
+				modifiers.remove(enumValue);
+				CharacterUtils.appendToImportLog(log, "</br>"+enumValue.toString()+":false");
+			} else {
+				CharacterUtils.appendToImportLog(log, "</br>"+enumValue.toString()+":not present, defaulted to "+modifiers.contains(enumValue));
+			}
+		}
 	}
 	
 	

--- a/src/com/lilithsthrone/game/character/body/FluidCum.java
+++ b/src/com/lilithsthrone/game/character/body/FluidCum.java
@@ -68,7 +68,11 @@ public class FluidCum implements BodyPartInterface, Serializable, XMLSaving {
 		Element cumModifiers = (Element)cum.getElementsByTagName("cumModifiers").item(0);
 		for(FluidModifier fm : FluidModifier.values()) {
 			if(Boolean.valueOf(cumModifiers.getAttribute(fm.toString()))) {
-				fluidCum.fluidModifiers.add(fm);
+				if (!fluidCum.hasFluidModifier(fm)) {
+					fluidCum.fluidModifiers.add(fm);
+				}
+			} else if (!cumModifiers.getAttribute(fm.toString()).isEmpty()) {
+				fluidCum.fluidModifiers.remove(fm);
 			}
 		}
 		


### PR DESCRIPTION
This fixes #427 - most of the bug is already described there. Basically, the game used to load modifiers from a type, but then also from the modifiers themselves. This PR alters the loading to only add modifiers if they're not present already, and if the modifiers are present and the savefile says the character doesn't have them, they're removed.

Tested on ad09d08835661cc5c983016a31025e52f79e4652 (0.2.4.5), although I didn't test all the cases.

**As a result, This needs a proper review.**