### PR TITLE
Rental Mommy Punctuation Fixes

### DIFF
--- a/res/txt/characters/dominion/rentalMommy.xml
+++ b/res/txt/characters/dominion/rentalMommy.xml
@@ -44,7 +44,7 @@
 	<htmlContent tag="MOMMYS_EXTRAS"><![CDATA[
 	<p>
 		[pc.speech(That sounds kind of nice...)]
-		 You find yourself answering.
+		 you find yourself answering.
 	</p>
 	<p>
 		[npc.speech(Well, fifty flames, and you can find out just how nice it is!)] Mommy cheerfully replies, before patting her plump thighs once more.
@@ -79,21 +79,21 @@
 	
 	<htmlContent tag="MOMMY_HOUSE_ENTRY_BREASTFEEDING"><![CDATA[
 	<p>
-		[pc.speech(Mommy, could I have some milk?)] You ask, producing five hundred flames before handing them over to the [npc.name].
+		[pc.speech(Mommy, could I have some milk?)] you ask, producing five hundred flames before handing them over to the [npc.name].
 	</p>
 	]]>
 	</htmlContent>
 	
 	<htmlContent tag="MOMMY_HOUSE_ENTRY_SEX_SUB"><![CDATA[
 	<p>
-		[pc.speech(Mommy, could I help you to have some fun?)] You ask, producing one thousand flames before handing them over to the [npc.name].
+		[pc.speech(Mommy, could I help you to have some fun?)] you ask, producing one thousand flames before handing them over to the [npc.name].
 	</p>
 	]]>
 	</htmlContent>
 	
 	<htmlContent tag="MOMMY_HOUSE_ENTRY_SEX_DOM"><![CDATA[
 	<p>
-		[pc.speech(Mommy, I'd like to show you a good time.)] You say, producing two thousand flames before handing them over to the [npc.name].
+		[pc.speech(Mommy, I'd like to show you a good time,)] you say, producing two thousand flames before handing them over to the [npc.name].
 	</p>
 	]]>
 	</htmlContent>
@@ -113,14 +113,14 @@
 	
 	<htmlContent tag="MOMMY_SEX_SUB"><![CDATA[
 	<p>
-		[npc.speech(Good [pc.girl]!)] She cheerfully exclaims. [npc.speech(Now, let Mommy take good care of you...)]
+		[npc.speech(Good [pc.girl]!)] she cheerfully exclaims. [npc.speech(Now, let Mommy take good care of you...)]
 	</p>
 	]]>
 	</htmlContent>
 	
 	<htmlContent tag="MOMMY_SEX_DOM"><![CDATA[
 	<p>
-		[npc.speech(Good [pc.girl]!)] She cheerfully exclaims. [npc.speech(Now, show me how you want to treat your Mommy...)]
+		[npc.speech(Good [pc.girl]!)] she cheerfully exclaims. [npc.speech(Now, show me how you want to treat your Mommy...)]
 	</p>
 	]]>
 	</htmlContent>
@@ -141,7 +141,7 @@
 	
 	<htmlContent tag="MOMMYS_EXTRAS_BREASTFEEDING"><![CDATA[
 	<p>
-		[npc.speech(Good [pc.girl]!)] She cheerfully exclaims. [npc.speech(Now, come over here and take a seat!)]
+		[npc.speech(Good [pc.girl]!)] she cheerfully exclaims. [npc.speech(Now, come over here and take a seat!)]
 	</p>
 	<p>
 		You obediently follow Mommy as she steps back and leads you over to the nearest sofa. Pulling you down onto the cushions next to her, Mommy turns and beams at you, before lifting up her t-shirt. [npc.speech(Mommy's nice and full and today, so you make sure to drink as much milk as you want!)]
@@ -165,14 +165,14 @@
 		You smile at Mommy as she clips her bra back into place, before pulling her t-shirt back down over her head. Taking hold of your hand, she then leads you back outside, before planting a wet kiss on your cheek and giving your [pc.ass] a little slap. [npc.speech(Run along now, and please do visit if you get hungry again!)]
 	</p>
 	<p>
-		[pc.speech(I will!)] You call out to Mommy, before continuing on your way down Dominion's boulevard.
+		[pc.speech(I will!)] you call out to Mommy, before continuing on your way down Dominion's boulevard.
 	</p>
 	]]>
 	</htmlContent>
 	
 	<htmlContent tag="MOMMYS_EXTRAS_BREASTFEEDING_PUBLIC"><![CDATA[
 	<p>
-		[pc.speech(Mommy, could I have some milk out here?)] You ask, before handing over one thousand flames.
+		[pc.speech(Mommy, could I have some milk out here?)] you ask, before handing over one thousand flames.
 	</p>
 	<p>
 		[npc.speech(Of course, sweetie!)] Mommy happily replies, while continuing to stroke your head. [npc.speech(Mommy's nice and full and today, so you make sure to drink as much milk as you want!)]
@@ -196,7 +196,7 @@
 		You smile at Mommy as she clips her bra's cups back into place, before pulling her t-shirt back down over her breasts. As you sit up on the bench, Mommy leans over to plant a wet kiss on your cheek, before giving your head a little pat. [npc.speech(Run along now, and please do visit if you get hungry again!)]
 	</p>
 	<p>
-		[pc.speech(I will!)] You call out to Mommy, before standing up and continuing on your way down Dominion's boulevard.
+		[pc.speech(I will!)] you call out to Mommy, before standing up and continuing on your way down Dominion's boulevard.
 	</p>
 	]]>
 	</htmlContent>
@@ -229,20 +229,20 @@
 		You do as Mommy says, tidying up the lounge so that it's in the same state as when you entered. Once you're done, Mommy takes hold of your hand, before leading you back outside, planting a wet kiss on your cheek, and giving your [pc.ass] a little slap. [npc.speech(Run along now, and please do visit Mommy again!)]
 	</p>
 	<p>
-		[pc.speech(I will!)] You call out to Mommy, before continuing on your way down Dominion's boulevard.
+		[pc.speech(I will!)] you call out to Mommy, before continuing on your way down Dominion's boulevard.
 	</p>
 	]]>
 	</htmlContent>
 	
 	<htmlContent tag="AFTER_SEX_MOMMY_AS_SUB_END"><![CDATA[
 	<p>
-		[npc.speech(Now, you sit still while Mommy tidies up her lounge, like a good [pc.girl].)] Mommy says, smiling lovingly at you.
+		[npc.speech(Now, you sit still while Mommy tidies up her lounge, like a good [pc.girl],)] Mommy says, smiling lovingly at you.
 	</p>
 	<p>
 		You do as Mommy says, sitting down on one of her sofas as she tidies up the lounge. Once she's done, Mommy takes hold of your hand, before leading you back outside, planting a wet kiss on your cheek, and giving your [pc.ass] a little slap. [npc.speech(Run along now, and please do visit Mommy again!)]
 	</p>
 	<p>
-		[pc.speech(I will!)] You call out to Mommy, before continuing on your way down Dominion's boulevard.
+		[pc.speech(I will!)] you call out to Mommy, before continuing on your way down Dominion's boulevard.
 	</p>
 	]]>
 	</htmlContent>


### PR DESCRIPTION
Just some quick dialogue punctuation corrections for the Mother's Day event.

Remember, a dialogue tag coming after the dialogue itself begins in lowercase, even if the dialogue ended on a question mark, exclamation mark or ellipsis.