### PR TITLE
Increase utiltext parse performance

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -4568,73 +4568,65 @@ public class UtilText {
 	private static String parseSyntaxNew(String target, String command, String arguments, List<GameCharacter> specialNPCList) {
 		
 		UtilText.specialNPCList = specialNPCList;
-		parseCapitalise=false;
-		parseAddPronoun=false;
+		parseCapitalise = false;
+		parseAddPronoun = false;
 		
 		if(command.split("_").length==2) {
 			if(Character.isUpperCase(command.split("_")[0].charAt(0)))
 				parseCapitalise = true;
 			command = command.split("_")[1];
-			if(Character.isUpperCase(command.charAt(0)))
-				parseCapitalise = true;
 			parseAddPronoun = true;
+		} 
 			
-		} else {
-			if(Character.isUpperCase(command.charAt(0)))
-				parseCapitalise = true;
+		if(Character.isUpperCase(command.charAt(0))) {
+			parseCapitalise = true;
 		}
 		
-		String output = "";
-		boolean commandFound=false;
-		
-		boolean characterFound = false;
-		targetLoop:
-		for(ParserTarget parserTarget : ParserTarget.values()) {
-			for(String s : parserTarget.getTags()) {
-				if(s.toLowerCase().equals(target.toLowerCase())) {
-					character = parserTarget.getCharacter(s.toLowerCase());
-					characterFound = true;
-					break targetLoop;
-				}
-			}
-//			if(parserTarget.getTags().contains(target.toLowerCase())) {
-//				character = parserTarget.getCharacter();
-//				characterFound = true;
-//				break;
-//			}
-		}
-		if(!characterFound) {
+		ParserTarget parserTarget = findParserTargetWithTag(target);
+		if (parserTarget == null) {
 			return "INVALID_TARGET_NAME";
 		}
+		character = parserTarget.getCharacter(target.toLowerCase());
 		
 		// Commands with arguments:
-		
-		hibikeEuphoniumIsTheBest:
-		for(ParserCommand cmd : commandsList) {
-			for(String s : cmd.getTags()) {
-				if(command.equalsIgnoreCase(s)) {
-					commandFound=true;
-					output = cmd.parse(command, arguments, target);
-					if (!cmd.isAllowsCapitalisation()) {
-						parseCapitalise = false;
-					}
-					if (!cmd.isAllowsPronoun()) {
-						parseAddPronoun = false;
-					}
-					break hibikeEuphoniumIsTheBest;
-				}
-			}
+		ParserCommand cmd = findCommandWithTag(command);
+		if (cmd == null) {
+			return "<i style='color:"+Colour.GENERIC_BAD.toWebHexString()+";'>command_unknown</i>";
 		}
 		
-		if(!commandFound)
-			return "<i style='color:"+Colour.GENERIC_BAD.toWebHexString()+";'>command_unknown</i>";
+		String output = cmd.parse(command, arguments, target);
+		parseCapitalise = parseCapitalise && cmd.isAllowsCapitalisation();
+		parseAddPronoun = parseAddPronoun && cmd.isAllowsPronoun();
 		
 		if(parseAddPronoun) {
 			output = (UtilText.isVowel(output.charAt(0))?"an ":"a ")+output;
-			return (parseCapitalise?Util.capitaliseSentence(output):output);
-		} else {
-			return (parseCapitalise?Util.capitaliseSentence(output):output);
 		}
+		if (parseCapitalise) {
+			return Util.capitaliseSentence(output);
+		}
+		return output;
+	}
+
+	private static ParserTarget findParserTargetWithTag(String target) {
+		for(ParserTarget parserTarget : ParserTarget.values()) {
+			for(String s : parserTarget.getTags()) {
+				if(s.toLowerCase().equals(target.toLowerCase())) {
+					return parserTarget;
+				}
+			}
+		}
+		return null;
+	}
+
+	private static ParserCommand findCommandWithTag(String command) {
+		for(ParserCommand cmd : commandsList) {
+			for(String s : cmd.getTags()) {
+				if(command.equalsIgnoreCase(s)) {
+					return cmd;
+				}
+			}
+		}
+		return null;
 	}
 	
 	private static String parseConditionalSyntaxNew(String target, String command, String arguments, String conditionalTrue, String conditionalFalse) {
@@ -4642,20 +4634,11 @@ public class UtilText {
 			target = "npc";
 		}
 		
-		boolean characterFound = false;
-		targetLoop:
-		for(ParserTarget parserTarget : ParserTarget.values()) {
-			for(String s : parserTarget.getTags()) {
-				if(s.toLowerCase().equals(target.toLowerCase())) {
-					character = parserTarget.getCharacter(s.toLowerCase());
-					characterFound = true;
-					break targetLoop;
-				}
-			}
-		}
-		if(!characterFound) {
+		ParserTarget parserTarget = findParserTargetWithTag(target);
+		if (parserTarget == null) {
 			return "INVALID_TARGET_NAME";
 		}
+		character = parserTarget.getCharacter(target.toLowerCase());
 		
 		// Commands with arguments:
 		

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -732,11 +732,12 @@ public class UtilText {
 					System.err.println("Error in parsing: StartIndex:"+startIndex+" ("+target+", "+command+")");
 					return input;
 				}
-				return parse(specialNPC, input.substring(0, startIndex)
+				return input.substring(0, startIndex) 
 						+ (processingConditional
-								?parseConditionalSyntaxNew(target, command, arguments, conditionalTrue, conditionalFalse)
-								:parseSyntaxNew(target, command, arguments, specialNPC))
-						+ input.substring(endIndex+1, input.length()));
+								? parseConditionalSyntaxNew(target, command, arguments, conditionalTrue, conditionalFalse)
+								: parseSyntaxNew(target, command, arguments, specialNPC))
+						+ parse(specialNPC, "" 
+								+input.substring(endIndex+1, input.length()));
 			} else {
 				return input;//.replaceAll(" a ", " <span style='color:"+Colour.GENERIC_SEX.toWebHexString()+";'>a big moo</span> ");
 			}

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -4232,12 +4232,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(character.getEyeType().getBodyCoveringType(character)).getFullDescription(character, true);
-					}
-				}
-				return character.getCovering(character.getEyeType().getBodyCoveringType(character)).getFullDescription(character, false);
+				return character.getCovering(character.getEyeType().getBodyCoveringType(character))
+						.getFullDescription(character, arguments != null && arguments.equalsIgnoreCase("true"));
 			}
 		});
 		
