### PR TITLE
Clean BodyCoveringType via BodyCoveringTemplateFactory

### DIFF
--- a/src/com/lilithsthrone/game/character/body/types/BodyCoveringTemplate.java
+++ b/src/com/lilithsthrone/game/character/body/types/BodyCoveringTemplate.java
@@ -1,0 +1,70 @@
+package com.lilithsthrone.game.character.body.types;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import com.lilithsthrone.game.character.body.valueEnums.CoveringModifier;
+import com.lilithsthrone.game.character.body.valueEnums.CoveringPattern;
+import com.lilithsthrone.utils.Colour;
+
+public class BodyCoveringTemplate {
+	public final String determiner; 
+	public final String namePlural;
+	public final String nameSingular;
+	public final List<CoveringModifier> naturalModifiers;
+	public final List<CoveringModifier> extraModifiers;
+	public final List<Colour> naturalColoursPrimary;
+	public final List<Colour> dyeColoursPrimary;
+	public final List<Colour> naturalColoursSecondary;
+	public final List<Colour> dyeColoursSecondary;
+	public final List<CoveringPattern> naturalPatterns;
+	public final List<CoveringPattern> dyePatterns;
+	public final boolean isDefaultPlural;
+
+	public BodyCoveringTemplate(
+			String determiner,
+			boolean isDefaultPlural,
+			String namePlural,
+			String nameSingular,
+			List<CoveringModifier> naturalModifiers,
+			List<CoveringModifier> extraModifiers,
+			List<CoveringPattern> naturalPatterns,
+			List<CoveringPattern> dyePatterns,
+			List<Colour> naturalColoursPrimary,
+			List<Colour> dyeColoursPrimary,
+			List<Colour> naturalColoursSecondary,
+			List<Colour> dyeColoursSecondary) {
+		
+		this.determiner = determiner;
+		this.namePlural = namePlural;
+		this.nameSingular = nameSingular;
+		this.isDefaultPlural = isDefaultPlural;
+		
+		this.naturalModifiers = getImmutableListFromNullableList(naturalModifiers);
+		this.extraModifiers = getImmutableListFromNullableList(extraModifiers);
+		this.naturalPatterns = getImmutableListFromNullableList(naturalPatterns, () -> Arrays.asList(CoveringPattern.NONE));
+		List<CoveringPattern> dyePatternsList = getListFromNullableList(dyePatterns);
+		dyePatternsList.removeAll(this.naturalPatterns);
+		this.dyePatterns = Collections.unmodifiableList(dyePatternsList);
+		this.naturalColoursPrimary = getImmutableListFromNullableList(naturalColoursPrimary);
+		this.dyeColoursPrimary = getImmutableListFromNullableList(dyeColoursPrimary);
+		this.naturalColoursSecondary = getImmutableListFromNullableList(naturalColoursSecondary);
+		this.dyeColoursSecondary = getImmutableListFromNullableList(dyeColoursSecondary);
+	}
+	
+	private <T> List<T> getImmutableListFromNullableList(List<T> nullableList) {
+		return Collections.unmodifiableList(getListFromNullableList(nullableList));
+	}
+	
+	private <T> List<T> getImmutableListFromNullableList(List<T> nullableList, Supplier<List<T>> replacement) {
+		return Collections.unmodifiableList(Optional.ofNullable(nullableList).orElseGet(replacement));
+	}
+	
+	private <T> List<T> getListFromNullableList(List<T> nullableList) {
+		return Optional.ofNullable(nullableList).orElse(new ArrayList<>());
+	}
+}

