### PR TITLE
fix softlock caused by opening options menu during examining alexandria in intro

### DIFF
--- a/src/com/lilithsthrone/controller/MainController.java
+++ b/src/com/lilithsthrone/controller/MainController.java
@@ -195,9 +195,10 @@ public class MainController implements Initializable {
 			Main.game.restoreSavedContent();
 			
 		} else if (!Main.game.getCurrentDialogueNode().isOptionsDisabled()) {
-			if (Main.game.getCurrentDialogueNode().getDialogueNodeType() == DialogueNodeType.NORMAL
-					|| Main.game.getCurrentDialogueNode().getDialogueNodeType() == DialogueNodeType.SLAVERY_MANAGEMENT
-					|| !Main.game.isInNewWorld()) {
+			DialogueNodeType currentDialogueNodeType = Main.game.getCurrentDialogueNode().getDialogueNodeType();
+			if (currentDialogueNodeType == DialogueNodeType.NORMAL
+					|| currentDialogueNodeType == DialogueNodeType.SLAVERY_MANAGEMENT
+					|| (!Main.game.isInNewWorld() && currentDialogueNodeType != DialogueNodeType.CHARACTERS_PRESENT)) {
 				Main.game.saveDialogueNode();
 			}
 			


### PR DESCRIPTION
Opening character examination in intro causes saved dialogue node
Opening options causes saving current dialogue node

This overwrites the previous dialogue node, making you stuck

Solution; don't save when opening options when in character examination in intro