@@ -4254,12 +4250,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(character.getEyeType().getBodyCoveringType(character)).getColourDescriptor(character, true, parseCapitalise);
-					}
-				}
-				return character.getCovering(character.getEyeType().getBodyCoveringType(character)).getColourDescriptor(character, false, parseCapitalise);
+				return character.getCovering(character.getEyeType().getBodyCoveringType(character))
+						.getColourDescriptor(character, arguments != null && arguments.equalsIgnoreCase("true"), parseCapitalise);
 			}
 		});
 		
@@ -4280,12 +4272,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(character.getEyeType().getBodyCoveringType(character)).getPrimaryColourDescriptor(true);
-					}
-				}
-				return character.getCovering(character.getEyeType().getBodyCoveringType(character)).getPrimaryColourDescriptor(false);
+				return character.getCovering(character.getEyeType().getBodyCoveringType(character))
+						.getPrimaryColourDescriptor(arguments != null && arguments.equalsIgnoreCase("true"));
 			}
 		});
 
@@ -4306,12 +4294,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(character.getEyeType().getBodyCoveringType(character)).getSecondaryColourDescriptor(true);
-					}
-				}
-				return character.getCovering(character.getEyeType().getBodyCoveringType(character)).getSecondaryColourDescriptor(false);
+				return character.getCovering(character.getEyeType().getBodyCoveringType(character))
+						.getSecondaryColourDescriptor(arguments != null && arguments.equalsIgnoreCase("true"));
 			}
 		});
 		
@@ -4341,12 +4325,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(BodyCoveringType.EYE_PUPILS).getFullDescription(character, true);
-					}
-				}
-				return character.getCovering(BodyCoveringType.EYE_PUPILS).getFullDescription(character, false);
+				return character.getCovering(BodyCoveringType.EYE_PUPILS)
+						.getFullDescription(character, arguments != null && arguments.equalsIgnoreCase("true"));
 			}
 		});
 		
@@ -4363,12 +4343,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(BodyCoveringType.EYE_PUPILS).getColourDescriptor(character, true, parseCapitalise);
-					}
-				}
-				return character.getCovering(BodyCoveringType.EYE_PUPILS).getColourDescriptor(character, false, parseCapitalise);
+				return character.getCovering(BodyCoveringType.EYE_PUPILS)
+						.getColourDescriptor(character, arguments != null && arguments.equalsIgnoreCase("true"), parseCapitalise);
 			}
 		});
 		
@@ -4389,12 +4365,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(BodyCoveringType.EYE_PUPILS).getPrimaryColourDescriptor(true);
-					}
-				}
-				return character.getCovering(BodyCoveringType.EYE_PUPILS).getPrimaryColourDescriptor(false);
+				return character.getCovering(BodyCoveringType.EYE_PUPILS)
+						.getPrimaryColourDescriptor(arguments != null && arguments.equalsIgnoreCase("true"));
 			}
 		});
 