--- a/src/com/lilithsthrone/game/character/body/types/BodyCoveringTemplateFactory.java
+++ b/src/com/lilithsthrone/game/character/body/types/BodyCoveringTemplateFactory.java
@@ -1,0 +1,148 @@
+package com.lilithsthrone.game.character.body.types;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.lilithsthrone.game.character.body.valueEnums.CoveringModifier;
+import com.lilithsthrone.game.character.body.valueEnums.CoveringPattern;
+import com.lilithsthrone.utils.Colour;
+import com.lilithsthrone.utils.Util;
+
+public class BodyCoveringTemplateFactory {
+	
+	public static BodyCoveringTemplate createSkin(List<CoveringPattern> coverPatterns, List<Colour> naturalPrimaryColors, List<Colour> naturalSecondaryColours, List<Colour> dyeColours) {
+		return new BodyCoveringTemplate("a layer of",
+				false,
+				"skin",
+				"skin",
+				Util.newArrayListOfValues(CoveringModifier.SMOOTH),
+				null,
+				coverPatterns,
+				CoveringPattern.allStandardCoveringPatterns,
+				naturalPrimaryColors,
+				dyeColours,
+				naturalSecondaryColours,
+				dyeColours);
+	}
+	
+	public static BodyCoveringTemplate createTopSkin(List<CoveringPattern> coverPatterns, List<Colour> skinColors) {
+		return createSkin(coverPatterns, skinColors, skinColors, null);
+	}
+	
+	public static BodyCoveringTemplate createBottomSkin(List<Colour> skinColors) {
+		return createSkin(Util.newArrayListOfValues(CoveringPattern.NONE), skinColors, null, Colour.allSkinColours);
+	}
+	
+	public static BodyCoveringTemplate createSlime(CoveringPattern basePattern, List<CoveringPattern> coverPatterns) {
+		return new BodyCoveringTemplate("a layer of",
+				false,
+				"slime",
+				"slime",
+				Util.newArrayListOfValues(CoveringModifier.GOOEY),
+				null,
+				Util.newArrayListOfValues(basePattern),
+				coverPatterns,
+				Colour.allSlimeColours,
+				null,
+				Colour.allSlimeColours,
+				null);
+	}
+	
+	public static BodyCoveringTemplate createFurSkinHair(List<CoveringModifier> modifiers, List<CoveringPattern> patterns) {
+		return createHair("a layer of", "fur", modifiers, patterns);
+	}
+	
+	private static BodyCoveringTemplate createHair(String determiner, String name, List<CoveringModifier> modifiers, List<CoveringPattern> patterns) {
+		return new BodyCoveringTemplate(determiner,
+				false,
+				name,
+				name,
+				modifiers,
+				null,
+				patterns,
+				CoveringPattern.allHairCoveringPatterns,
+				Colour.naturalHairColours,
+				Colour.dyeHairColours,
+				Colour.naturalHairColours,
+				Colour.dyeHairColours);
+	}
+	
+	private static BodyCoveringTemplate createHairWithoutPatterns(String determiner, String name, CoveringModifier modifier) {
+		return createHair(determiner, name, Util.newArrayListOfValues(modifier), Util.newArrayListOfValues(CoveringPattern.NONE));
+	}
+	
+	public static BodyCoveringTemplate createHeadHair(CoveringModifier modifier) {
+		return createHairWithoutPatterns("a head of", "hair", modifier);
+	}
+	
+	public static BodyCoveringTemplate createFurHeadHair(CoveringModifier modifier) {
+		return createHairWithoutPatterns("a layer of", "hair", modifier);
+	}
+	
+	public static BodyCoveringTemplate createBodyHair(CoveringModifier modifier) {
+		return createHairWithoutPatterns("a layer of", "hair", modifier);
+	}
+	
+	public static BodyCoveringTemplate createElemental(String name, CoveringModifier modifier, Colour... naturalHairColours) {
+		return new BodyCoveringTemplate("",
+				false,
+				name,
+				name,
+				Util.newArrayListOfValues(modifier),
+				null,
+				Util.newArrayListOfValues(CoveringPattern.NONE),
+				null,
+				Arrays.asList(naturalHairColours),
+				null,
+				null,
+				null);
+	}
+	
+	public static BodyCoveringTemplate createOrificeSkin(CoveringPattern pattern) {
+		return new BodyCoveringTemplate("a layer of",
+				false,
+				"skin",
+				"skin",
+				Util.newArrayListOfValues(CoveringModifier.SMOOTH),
+				null,
+				pattern == null ? null : Util.newArrayListOfValues(pattern),
+				null,
+				Colour.allSkinColours,
+				null,
+				Util.newArrayListOfValues(Colour.ORIFICE_INTERIOR),
+				Colour.allSkinColours);
+	}
+	
+	private static BodyCoveringTemplate createEyeIrisesWithCustomColors(List<Colour> naturalIrisColors, List<Colour> dyeIrisColours, boolean heteroIsExtra) {
+		List<CoveringPattern> natural = Util.newArrayListOfValues(CoveringPattern.EYE_IRISES, CoveringPattern.EYE_IRISES_HETEROCHROMATIC);
+		List<CoveringPattern> extra = null;
+		if (heteroIsExtra) {
+			natural = Util.newArrayListOfValues(CoveringPattern.EYE_IRISES);
+			extra = Util.newArrayListOfValues(CoveringPattern.EYE_IRISES_HETEROCHROMATIC);
+		}
+		return new BodyCoveringTemplate("a pair of",
+				true,
+				"eyes",
+				"eye",
+				Util.newArrayListOfValues(CoveringModifier.EYE),
+				null,
+				natural,
+				extra,
+				naturalIrisColors,
+				dyeIrisColours,
+				naturalIrisColors,
+				dyeIrisColours);
+	}
+	
+	public static BodyCoveringTemplate createEyeIrisesWithCustomColors(List<Colour> naturalIrisColours, List<Colour> dyeIrisColours) {
+		return createEyeIrisesWithCustomColors(naturalIrisColours, dyeIrisColours, true);
+	}
+	
+	public static BodyCoveringTemplate createEyeIrises() {
+		return createEyeIrisesWithCustomColors(Colour.naturalIrisColours, Colour.dyeIrisColours, true);
+	}
+	
+	public static BodyCoveringTemplate createEyeIrisesHeterochromiaNaturallyOccuring() {
+		return createEyeIrisesWithCustomColors(Colour.naturalIrisColours, Colour.dyeIrisColours, false);
+	}
+}

--- a/src/com/lilithsthrone/game/character/body/types/BodyCoveringType.java
+++ b/src/com/lilithsthrone/game/character/body/types/BodyCoveringType.java
@@ -19,33 +19,13 @@ public enum BodyCoveringType {
 
 	// Skin shades go light->dark
 
-	HUMAN("a layer of",
-			false,
-			"skin",
-			"skin",
-			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE,
-					CoveringPattern.FRECKLED),
-			CoveringPattern.allStandardCoveringPatterns,
-			Colour.humanSkinColours,
-			null,
-			Colour.humanSkinColours,
-			null),
-
-	ANGEL("a layer of",
-			false,
-			"skin",
-			"skin",
-			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
-			null,
+	HUMAN(BodyCoveringTemplateFactory.createTopSkin(
+			Util.newArrayListOfValues(CoveringPattern.NONE, CoveringPattern.FRECKLED),
+			Colour.humanSkinColours)),
+	
+	ANGEL(BodyCoveringTemplateFactory.createTopSkin(
 			Util.newArrayListOfValues(CoveringPattern.NONE),
-			CoveringPattern.allStandardCoveringPatterns,
-			Colour.humanSkinColours,
-			null,
-			Colour.humanSkinColours,
-			null),
+			Colour.humanSkinColours)),
 
 	ANGEL_FEATHER("a layer of",
 			true,
@@ -60,179 +40,58 @@ public enum BodyCoveringType {
 			Util.newArrayListOfValues(Colour.FEATHERS_WHITE),
 			Colour.allFeatherColours),
 	
-	DEMON_COMMON("a layer of",
-			false,
-			"skin",
-			"skin",
-			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allStandardCoveringPatterns,
-			Colour.demonSkinColours,
-			null,
-			Colour.demonSkinColours,
-			null),
-
-	IMP("a layer of",
-			false,
-			"skin",
-			"skin",
-			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allStandardCoveringPatterns,
-			Colour.demonSkinColours,
-			null,
-			Colour.demonSkinColours,
-			null),
-
-	BAT_SKIN("a layer of",
-			false,
-			"skin",
-			"skin",
-			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allStandardCoveringPatterns,
-			Colour.humanSkinColours,
-			Colour.allSkinColours,
-			null,
-			Colour.allSkinColours),
+	DEMON_COMMON(BodyCoveringTemplateFactory.createTopSkin(
+			Util.newArrayListOfValues(CoveringPattern.NONE),
+			Colour.demonSkinColours)),
 	
-	BAT_FUR("a layer of",
-			false,
-			"fur",
-			"fur",
-			Util.newArrayListOfValues(
-					CoveringModifier.SHORT),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours),
+	IMP(BodyCoveringTemplateFactory.createTopSkin(
+			Util.newArrayListOfValues(CoveringPattern.NONE),
+			Colour.demonSkinColours)),
+
+
+	BAT_SKIN(BodyCoveringTemplateFactory.createBottomSkin(Colour.humanSkinColours)),
 	
-	CANINE_FUR("a layer of",
-			false,
-			"fur",
-			"fur",
+	BAT_FUR(BodyCoveringTemplateFactory.createFurSkinHair(
+			Util.newArrayListOfValues(CoveringModifier.SHORT),
+			Util.newArrayListOfValues(CoveringPattern.NONE))),
+	
+	CANINE_FUR(BodyCoveringTemplateFactory.createFurSkinHair(
 			Util.newArrayListOfValues(
 					CoveringModifier.FLUFFY,
 					CoveringModifier.SHORT,
 					CoveringModifier.SHAGGY),
-			null,
 			Util.newArrayListOfValues(
 					CoveringPattern.NONE,
 					CoveringPattern.MARKED,
-					CoveringPattern.SPOTTED),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours),
+					CoveringPattern.SPOTTED))),
 	
