### PR TITLE
Fix Incubus ignoring genital feminisation choices

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/npcDialogue/dominion/DominionSuccubusDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/npcDialogue/dominion/DominionSuccubusDialogue.java
@@ -427,6 +427,7 @@ public class DominionSuccubusDialogue {
 					@Override
 					public void effects() {
 						Main.game.getActiveNPC().getPlayerKnowsAreas().add(CoverableArea.PENIS);
+						Main.game.getActiveNPC().setPenisType(PenisType.NONE);
 						Main.game.getTextStartStringBuilder().append(
 								"<p>"
 								+ "Not really liking the idea of [npc.name] having a cock, you tell [npc.herHim] as much, "
@@ -590,6 +591,7 @@ public class DominionSuccubusDialogue {
 					@Override
 					public void effects() {
 						Main.game.getActiveNPC().getPlayerKnowsAreas().add(CoverableArea.VAGINA);
+						Main.game.getActiveNPC().setVaginaType(VaginaType.DEMON_COMMON);
 						Main.game.getTextStartStringBuilder().append(
 								"<p>"
 								+ "Wanting to make sure that [npc.she]'s got a nice demonic pussy, you order [npc.herHim], "


### PR DESCRIPTION
Fix for #490 and #519. The choices for "No dick" and "Vagina" didn't actually do anything, presumably a relic of when the encounter was _just_ succubi, and they would have female genitals to begin with.