@@ -4415,12 +4387,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(BodyCoveringType.EYE_PUPILS).getSecondaryColourDescriptor(true);
-					}
-				}
-				return character.getCovering(BodyCoveringType.EYE_PUPILS).getSecondaryColourDescriptor(false);
+				return character.getCovering(BodyCoveringType.EYE_PUPILS)
+						.getSecondaryColourDescriptor(arguments != null && arguments.equalsIgnoreCase("true"));
 			}
 		});
 		
@@ -4435,12 +4403,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(BodyCoveringType.EYE_SCLERA).getFullDescription(character, true);
-					}
-				}
-				return character.getCovering(BodyCoveringType.EYE_SCLERA).getFullDescription(character, false);
+				return character.getCovering(BodyCoveringType.EYE_SCLERA)
+						.getFullDescription(character, arguments != null && arguments.equalsIgnoreCase("true"));
 			}
 		});
 		
@@ -4457,12 +4421,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(BodyCoveringType.EYE_SCLERA).getColourDescriptor(character, true, parseCapitalise);
-					}
-				}
-				return character.getCovering(BodyCoveringType.EYE_SCLERA).getColourDescriptor(character, false, parseCapitalise);
+				return character.getCovering(BodyCoveringType.EYE_SCLERA)
+						.getColourDescriptor(character, arguments != null && arguments.equalsIgnoreCase("true"), parseCapitalise);
 			}
 		});
 		
@@ -4483,12 +4443,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(BodyCoveringType.EYE_SCLERA).getPrimaryColourDescriptor(true);
-					}
-				}
-				return character.getCovering(BodyCoveringType.EYE_SCLERA).getPrimaryColourDescriptor(false);
+				return character.getCovering(BodyCoveringType.EYE_SCLERA)
+						.getPrimaryColourDescriptor(arguments != null && arguments.equalsIgnoreCase("true"));
 			}
 		});
 
@@ -4509,12 +4465,8 @@ public class UtilText {
 				BodyPartType.EYE){//TODO
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments!=null) {
-					if(arguments.equalsIgnoreCase("true")) {
-						return character.getCovering(BodyCoveringType.EYE_SCLERA).getSecondaryColourDescriptor(true);
-					}
-				}
-				return character.getCovering(BodyCoveringType.EYE_SCLERA).getSecondaryColourDescriptor(false);
+				return character.getCovering(BodyCoveringType.EYE_SCLERA)
+						.getSecondaryColourDescriptor(arguments != null && arguments.equalsIgnoreCase("true"));
 			}
 		});
 		

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -485,12 +485,11 @@ public class UtilText {
 		return femaleCumNames[Util.random.nextInt(femaleCumNames.length)];
 	}
 
-	private static List<String> randomStrings = new ArrayList<>();
 	/**
 	 * @return Returns one of the supplied Strings, randomly chosen by using Random's nextInt() method.
 	 */
 	public static String returnStringAtRandom(String... strings) {
-		randomStrings.clear();
+		List<String> randomStrings = new ArrayList<>();
 		
 		for(String s : strings) {
 			if(s!=null && !s.isEmpty()) {


### PR DESCRIPTION
### Purpose
Improve performance and fix crashes/infinite loops with npcs being called [npc.name].

### Description
I described this on discord:
parsing works by scanning the entire string, then looking for the first executable section, then doing that and starting over from the beginning.
Lower bound complexity is O(n); it has to check each character to find 0 ['s.
Upper bound is infinite loop, as seen when pc.name is [pc.name].
Pretending there are no infinite loops and commands don't output commands,
Upper bound would be O(n^n)
thus if we feed it large slabs of text we're screwed
but here's what I wonder
provided that the output shouldn't contain commands...
why would you need to parse the things you already parsed?
Thus I will try to see what happens if I get rid of the "and start over from the beginning"
```
Before
Took 598.196056 for input of length 2770447
Took 583.028787 for input of length 2770447
Took 566.70835 for input of length 2770447
Took 426.148428 for input of length 2770447
Took 514.132226 for input of length 2770447

After
Took 381.883276 for input of length 2770447
Took 262.659686 for input of length 2770447
Took 296.367686 for input of length 2770447
Took 232.573062 for input of length 2770447
Took 198.476419 for input of length 2770447
```
This is about opening the fetishes screen
and it's in milliseconds

Next, of course, I wonder if the command output really needs to be parsed again
And the answer seems to be "no", although this has no real visible effect in parse times(edited)
It should, however, stop people from creating infinite loops.
meaning you can now call people [npc.name] without the game exploding
I think we should have this in a beta release or something; the non-exe release
I mean, I'm absolutely sure that "not parsing things again you've already found to not contain any commands", that's correct
but "not parsing the result of commands" might not be
The main thing I'm worried of is things like [style.colourPink(feminine)] style things
like, one insertion has occured, but it still needed coloring

### Graphical assets required
None

### Tested?
Yes, on 0261d14169c96f2060f04daae627cb84cf5e12f8 (0.2.5.5 pre-release)