-	LYCAN_FUR("a layer of",
-			false,
-			"fur",
-			"fur",
-			Util.newArrayListOfValues(
-					CoveringModifier.SHAGGY),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours),
+	LYCAN_FUR(BodyCoveringTemplateFactory.createFurSkinHair(Util.newArrayListOfValues(CoveringModifier.SHAGGY), null)),
 
-	FELINE_FUR("a layer of",
-			false,
-			"fur",
-			"fur",
+	FELINE_FUR(BodyCoveringTemplateFactory.createFurSkinHair(
 			Util.newArrayListOfValues(
 					CoveringModifier.SMOOTH,
 					CoveringModifier.FLUFFY),
-			null,
 			Util.newArrayListOfValues(
 					CoveringPattern.NONE,
 					CoveringPattern.MOTTLED,
 					CoveringPattern.SPOTTED,
 					CoveringPattern.MARKED,
 					CoveringPattern.STRIPED,
-					CoveringPattern.HIGHLIGHTS),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours),
+					CoveringPattern.HIGHLIGHTS))),
 
-	SQUIRREL_FUR("a layer of",
-			false,
-			"fur",
-			"fur",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours),
-
-	RAT_SKIN("a layer of",
-			false,
-			"skin",
-			"skin",
-			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allStandardCoveringPatterns,
-			Colour.ratSkinColours,
-			Colour.allSkinColours,
-			null,
-			Colour.allSkinColours),
+	SQUIRREL_FUR(BodyCoveringTemplateFactory.createFurSkinHair(Util.newArrayListOfValues(CoveringModifier.SMOOTH), null)),
 	
-	RAT_FUR("a layer of",
-			false,
-			"fur",
-			"fur",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours),
+	RAT_SKIN(BodyCoveringTemplateFactory.createBottomSkin(Colour.ratSkinColours)),
+	
+	RAT_FUR(BodyCoveringTemplateFactory.createFurSkinHair(Util.newArrayListOfValues(CoveringModifier.SMOOTH), null)),
 
-	RABBIT_FUR("a layer of",
-			false,
-			"fur",
-			"fur",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours),
+	RABBIT_FUR(BodyCoveringTemplateFactory.createFurSkinHair(Util.newArrayListOfValues(CoveringModifier.SMOOTH), null)),
 	
 	HORSE_HAIR("a layer of",
 			false,
 			"hair",
 			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.SHORT),
+			Util.newArrayListOfValues(CoveringModifier.SHORT),
 			null,
 			Util.newArrayListOfValues(
 					CoveringPattern.NONE,
@@ -246,46 +105,25 @@ public enum BodyCoveringType {
 			Colour.naturalFurColours,
 			Colour.dyeFurColours),
 	
-	REINDEER_FUR("a layer of",
-			false,
-			"fur",
-			"fur",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours),
+	REINDEER_FUR(BodyCoveringTemplateFactory.createFurSkinHair(
+			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
+			Util.newArrayListOfValues(CoveringPattern.NONE))),
 	
-	BOVINE_FUR("a layer of",
-			false,
-			"fur",
-			"fur",
+	BOVINE_FUR(BodyCoveringTemplateFactory.createFurSkinHair(
 			Util.newArrayListOfValues(
 					CoveringModifier.SHORT,
 					CoveringModifier.SMOOTH),
-			null,
 			Util.newArrayListOfValues(
 					CoveringPattern.NONE,
 					CoveringPattern.MOTTLED,
 					CoveringPattern.SPOTTED,
-					CoveringPattern.MARKED),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours,
-			Colour.naturalFurColours,
-			Colour.dyeFurColours),
+					CoveringPattern.MARKED))),
 	
 	DILDO("a layer of", // This colour is set in GameCharacter's getCovering method, based on the colour of the dildo equipped.
 			false,
 			"silicone",
 			"silicone",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
+			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
 			null,
 			null,
 			null,
@@ -294,452 +132,80 @@ public enum BodyCoveringType {
 			ColourListPresets.ALL.getPresetColourList(),
 			null),
 	
-	PENIS("a layer of",
-			false,
-			"skin",
-			"skin",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
-			null,
-			null,
-			null,
-			Colour.allSkinColours,
-			null,
-			Util.newArrayListOfValues(
-					Colour.ORIFICE_INTERIOR),
-			Colour.allSkinColours),
+	PENIS(BodyCoveringTemplateFactory.createOrificeSkin(null)),
 
-	ANUS("a layer of",
-			false,
-			"skin",
-			"skin",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.ORIFICE_ANUS),
-			null,
-			Colour.allSkinColours,
-			null,
-			Util.newArrayListOfValues(
-					Colour.ORIFICE_INTERIOR),
-			Colour.allSkinColours),
+	ANUS(BodyCoveringTemplateFactory.createOrificeSkin(CoveringPattern.ORIFICE_ANUS)),
 	
-	MOUTH("a layer of",
-			false,
-			"skin",
-			"skin",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.ORIFICE_MOUTH),
-			null,
-			Colour.allSkinColours,
-			null,
-			Util.newArrayListOfValues(
-					Colour.ORIFICE_INTERIOR),
-			Colour.allSkinColours),
+	MOUTH(BodyCoveringTemplateFactory.createOrificeSkin(CoveringPattern.ORIFICE_MOUTH)),
 	
-	NIPPLES("a layer of",
-			false,
-			"skin",
-			"skin",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.ORIFICE_NIPPLE),
-			null,
-			Colour.allSkinColours,
-			null,
-			Util.newArrayListOfValues(
-					Colour.ORIFICE_INTERIOR),
-			Colour.allSkinColours),
+	NIPPLES(BodyCoveringTemplateFactory.createOrificeSkin(CoveringPattern.ORIFICE_NIPPLE)),
 	
-	VAGINA("a layer of",
-			false,
-			"skin",
-			"skin",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.ORIFICE_VAGINA),
-			null,
-			Colour.allSkinColours,
-			null,
-			Util.newArrayListOfValues(
-					Colour.ORIFICE_INTERIOR),
-			Colour.allSkinColours),
+	VAGINA(BodyCoveringTemplateFactory.createOrificeSkin(CoveringPattern.ORIFICE_VAGINA)),
 	
 
-	FIRE("",
-			false,
-			"flames",
-			"flames",
-			Util.newArrayListOfValues(
-					CoveringModifier.BLAZING),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
+	FIRE(BodyCoveringTemplateFactory.createElemental("flames", CoveringModifier.BLAZING, 
 					Colour.COVERING_ORANGE,
-					Colour.COVERING_BLUE_LIGHT),
-			null,
-			null,
-			null),
-	FIRE_HAIR("",
-			false,
-			"flames",
-			"flames",
-			Util.newArrayListOfValues(
-					CoveringModifier.BLAZING),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_ORANGE,
-					Colour.COVERING_BLUE_LIGHT),
-			null,
-			null,
-			null),
+					Colour.COVERING_BLUE_LIGHT)),
 	
-	WATER("",
-			false,
-			"water",
-			"water",
-			Util.newArrayListOfValues(
-					CoveringModifier.SHIMMERING),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_BLUE,
-					Colour.COVERING_BLUE_LIGHT),
-			null,
-			null,
-			null),
-	WATER_HAIR("",
-			false,
-			"water",
-			"water",
-			Util.newArrayListOfValues(
-					CoveringModifier.SHIMMERING),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_BLUE,
-					Colour.COVERING_BLUE_LIGHT),
-			null,
-			null,
-			null),
+	FIRE_HAIR(BodyCoveringTemplateFactory.createElemental("flames", CoveringModifier.BLAZING, 
+			Colour.COVERING_ORANGE,
+			Colour.COVERING_BLUE_LIGHT)),
+	
+	WATER(BodyCoveringTemplateFactory.createElemental("water", CoveringModifier.SHIMMERING, 
+			Colour.COVERING_BLUE,
+			Colour.COVERING_BLUE_LIGHT)),
+	
+	WATER_HAIR(BodyCoveringTemplateFactory.createElemental("water", CoveringModifier.SHIMMERING, 
+			Colour.COVERING_BLUE,
+			Colour.COVERING_BLUE_LIGHT)),
 
-	ICE("",
-			false,
-			"ice",
-			"ice",
-			Util.newArrayListOfValues(
-					CoveringModifier.SHIMMERING),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_BLUE_LIGHT),
-			null,
-			null,
-			null),
-	ICE_HAIR("",
-			false,
-			"ice",
-			"ice",
-			Util.newArrayListOfValues(
-					CoveringModifier.SHIMMERING),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_BLUE_LIGHT),
-			null,
-			null,
-			null),
+	ICE(BodyCoveringTemplateFactory.createElemental("ice", CoveringModifier.SHIMMERING, Colour.COVERING_BLUE_LIGHT)),
+	
+	ICE_HAIR(BodyCoveringTemplateFactory.createElemental("ice", CoveringModifier.SHIMMERING, Colour.COVERING_BLUE_LIGHT)),
 
-	AIR("",
-			false,
-			"vapours",
-			"vapours",
-			Util.newArrayListOfValues(
-					CoveringModifier.SWIRLING),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_BLUE_LIGHT),
-			null,
-			null,
-			null),
-	AIR_HAIR("",
-			false,
-			"vapours",
-			"vapours",
-			Util.newArrayListOfValues(
-					CoveringModifier.SWIRLING),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_BLUE_LIGHT),
-			null,
-			null,
-			null),
+	AIR(BodyCoveringTemplateFactory.createElemental("vapours", CoveringModifier.SWIRLING, Colour.COVERING_BLUE_LIGHT)),
+	
+	AIR_HAIR(BodyCoveringTemplateFactory.createElemental("vapours", CoveringModifier.SWIRLING, Colour.COVERING_BLUE_LIGHT)),
 
-	STONE("",
-			false,
-			"stone",
-			"stone",
-			Util.newArrayListOfValues(
-					CoveringModifier.MATTE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_GREY),
-			null,
-			null,
-			null),
-	STONE_HAIR("",
-			false,
-			"stone",
-			"stone",
-			Util.newArrayListOfValues(
-					CoveringModifier.MATTE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_GREY),
-			null,
-			null,
-			null),
+	STONE(BodyCoveringTemplateFactory.createElemental("stone", CoveringModifier.MATTE, Colour.COVERING_GREY)),
+	
+	STONE_HAIR(BodyCoveringTemplateFactory.createElemental("stone", CoveringModifier.MATTE, Colour.COVERING_GREY)),
 
-	RUBBER("",
-			false,
-			"rubber",
-			"rubber",
-			Util.newArrayListOfValues(
-					CoveringModifier.GLOSSY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_BLACK),
-			null,
-			null,
-			null),
-	RUBBER_HAIR("",
-			false,
-			"rubber",
-			"rubber",
-			Util.newArrayListOfValues(
-					CoveringModifier.GLOSSY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_BLACK),
-			null,
-			null,
-			null),
+	RUBBER(BodyCoveringTemplateFactory.createElemental("rubber", CoveringModifier.GLOSSY, Colour.COVERING_BLACK)),
+	
+	RUBBER_HAIR(BodyCoveringTemplateFactory.createElemental("rubber", CoveringModifier.GLOSSY, Colour.COVERING_BLACK)),
 
-	ARCANE("",
-			false,
-			"energy",
-			"energy",
-			Util.newArrayListOfValues(
-					CoveringModifier.SWIRLING),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_PINK),
-			null,
-			null,
-			null),
-	ARCANE_HAIR("",
-			false,
-			"energy",
-			"energy",
-			Util.newArrayListOfValues(
-					CoveringModifier.SWIRLING),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_PINK),
-			null,
-			null,
-			null),
+	ARCANE(BodyCoveringTemplateFactory.createElemental("energy", CoveringModifier.SWIRLING, Colour.COVERING_PINK)),
+	
+	ARCANE_HAIR(BodyCoveringTemplateFactory.createElemental("energy", CoveringModifier.SWIRLING, Colour.COVERING_PINK)),
 	
 	
-	SLIME("a layer of",
-			false,
-			"slime",
-			"slime",
-			Util.newArrayListOfValues(
-					CoveringModifier.GOOEY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allStandardCoveringPatterns,
-			Colour.allSlimeColours,
-			null,
-			Colour.allSlimeColours,
-			null),
+	SLIME(BodyCoveringTemplateFactory.createSlime(CoveringPattern.NONE, CoveringPattern.allStandardCoveringPatterns)),
 
-	SLIME_EYE("a layer of",
-			false,
-			"slime",
-			"slime",
-			Util.newArrayListOfValues(
-					CoveringModifier.GOOEY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.allSlimeColours,
-			null,
-			Colour.allSlimeColours,
-			null),
+	SLIME_EYE(BodyCoveringTemplateFactory.createSlime(CoveringPattern.EYE_IRISES,
+			Util.newArrayListOfValues(CoveringPattern.EYE_IRISES_HETEROCHROMATIC))),
 	
-	SLIME_PUPILS("a layer of",
-			false,
-			"slime",
-			"slime",
-			Util.newArrayListOfValues(
-					CoveringModifier.GOOEY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_PUPILS),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_PUPILS_HETEROCHROMATIC),
-			Colour.allSlimeColours,
-			null,
-			Colour.allSlimeColours,
-			null),
+	SLIME_PUPILS(BodyCoveringTemplateFactory.createSlime(CoveringPattern.EYE_PUPILS,
+			Util.newArrayListOfValues(CoveringPattern.EYE_PUPILS_HETEROCHROMATIC))),
 	
-	SLIME_SCLERA("a layer of",
-			false,
-			"slime",
-			"slime",
-			Util.newArrayListOfValues(
-					CoveringModifier.GOOEY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_SCLERA),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_SCLERA_HETEROCHROMATIC),
-			Colour.allSlimeColours,
-			null,
-			Colour.allSlimeColours,
-			null),
+	SLIME_SCLERA(BodyCoveringTemplateFactory.createSlime(CoveringPattern.EYE_SCLERA,
+			Util.newArrayListOfValues(CoveringPattern.EYE_SCLERA_HETEROCHROMATIC))),
 	
-	SLIME_HAIR("a layer of",
-			false,
-			"slime",
-			"slime",
-			Util.newArrayListOfValues(
-					CoveringModifier.GOOEY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.allSlimeColours,
-			null,
-			Colour.allSlimeColours,
-			null),
+	SLIME_HAIR(BodyCoveringTemplateFactory.createSlime(CoveringPattern.NONE, CoveringPattern.allHairCoveringPatterns)),
 	
-	SLIME_ANUS("a layer of",
-			false,
-			"slime",
-			"slime",
-			Util.newArrayListOfValues(
-					CoveringModifier.GOOEY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.ORIFICE_ANUS),
-			null,
-			Colour.allSlimeColours,
-			null,
-			Colour.allSlimeColours,
-			null),
+	SLIME_ANUS(BodyCoveringTemplateFactory.createSlime(CoveringPattern.ORIFICE_ANUS, null)),
 	
-	SLIME_MOUTH("a layer of",
-			false,
-			"slime",
-			"slime",
-			Util.newArrayListOfValues(
-					CoveringModifier.GOOEY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.ORIFICE_MOUTH),
-			null,
-			Colour.allSlimeColours,
-			null,
-			Colour.allSlimeColours,
-			null),
+	SLIME_MOUTH(BodyCoveringTemplateFactory.createSlime(CoveringPattern.ORIFICE_MOUTH, null)),
 	
-	SLIME_NIPPLES("a layer of",
-			false,
-			"slime",
-			"slime",
-			Util.newArrayListOfValues(
-					CoveringModifier.GOOEY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.ORIFICE_NIPPLE),
-			null,
-			Colour.allSlimeColours,
-			null,
-			Colour.allSlimeColours,
-			null),
+	SLIME_NIPPLES(BodyCoveringTemplateFactory.createSlime(CoveringPattern.ORIFICE_NIPPLE, null)),
 	
-	SLIME_VAGINA("a layer of",
-			false,
-			"slime",
-			"slime",
-			Util.newArrayListOfValues(
-					CoveringModifier.GOOEY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.ORIFICE_VAGINA),
-			null,
-			Colour.allSlimeColours,
-			null,
-			Colour.allSlimeColours,
-			null),
+	SLIME_VAGINA(BodyCoveringTemplateFactory.createSlime(CoveringPattern.ORIFICE_VAGINA, null)),
 
 	FEATHERS("a layer of",
 			true,
 			"feathers",
 			"feather",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
+			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
 			null,
 			Util.newArrayListOfValues(
 					CoveringPattern.NONE,
@@ -757,11 +223,9 @@ public enum BodyCoveringType {
 			true,
 			"scales",
 			"scale",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
+			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
+			Util.newArrayListOfValues(CoveringPattern.NONE),
 			CoveringPattern.allScalesCoveringPatterns,
 			Colour.naturalScaleColours,
 			Colour.dyeScaleColours,
@@ -774,8 +238,7 @@ public enum BodyCoveringType {
 			false,
 			"keratin",
 			"keratin",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
+			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
 			null,
 			null,
 			CoveringPattern.allScalesCoveringPatterns,
@@ -788,8 +251,7 @@ public enum BodyCoveringType {
 			false,
 			"velvet",
 			"velvet",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
+			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
 			null,
 			null,
 			CoveringPattern.allScalesCoveringPatterns,
@@ -802,236 +264,50 @@ public enum BodyCoveringType {
 			false,
 			"skin",
 			"skin",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
+			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
 			null,
 			null,
 			CoveringPattern.allStandardCoveringPatterns,
-			Util.newArrayListOfValues(
-					Colour.ORIFICE_INTERIOR),
+			Util.newArrayListOfValues(Colour.ORIFICE_INTERIOR),
 			Colour.allSkinColours,
-			Util.newArrayListOfValues(
-					Colour.ORIFICE_INTERIOR),
+			Util.newArrayListOfValues(Colour.ORIFICE_INTERIOR),
 			Colour.allSkinColours),
 
 	// HAIR:
 
-	HAIR_HUMAN("a head of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
-
-	HAIR_ANGEL("a head of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.SILKEN),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
-
-	HAIR_DEMON("a head of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.SILKEN),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
-
-	HAIR_IMP("a head of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.SILKEN),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	HAIR_HUMAN(BodyCoveringTemplateFactory.createHeadHair(CoveringModifier.SMOOTH)),
 	
-	HAIR_CANINE_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	HAIR_ANGEL(BodyCoveringTemplateFactory.createHeadHair(CoveringModifier.SILKEN)),
 
-	HAIR_LYCAN_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	HAIR_DEMON(BodyCoveringTemplateFactory.createHeadHair(CoveringModifier.SILKEN)),
 
-	HAIR_FELINE_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
-
-	HAIR_HORSE_HAIR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.COARSE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
-
-	HAIR_REINDEER_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.COARSE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
-
-	HAIR_BOVINE_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.COARSE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
-
-	HAIR_SQUIRREL_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
-
-	HAIR_RAT_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
-
-	HAIR_RABBIT_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	HAIR_IMP(BodyCoveringTemplateFactory.createHeadHair(CoveringModifier.SILKEN)),
 	
-	HAIR_BAT_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	HAIR_CANINE_FUR(BodyCoveringTemplateFactory.createFurHeadHair(CoveringModifier.FURRY)),
+
+	HAIR_LYCAN_FUR(BodyCoveringTemplateFactory.createFurHeadHair(CoveringModifier.FURRY)),
+
+	HAIR_FELINE_FUR(BodyCoveringTemplateFactory.createFurHeadHair(CoveringModifier.FURRY)),
+
+	HAIR_HORSE_HAIR(BodyCoveringTemplateFactory.createFurHeadHair(CoveringModifier.COARSE)),
+
+	HAIR_REINDEER_FUR(BodyCoveringTemplateFactory.createFurHeadHair(CoveringModifier.COARSE)),
+
+	HAIR_BOVINE_FUR(BodyCoveringTemplateFactory.createFurHeadHair(CoveringModifier.COARSE)),
+
+	HAIR_SQUIRREL_FUR(BodyCoveringTemplateFactory.createFurHeadHair(CoveringModifier.FURRY)),
+
+	HAIR_RAT_FUR(BodyCoveringTemplateFactory.createFurHeadHair(CoveringModifier.FURRY)),
+
+	HAIR_RABBIT_FUR(BodyCoveringTemplateFactory.createFurHeadHair(CoveringModifier.FURRY)),
+	
+	HAIR_BAT_FUR(BodyCoveringTemplateFactory.createFurHeadHair(CoveringModifier.FURRY)),
 	
 	HAIR_HARPY("a plume of",
 			true,
 			"feathers",
 			"feather",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
+			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
 			null,
 			CoveringPattern.allHairCoveringPatterns,
 			null,
@@ -1040,226 +316,44 @@ public enum BodyCoveringType {
 			Colour.allFeatherColours,
 			null),
 	
-	HAIR_SCALES_ALLIGATOR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.COARSE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	HAIR_SCALES_ALLIGATOR(BodyCoveringTemplateFactory.createFurHeadHair(CoveringModifier.COARSE)), //Why do alligators have hair?!
 	
 	
 	// BODY HAIR:
 	
-	BODY_HAIR_HUMAN("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.COARSE),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_HUMAN(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.COARSE)),
 
-	BODY_HAIR_ANGEL("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.SILKEN),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_ANGEL(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.SILKEN)),
 
-	BODY_HAIR_DEMON("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.SILKEN),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_DEMON(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.SILKEN)),
 
-	BODY_HAIR_IMP("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.SILKEN),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_IMP(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.SILKEN)),
 
-	BODY_HAIR_CANINE_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_CANINE_FUR(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.FURRY)),
 
-	BODY_HAIR_LYCAN_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_LYCAN_FUR(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.FURRY)),
 
-	BODY_HAIR_FELINE_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_FELINE_FUR(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.FURRY)),
 
-	BODY_HAIR_HORSE_HAIR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.COARSE),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_HORSE_HAIR(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.COARSE)),
 
-	BODY_HAIR_REINDEER_HAIR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.COARSE),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_REINDEER_HAIR(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.COARSE)),
 
-	BODY_HAIR_BOVINE_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.COARSE),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_BOVINE_FUR(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.COARSE)),
 
-	BODY_HAIR_SQUIRREL_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_SQUIRREL_FUR(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.FURRY)),
 
-	BODY_HAIR_RAT_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_RAT_FUR(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.FURRY)),
 
-	BODY_HAIR_RABBIT_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_RABBIT_FUR(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.FURRY)),
 	
-	BODY_HAIR_BAT_FUR("a layer of",
-			false,
-			"hair",
-			"hair",
-			Util.newArrayListOfValues(
-					CoveringModifier.FURRY),
-			null,
-			null,
-			CoveringPattern.allHairCoveringPatterns,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours,
-			Colour.naturalHairColours,
-			Colour.dyeHairColours),
+	BODY_HAIR_BAT_FUR(BodyCoveringTemplateFactory.createBodyHair(CoveringModifier.FURRY)),
 	
 	BODY_HAIR_HARPY("a plume of",
 			true,
 			"feathers",
 			"feather",
-			Util.newArrayListOfValues(
-					CoveringModifier.FLUFFY),
+			Util.newArrayListOfValues(CoveringModifier.FLUFFY),
 			null,
 			null,
 			CoveringPattern.allHairCoveringPatterns,
@@ -1272,8 +366,7 @@ public enum BodyCoveringType {
 			false,
 			"scales",
 			"scale",
-			Util.newArrayListOfValues(
-					CoveringModifier.SMOOTH),
+			Util.newArrayListOfValues(CoveringModifier.SMOOTH),
 			null,
 			null,
 			CoveringPattern.allStandardCoveringPatterns,
@@ -1285,274 +378,51 @@ public enum BodyCoveringType {
 
 	
 	// EYES:
-
-	EYE_HUMAN("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES,
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			null,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
-
-	EYE_ANGEL("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
-
-	EYE_DEMON_COMMON("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalDemonIrisColours,
-			Colour.dyeDemonIrisColours,
-			Colour.naturalDemonIrisColours,
-			Colour.dyeDemonIrisColours),
-
-	EYE_IMP("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalDemonIrisColours,
-			Colour.dyeDemonIrisColours,
-			Colour.naturalDemonIrisColours,
-			Colour.dyeDemonIrisColours),
 	
-	EYE_DOG_MORPH("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
+	EYE_HUMAN(BodyCoveringTemplateFactory.createEyeIrisesHeterochromiaNaturallyOccuring()),
 
-	EYE_LYCAN("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalPredatorIrisColours,
-			Colour.dyePredatorIrisColours,
-			Colour.naturalPredatorIrisColours,
-			Colour.dyePredatorIrisColours),
+	EYE_ANGEL(BodyCoveringTemplateFactory.createEyeIrises()),
 
-	EYE_FELINE("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalPredatorIrisColours,
-			Colour.dyePredatorIrisColours,
-			Colour.naturalPredatorIrisColours,
-			Colour.dyePredatorIrisColours),
+	EYE_DEMON_COMMON(BodyCoveringTemplateFactory.createEyeIrisesWithCustomColors(
+			Colour.naturalDemonIrisColours, Colour.dyeDemonIrisColours)),
 
-	EYE_SQUIRREL("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
-
-	EYE_RAT("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
-
-	EYE_RABBIT("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
+	EYE_IMP(BodyCoveringTemplateFactory.createEyeIrisesWithCustomColors(
+			Colour.naturalDemonIrisColours, Colour.dyeDemonIrisColours)),
 	
-	EYE_BAT("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
+	EYE_DOG_MORPH(BodyCoveringTemplateFactory.createEyeIrises()),
+
+	EYE_LYCAN(BodyCoveringTemplateFactory.createEyeIrisesWithCustomColors(
+			Colour.naturalPredatorIrisColours, Colour.dyePredatorIrisColours)),
+
+	EYE_FELINE(BodyCoveringTemplateFactory.createEyeIrisesWithCustomColors(
+			Colour.naturalPredatorIrisColours, Colour.dyePredatorIrisColours)),
+
+	EYE_SQUIRREL(BodyCoveringTemplateFactory.createEyeIrises()),
+
+	EYE_RAT(BodyCoveringTemplateFactory.createEyeIrises()),
+
+	EYE_RABBIT(BodyCoveringTemplateFactory.createEyeIrises()),
 	
-	EYE_ALLIGATOR_MORPH("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
+	EYE_BAT(BodyCoveringTemplateFactory.createEyeIrises()),
+	
+	EYE_ALLIGATOR_MORPH(BodyCoveringTemplateFactory.createEyeIrises()),
 
-	EYE_HORSE_MORPH("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
+	EYE_HORSE_MORPH(BodyCoveringTemplateFactory.createEyeIrises()),
 
-	EYE_REINDEER_MORPH("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
+	EYE_REINDEER_MORPH(BodyCoveringTemplateFactory.createEyeIrises()),
 
-	EYE_COW_MORPH("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
+	EYE_COW_MORPH(BodyCoveringTemplateFactory.createEyeIrises()),
 
-	EYE_HARPY("a pair of",
-			true,
-			"eyes",
-			"eye",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
-			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_IRISES_HETEROCHROMATIC),
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours,
-			Colour.naturalIrisColours,
-			Colour.dyeIrisColours),
+	EYE_HARPY(BodyCoveringTemplateFactory.createEyeIrises()),
 
 	EYE_PUPILS("a pair of",
 			true,
 			"pupils",
 			"pupil",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
+			Util.newArrayListOfValues(CoveringModifier.EYE),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_PUPILS),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_PUPILS_HETEROCHROMATIC),
+			Util.newArrayListOfValues(CoveringPattern.EYE_PUPILS),
+			Util.newArrayListOfValues(CoveringPattern.EYE_PUPILS_HETEROCHROMATIC),
 			Colour.naturalPupilColours,
 			Colour.dyePupilColours,
 			Colour.naturalPupilColours,
@@ -1562,13 +432,10 @@ public enum BodyCoveringType {
 			true,
 			"sclerae",
 			"sclera",
-			Util.newArrayListOfValues(
-					CoveringModifier.EYE),
+			Util.newArrayListOfValues(CoveringModifier.EYE),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_SCLERA),
-			Util.newArrayListOfValues(
-					CoveringPattern.EYE_SCLERA_HETEROCHROMATIC),
+			Util.newArrayListOfValues(CoveringPattern.EYE_SCLERA),
+			Util.newArrayListOfValues(CoveringPattern.EYE_SCLERA_HETEROCHROMATIC),
 			Colour.naturalScleraColours,
 			Colour.dyeScleraColours,
 			Colour.naturalScleraColours,
@@ -1580,14 +447,11 @@ public enum BodyCoveringType {
 			false,
 			"cum",
 			"cum",
-			Util.newArrayListOfValues(
-					CoveringModifier.FLUID),
+			Util.newArrayListOfValues(CoveringModifier.FLUID),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.FLUID),
+			Util.newArrayListOfValues(CoveringPattern.FLUID),
 			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_WHITE),
+			Util.newArrayListOfValues(Colour.COVERING_WHITE),
 			Util.newArrayListOfValues(
 					Colour.COVERING_CLEAR,
 					Colour.COVERING_BROWN,
@@ -1603,14 +467,11 @@ public enum BodyCoveringType {
 			false,
 			"girlcum",
 			"girlcum",
-			Util.newArrayListOfValues(
-					CoveringModifier.FLUID),
+			Util.newArrayListOfValues(CoveringModifier.FLUID),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.FLUID),
+			Util.newArrayListOfValues(CoveringPattern.FLUID),
 			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_CLEAR),
+			Util.newArrayListOfValues(Colour.COVERING_CLEAR),
 			Util.newArrayListOfValues(
 					Colour.COVERING_WHITE,
 					Colour.COVERING_BROWN,
@@ -1626,14 +487,11 @@ public enum BodyCoveringType {
 			false,
 			"milk",
 			"milk",
-			Util.newArrayListOfValues(
-					CoveringModifier.FLUID),
+			Util.newArrayListOfValues(CoveringModifier.FLUID),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.FLUID),
+			Util.newArrayListOfValues(CoveringPattern.FLUID),
 			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_WHITE),
+			Util.newArrayListOfValues(Colour.COVERING_WHITE),
 			Util.newArrayListOfValues(
 					Colour.COVERING_CLEAR,
 					Colour.COVERING_BROWN,
@@ -1651,14 +509,11 @@ public enum BodyCoveringType {
 			false,
 			"blusher",
 			"blusher",
-			Util.newArrayListOfValues(
-					CoveringModifier.MAKEUP),
+			Util.newArrayListOfValues(CoveringModifier.MAKEUP),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
+			Util.newArrayListOfValues(CoveringPattern.NONE),
 			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_NONE),
+			Util.newArrayListOfValues(Colour.COVERING_NONE),
 			Util.newArrayListOfValues(
 					Colour.COVERING_RED,
 					Colour.COVERING_RED_DARK,
@@ -1682,14 +537,11 @@ public enum BodyCoveringType {
 			false,
 			"eye liner",
 			"eye liner",
-			Util.newArrayListOfValues(
-					CoveringModifier.MAKEUP),
+			Util.newArrayListOfValues(CoveringModifier.MAKEUP),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
+			Util.newArrayListOfValues(CoveringPattern.NONE),
 			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_NONE),
+			Util.newArrayListOfValues(Colour.COVERING_NONE),
 			Util.newArrayListOfValues(
 					Colour.COVERING_RED,
 					Colour.COVERING_RED_DARK,
@@ -1718,11 +570,9 @@ public enum BodyCoveringType {
 					CoveringModifier.SPARKLY,
 					CoveringModifier.METALLIC),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
+			Util.newArrayListOfValues(CoveringPattern.NONE),
 			null,
-			Util.newArrayListOfValues(
-					Colour.COVERING_NONE),
+			Util.newArrayListOfValues(Colour.COVERING_NONE),
 			Util.newArrayListOfValues(
 					Colour.COVERING_RED,
 					Colour.COVERING_RED_DARK,
@@ -1752,13 +602,11 @@ public enum BodyCoveringType {
 					CoveringModifier.SPARKLY,
 					CoveringModifier.METALLIC),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
+			Util.newArrayListOfValues(CoveringPattern.NONE),
 			Util.newArrayListOfValues(
 					CoveringPattern.SPOTTED,
 					CoveringPattern.STRIPED),
-			Util.newArrayListOfValues(
-					Colour.COVERING_NONE),
+			Util.newArrayListOfValues(Colour.COVERING_NONE),
 			Util.newArrayListOfValues(
 					Colour.COVERING_CLEAR,
 					Colour.COVERING_RED,
@@ -1804,13 +652,11 @@ public enum BodyCoveringType {
 					CoveringModifier.SPARKLY,
 					CoveringModifier.METALLIC),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
+			Util.newArrayListOfValues(CoveringPattern.NONE),
 			Util.newArrayListOfValues(
 					CoveringPattern.SPOTTED,
 					CoveringPattern.STRIPED),
-			Util.newArrayListOfValues(
-					Colour.COVERING_NONE),
+			Util.newArrayListOfValues(Colour.COVERING_NONE),
 			Util.newArrayListOfValues(
 					Colour.COVERING_CLEAR,
 					Colour.COVERING_RED,
@@ -1856,13 +702,11 @@ public enum BodyCoveringType {
 					CoveringModifier.SPARKLY,
 					CoveringModifier.METALLIC),
 			null,
-			Util.newArrayListOfValues(
-					CoveringPattern.NONE),
+			Util.newArrayListOfValues(CoveringPattern.NONE),
 			Util.newArrayListOfValues(
 					CoveringPattern.SPOTTED,
 					CoveringPattern.STRIPED),
-			Util.newArrayListOfValues(
-					Colour.COVERING_NONE),
+			Util.newArrayListOfValues(Colour.COVERING_NONE),
 			Util.newArrayListOfValues(
 					Colour.COVERING_CLEAR,
 					Colour.COVERING_RED,
@@ -1901,11 +745,55 @@ public enum BodyCoveringType {
 					Colour.COVERING_SILVER,
 					Colour.COVERING_BLACK));
 	
-	private String determiner, namePlural, nameSingular;
-	private List<CoveringModifier> naturalModifiers, extraModifiers;
-	private List<Colour> naturalColoursPrimary, dyeColoursPrimary, naturalColoursSecondary, dyeColoursSecondary, allColours, allPrimaryColours, allSecondaryColours;
-	private List<CoveringPattern> naturalPatterns, dyePatterns, allPatterns;
+	private String determiner; 
+	private String namePlural;
+	private String nameSingular;
+	private List<CoveringModifier> naturalModifiers;
+	private List<CoveringModifier> extraModifiers;
+	private List<Colour> naturalColoursPrimary;
+	private List<Colour> dyeColoursPrimary;
+	private List<Colour> naturalColoursSecondary;
+	private List<Colour> dyeColoursSecondary;
+	private List<Colour> allColours;
+	private List<Colour> allPrimaryColours;
+	private List<Colour> allSecondaryColours;
+	private List<CoveringPattern> naturalPatterns;
+	private List<CoveringPattern> dyePatterns;
+	private List<CoveringPattern> allPatterns;
 	private boolean isDefaultPlural;
+	
+	private BodyCoveringType(BodyCoveringTemplate template) {
+		determiner = template.determiner;
+		namePlural = template.namePlural;
+		nameSingular = template.nameSingular;
+		naturalModifiers = template.naturalModifiers;
+		extraModifiers = template.extraModifiers;
+		naturalColoursPrimary = template.naturalColoursPrimary;
+		dyeColoursPrimary = template.dyeColoursPrimary;
+		naturalColoursSecondary = template.naturalColoursSecondary;
+		dyeColoursSecondary = template.dyeColoursSecondary;
+		naturalPatterns = template.naturalPatterns;
+		dyePatterns = template.dyePatterns;
+		isDefaultPlural = template.isDefaultPlural;
+		
+		allPatterns = new ArrayList<>();
+		allPatterns.addAll(naturalPatterns);
+		allPatterns.addAll(dyePatterns);
+		
+		allColours = new ArrayList<>();
+		allColours.addAll(naturalColoursPrimary);
+		allColours.addAll(dyeColoursPrimary);
+		allColours.addAll(naturalColoursSecondary);
+		allColours.addAll(dyeColoursSecondary);
+		
+		allPrimaryColours = new ArrayList<>();
+		allPrimaryColours.addAll(naturalColoursPrimary);
+		allPrimaryColours.addAll(dyeColoursPrimary);
+		
+		allSecondaryColours = new ArrayList<>();
+		allSecondaryColours.addAll(naturalColoursSecondary);
+		allSecondaryColours.addAll(dyeColoursSecondary);
+	}
 
 	private BodyCoveringType(
 			String determiner,


### PR DESCRIPTION
### Purpose
To get rid of duplication and simplify the process of adding new races.

### Changes
I allowed BodyCoveringType to be created based on a template, then made a template factory, allowing me to deduplicate values normally passed to the normal constructor.

### Testing
I booted the game up, went into some transformation menus, seems to work fine. Didn't test in detail.

I'd like to see this reviewed, specifically with regards to the names of the methods in the BodyCoveringTemplateFactory
