### PR TITLE
Add configuration of player character pronouns

### DIFF
--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -44,6 +44,7 @@ import com.lilithsthrone.game.settings.ForcedFetishTendency;
 import com.lilithsthrone.game.settings.ForcedTFTendency;
 import com.lilithsthrone.game.settings.KeyCodeWithModifiers;
 import com.lilithsthrone.game.settings.KeyboardAction;
+import com.lilithsthrone.game.settings.PlayerPronouns;
 import com.lilithsthrone.main.Main;
 
 /**
@@ -88,7 +89,8 @@ public class Properties implements Serializable {
 	public Map<KeyboardAction, KeyCodeWithModifiers> hotkeyMapPrimary, hotkeyMapSecondary;
 
 	public Map<GenderNames, String> genderNameFemale, genderNameMale, genderNameNeutral;
-	public Map<GenderPronoun, String> genderPronounFemale, genderPronounMale;
+	public Map<GenderPronoun, String> genderPronounFirst, genderPronounSecond, genderPronounFemale, genderPronounMale;
+	public PlayerPronouns playerPronouns = PlayerPronouns.SECOND_PERSON;
 	
 	public Map<Gender, Integer> genderPreferencesMap;
 	private Map<Subspecies, FurryPreference> subspeciesFeminineFurryPreferencesMap, subspeciesMasculineFurryPreferencesMap;
@@ -124,10 +126,14 @@ public class Properties implements Serializable {
 			genderNameNeutral.put(gn, gn.getNeutral());
 		}
 		
+		genderPronounFirst = new EnumMap<>(GenderPronoun.class);
+		genderPronounSecond = new EnumMap<>(GenderPronoun.class);
 		genderPronounFemale = new EnumMap<>(GenderPronoun.class);
 		genderPronounMale = new EnumMap<>(GenderPronoun.class);
 
 		for (GenderPronoun gp : GenderPronoun.values()) {
+			genderPronounFirst.put(gp, gp.getFirst());
+			genderPronounSecond.put(gp, gp.getSecond());
 			genderPronounFemale.put(gp, gp.getFeminine());
 			genderPronounMale.put(gp, gp.getMasculine());
 		}
@@ -210,6 +216,7 @@ public class Properties implements Serializable {
 			createXMLElementWithValue(doc, settings, "preferredArtist", preferredArtist);
 			
 			createXMLElementWithValue(doc, settings, "androgynousIdentification", String.valueOf(androgynousIdentification));
+			createXMLElementWithValue(doc, settings, "playerPronouns", String.valueOf(playerPronouns));
 			createXMLElementWithValue(doc, settings, "humanEncountersLevel", String.valueOf(humanEncountersLevel));
 			createXMLElementWithValue(doc, settings, "multiBreasts", String.valueOf(multiBreasts));
 			createXMLElementWithValue(doc, settings, "forcedTFPercentage", String.valueOf(forcedTFPercentage));
@@ -300,6 +307,20 @@ public class Properties implements Serializable {
 				Attr pronounName = doc.createAttribute("pronounName");
 				pronounName.setValue(gp.toString());
 				element.setAttributeNode(pronounName);
+
+				Attr firstValue = doc.createAttribute("firstValue");
+				if(genderPronounFirst.get(gp)!=null)
+					firstValue.setValue(genderPronounFirst.get(gp));
+				else
+					firstValue.setValue(gp.getFirst());
+				element.setAttributeNode(firstValue);
+
+				Attr secondValue = doc.createAttribute("secondValue");
+				if(genderPronounSecond.get(gp)!=null)
+					secondValue.setValue(genderPronounSecond.get(gp));
+				else
+					secondValue.setValue(gp.getSecond());
+				element.setAttributeNode(secondValue);
 				
 				Attr feminineValue = doc.createAttribute("feminineValue");
 				if(genderPronounFemale.get(gp)!=null)
@@ -553,6 +574,10 @@ public class Properties implements Serializable {
 					androgynousIdentification = AndrogynousIdentification.valueOf(((Element)element.getElementsByTagName("androgynousIdentification").item(0)).getAttribute("value"));
 				}
 				
+				if(element.getElementsByTagName("playerPronouns").item(0)!=null) {
+					playerPronouns = PlayerPronouns.valueOf(((Element)element.getElementsByTagName("playerPronouns").item(0)).getAttribute("value"));
+				}
+				
 				if(element.getElementsByTagName("humanEncountersLevel").item(0)!=null) {
 					humanEncountersLevel = Integer.valueOf(((Element)element.getElementsByTagName("humanEncountersLevel").item(0)).getAttribute("value"));
 				} else {
@@ -646,6 +671,18 @@ public class Properties implements Serializable {
 						Element e = ((Element)element.getElementsByTagName("pronoun").item(i));
 						
 						try {
+							if(!e.getAttribute("firstValue").isEmpty()) {
+								genderPronounFirst.put(GenderPronoun.valueOf(e.getAttribute("pronounName")), e.getAttribute("firstValue"));
+							} else {
+								genderPronounFirst.put(GenderPronoun.valueOf(e.getAttribute("pronounName")), GenderPronoun.valueOf(e.getAttribute("pronounName")).getFirst());
+							}
+
+							if(!e.getAttribute("secondValue").isEmpty()) {
+								genderPronounSecond.put(GenderPronoun.valueOf(e.getAttribute("pronounName")), e.getAttribute("secondValue"));
+							} else {
+								genderPronounSecond.put(GenderPronoun.valueOf(e.getAttribute("pronounName")), GenderPronoun.valueOf(e.getAttribute("pronounName")).getSecond());
+							}
+
 							if(!e.getAttribute("feminineValue").isEmpty()) {
 								genderPronounFemale.put(GenderPronoun.valueOf(e.getAttribute("pronounName")), e.getAttribute("feminineValue"));
 							} else {

--- a/src/com/lilithsthrone/game/character/gender/Gender.java
+++ b/src/com/lilithsthrone/game/character/gender/Gender.java
@@ -104,47 +104,98 @@ public enum Gender {
 	}
 
 	/**
-	 * Possessive: his, her
+	 * Dependent possessive pronoun: his, her
 	 */
-	public String getPossessiveBeforeNoun() {
-		if(isFeminine()) {
-			return Main.getProperties().genderPronounFemale.get(GenderPronoun.POSSESSIVE_BEFORE_NOUN);
-		} else {
-			return Main.getProperties().genderPronounMale.get(GenderPronoun.POSSESSIVE_BEFORE_NOUN);
+	public String getDependentPossessive() {
+		switch(Main.getProperties().playerPronouns) {
+			case FIRST_PERSON:
+				return Main.getProperties().genderPronounFirst.get(GenderPronoun.DEPENDENT_POSSESSIVE_PRONOUN);
+			case SECOND_PERSON:
+				return Main.getProperties().genderPronounSecond.get(GenderPronoun.DEPENDENT_POSSESSIVE_PRONOUN);
+			case THIRD_PERSON:
+				if(isFeminine()) {
+					return Main.getProperties().genderPronounFemale.get(GenderPronoun.DEPENDENT_POSSESSIVE_PRONOUN);
+				} else {
+					return Main.getProperties().genderPronounMale.get(GenderPronoun.DEPENDENT_POSSESSIVE_PRONOUN);
+				}
 		}
+		return "";
 	}
 
 	/**
-	 * Possessive: his, hers
+	 * Independent possessive pronoun: his, hers
 	 */
-	public String getPossessiveAlone() {
-		if(isFeminine()) {
-			return Main.getProperties().genderPronounFemale.get(GenderPronoun.POSSESSIVE_ALONE);
-		} else {
-			return Main.getProperties().genderPronounMale.get(GenderPronoun.POSSESSIVE_ALONE);
+	public String getIndependentPossessive() {
+		switch(Main.getProperties().playerPronouns) {
+			case FIRST_PERSON:
+				return Main.getProperties().genderPronounFirst.get(GenderPronoun.INDEPENDENT_POSSESSIVE_PRONOUN);
+			case SECOND_PERSON:
+				return Main.getProperties().genderPronounSecond.get(GenderPronoun.INDEPENDENT_POSSESSIVE_PRONOUN);
+			case THIRD_PERSON:
+				if(isFeminine()) {
+					return Main.getProperties().genderPronounFemale.get(GenderPronoun.INDEPENDENT_POSSESSIVE_PRONOUN);
+				} else {
+					return Main.getProperties().genderPronounMale.get(GenderPronoun.INDEPENDENT_POSSESSIVE_PRONOUN);
+				}
 		}
+		return "";
 	}
 
 	/**
-	 * Second person: he, she
+	 * Subjective pronoun: he, she
 	 */
-	public String getSecondPerson() {
-		if(isFeminine()) {
-			return Main.getProperties().genderPronounFemale.get(GenderPronoun.SECOND_PERSON);
-		} else {
-			return Main.getProperties().genderPronounMale.get(GenderPronoun.SECOND_PERSON);
+	public String getSubjective() {
+		switch(Main.getProperties().playerPronouns) {
+			case FIRST_PERSON:
+				return Main.getProperties().genderPronounFirst.get(GenderPronoun.SUBJECTIVE_PRONOUN);
+			case SECOND_PERSON:
+				return Main.getProperties().genderPronounSecond.get(GenderPronoun.SUBJECTIVE_PRONOUN);
+			case THIRD_PERSON:
+				if(isFeminine()) {
+					return Main.getProperties().genderPronounFemale.get(GenderPronoun.SUBJECTIVE_PRONOUN);
+				} else {
+					return Main.getProperties().genderPronounMale.get(GenderPronoun.SUBJECTIVE_PRONOUN);
+				}
 		}
+		return "";
 	}
 
 	/**
-	 * Pronoun: him, her
+	 * Objective pronoun: him, her
 	 */
-	public String getThirdPerson() {
-		if(isFeminine()) {
-			return Main.getProperties().genderPronounFemale.get(GenderPronoun.THIRD_PERSON);
-		} else {
-			return Main.getProperties().genderPronounMale.get(GenderPronoun.THIRD_PERSON);
+	public String getObjective() {
+		switch(Main.getProperties().playerPronouns) {
+			case FIRST_PERSON:
+				return Main.getProperties().genderPronounFirst.get(GenderPronoun.OBJECTIVE_PRONOUN);
+			case SECOND_PERSON:
+				return Main.getProperties().genderPronounSecond.get(GenderPronoun.OBJECTIVE_PRONOUN);
+			case THIRD_PERSON:
+				if(isFeminine()) {
+					return Main.getProperties().genderPronounFemale.get(GenderPronoun.OBJECTIVE_PRONOUN);
+				} else {
+					return Main.getProperties().genderPronounMale.get(GenderPronoun.OBJECTIVE_PRONOUN);
+				}
 		}
+		return "";
+	}
+
+	/**
+	 * Reflexive pronoun: himself, herself
+	 */
+	public String getReflexive() {
+		switch(Main.getProperties().playerPronouns) {
+			case FIRST_PERSON:
+				return Main.getProperties().genderPronounFirst.get(GenderPronoun.REFLEXIVE_PRONOUN);
+			case SECOND_PERSON:
+				return Main.getProperties().genderPronounSecond.get(GenderPronoun.REFLEXIVE_PRONOUN);
+			case THIRD_PERSON:
+				if(isFeminine()) {
+					return Main.getProperties().genderPronounFemale.get(GenderPronoun.REFLEXIVE_PRONOUN);
+				} else {
+					return Main.getProperties().genderPronounMale.get(GenderPronoun.REFLEXIVE_PRONOUN);
+				}
+		}
+		return "";
 	}
 
 	public GenderPreference getGenderPreferenceDefault() {

--- a/src/com/lilithsthrone/game/character/gender/GenderPronoun.java
+++ b/src/com/lilithsthrone/game/character/gender/GenderPronoun.java
@@ -7,24 +7,36 @@ package com.lilithsthrone.game.character.gender;
  */
 public enum GenderPronoun {
 
-	NOUN("Noun", "woman", "man", "person"),
-	YOUNG_NOUN("Young noun", "girl", "boy", "person"),
+	NOUN("Noun", "", "", "woman", "man", "person"),
+	YOUNG_NOUN("Young noun", "", "", "girl", "boy", "person"),
+
+	SUBJECTIVE_PRONOUN("Subjective pronoun", "I", "you", "she", "he", "they"),
+	OBJECTIVE_PRONOUN("Objective pronoun", "me", "you", "her", "him", "them"),
+	DEPENDENT_POSSESSIVE_PRONOUN("Dependent possessive pronoun", "my", "your", "her", "his", "their"),
+	INDEPENDENT_POSSESSIVE_PRONOUN("Independent possessive pronoun", "mine", "yours", "hers", "his", "theirs"),
+	REFLEXIVE_PRONOUN("Reflexive pronoun", "myself", "yourself", "herself", "himself", "themselves");
 	
-	SECOND_PERSON("Second person", "she", "he", "they"),
-	THIRD_PERSON("Third person", "her", "him", "them"),
-	POSSESSIVE_BEFORE_NOUN("Possessive before noun", "her", "his", "their"),
-	POSSESSIVE_ALONE("Possessive alone", "hers", "his", "theirs");
+	private String name, first, second, feminine, masculine, neutral;
 	
-	private String name, feminine, masculine, neutral;
-	
-	private GenderPronoun(String name, String feminine, String masculine, String neutral){
+	private GenderPronoun(String name, String first, String second, String feminine, String masculine, String neutral){
 		this.name = name;
+		this.first = first;
+		this.second = second;
 		this.feminine = feminine;
 		this.masculine = masculine;
+		this.neutral = neutral;
 	}
 
 	public String getName() {
 		return name;
+	}
+
+	public String getFirst() {
+		return first;
+	}
+
+	public String getSecond() {
+		return second;
 	}
 	
 	public String getFeminine() {

--- a/src/com/lilithsthrone/game/dialogue/DebugDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/DebugDialogue.java
@@ -1046,7 +1046,7 @@ public class DebugDialogue {
 				return new Response("Load example 1", "", PARSER){
 					@Override
 					public void effects() {
-						rawText = "You see [lilaya.name] sitting at one of the tables in [lilaya.herHis] lab, playing around with an inert demonstone."
+						rawText = "[pc.YouName] [pc.verb(see)] [lilaya.name] sitting at one of the tables in [lilaya.herHis] lab, playing around with an inert demonstone."
 								+ " [rose.name] is sitting beside [lilaya.herPro], gazing up lovingly into [lilaya.name]'s [lilaya.eyes+] as [rose.her] [rose.tail+] gently swishes back and forth behind [rose.herPro]."
 								+ "\n</br></br>\n"
 								+ "Unable to concentrate with [lilaya.her] slave hovering so close at hand, [lilaya.name] places the demonstone down onto the table, before wrapping [lilaya.her] [lilaya.arms+] around [rose.name]'s back and pulling"
@@ -1103,11 +1103,11 @@ public class DebugDialogue {
 					
 					+ "<p>"
 					+"An example of use in a sentence would be:</br></br>"
-					+"As you start to read Innoxia's tedious parsing documentation, [lilaya.name] steps up behind you and wraps [lilaya.her] [lilaya.tail+] around your [pc.leg]."
-					+" Leaning in over your shoulder, [lilaya.she] groans, [lilaya.speech(Oh my God. This is so boring!)]'</br></br>"
+					+"As [pc.youName] [pc.verb(start)] to read Innoxia's tedious parsing documentation, [lilaya.name] steps up behind [pc.youObj] and wraps [lilaya.her] [lilaya.tail+] around [pc.your] [pc.leg]."
+					+" Leaning in over [pc.your] shoulder, [lilaya.she] groans, [lilaya.speech(Oh my God. This is so boring!)]'</br></br>"
 					+ "parses to:</br></br>"
-					+ UtilText.parse("As you start to read Innoxia's tedious parsing documentation, [lilaya.name] steps up behind you and wraps [lilaya.her] [lilaya.tail+] around your [pc.leg]."
-							+ " Leaning in over your shoulder, [lilaya.she] groans, [lilaya.speech(Oh my God. This is so boring!)]")
+					+ UtilText.parse("As [pc.youName] [pc.verb(start)] to read Innoxia's tedious parsing documentation, [lilaya.name] steps up behind [pc.youObj] and wraps [lilaya.her] [lilaya.tail+] around [pc.your] [pc.leg]."
+							+ " Leaning in over [pc.your] shoulder, [lilaya.she] groans, [lilaya.speech(Oh my God. This is so boring!)]")
 					+ "</p>"
 					+ "</br>"
 					

--- a/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
@@ -31,6 +31,7 @@ import com.lilithsthrone.game.settings.DifficultyLevel;
 import com.lilithsthrone.game.settings.ForcedFetishTendency;
 import com.lilithsthrone.game.settings.ForcedTFTendency;
 import com.lilithsthrone.game.settings.KeyboardAction;
+import com.lilithsthrone.game.settings.PlayerPronouns;
 import com.lilithsthrone.main.Main;
 import com.lilithsthrone.rendering.Artist;
 import com.lilithsthrone.rendering.ArtistWebsite;
@@ -853,15 +854,18 @@ public class OptionsDialogue {
 						+ "<table align='center'>"
 							+ "<tr>"
 								+ "<th>Pronoun</th>"
-								+ "<th style='color:"+Colour.MASCULINE.toWebHexString()+";'>Masculine</th>"
-								+ "<th style='color:"+Colour.FEMININE.toWebHexString()+";'>Feminine</th>"
+								+ "<th>First person</th>"
+								+ "<th>Second person</th>"
+								+ "<th style='color:"+Colour.MASCULINE.toWebHexString()+";'>Third person masculine</th>"
+								+ "<th style='color:"+Colour.FEMININE.toWebHexString()+";'>Third person feminine</th>"
 							+ "</tr>"
-							+ getPronounTableRow(GenderPronoun.NOUN)
-							+ getPronounTableRow(GenderPronoun.YOUNG_NOUN)
-							+ getPronounTableRow(GenderPronoun.SECOND_PERSON)
-							+ getPronounTableRow(GenderPronoun.THIRD_PERSON)
-							+ getPronounTableRow(GenderPronoun.POSSESSIVE_BEFORE_NOUN)
-							+ getPronounTableRow(GenderPronoun.POSSESSIVE_ALONE)
+							+ getPronounTableRow(GenderPronoun.NOUN, true)
+							+ getPronounTableRow(GenderPronoun.YOUNG_NOUN, true)
+							+ getPronounTableRow(GenderPronoun.SUBJECTIVE_PRONOUN, false)
+							+ getPronounTableRow(GenderPronoun.OBJECTIVE_PRONOUN, false)
+							+ getPronounTableRow(GenderPronoun.DEPENDENT_POSSESSIVE_PRONOUN, false)
+							+ getPronounTableRow(GenderPronoun.INDEPENDENT_POSSESSIVE_PRONOUN, false)
+							+ getPronounTableRow(GenderPronoun.REFLEXIVE_PRONOUN, false)
 						+ "</table>"
 					+ "</p>"
 					+ "<h5 style='text-align:center;'><span style='color:"+Colour.ANDROGYNOUS.toWebHexString()+";'>Androgynous bodies</span> (option 3)</h5>"
@@ -912,6 +916,8 @@ public class OptionsDialogue {
 							Main.getProperties().genderNameFemale.put(gn, gn.getFeminine());
 						}
 						for (GenderPronoun gp : GenderPronoun.values()) {
+							Main.getProperties().genderPronounFirst.put(gp, gp.getFirst());
+							Main.getProperties().genderPronounSecond.put(gp, gp.getSecond());
 							Main.getProperties().genderPronounFemale.put(gp, gp.getFeminine());
 							Main.getProperties().genderPronounMale.put(gp, gp.getMasculine());
 						}
@@ -942,6 +948,26 @@ public class OptionsDialogue {
 								break;
 						}
 						
+						Main.saveProperties();
+					}
+				};
+
+			} else if (index == 4) {
+				return new Response("Player pronouns: " + Main.getProperties().playerPronouns.getDescription(),
+						"Cycle the pronouns used for the player character.<br/><em>This is an unfinished option, most of the content still uses second person pronouns regardless of this option</em>.", OPTIONS_PRONOUNS) {
+					@Override
+					public void effects() {
+						switch(Main.getProperties().playerPronouns) {
+							case FIRST_PERSON:
+								Main.getProperties().playerPronouns = PlayerPronouns.SECOND_PERSON;
+								break;
+							case SECOND_PERSON:
+								Main.getProperties().playerPronouns = PlayerPronouns.THIRD_PERSON;
+								break;
+							case THIRD_PERSON:
+								Main.getProperties().playerPronouns = PlayerPronouns.FIRST_PERSON;
+								break;
+						}
 						Main.saveProperties();
 					}
 				};
@@ -988,19 +1014,23 @@ public class OptionsDialogue {
 				+ "</tr>";
 	}
 	
-	private static String getPronounTableRow(GenderPronoun pronoun) {
+	private static String getPronounTableRow(GenderPronoun pronoun, boolean thirdPersonOnly) {
 		return "<tr>"
 				+ "<td>"
 					+ pronoun.getName()
 				+ "</td>"
-					+ "<td style='min-width:160px;'>"
-					+"<form style='padding:0;margin:0;text-align:center;'><input type='text' id='masculine_" + pronoun + "' value='"+ UtilText.parseForHTMLDisplay(Main.getProperties().genderPronounMale.get(pronoun))+ "'>"
-					+ "</form>"
-				+ "</td>"
-				+ "<td style='min-width:160px;'>"
-					+"<form style='padding:0;margin:0;text-align:center;'><input type='text' id='feminine_" + pronoun + "' value='"+ UtilText.parseForHTMLDisplay(Main.getProperties().genderPronounFemale.get(pronoun))+ "'></form>"
-				+ "</td>"
+					+ getPronounTableElement("first", pronoun.toString(), UtilText.parseForHTMLDisplay(Main.getProperties().genderPronounFirst.get(pronoun)), thirdPersonOnly)
+					+ getPronounTableElement("second", pronoun.toString(), UtilText.parseForHTMLDisplay(Main.getProperties().genderPronounSecond.get(pronoun)), thirdPersonOnly)
+					+ getPronounTableElement("masculine", pronoun.toString(), UtilText.parseForHTMLDisplay(Main.getProperties().genderPronounMale.get(pronoun)), false)
+					+ getPronounTableElement("feminine", pronoun.toString(), UtilText.parseForHTMLDisplay(Main.getProperties().genderPronounFemale.get(pronoun)), false)
 				+ "</tr>";
+	}
+
+	private static String getPronounTableElement(String kind, String pronoun, String value, boolean disabled) {
+		return "<td style='min-width:160px;'>"
+				+"<form style='padding:0;margin:0;text-align:center;'><input type='text' id='" + kind + "_" + pronoun + "' value='" + (disabled ? "N/A' disabled>" : (value + "'>"))
+				+ "</form>"
+				+ "</td>";
 	}
 	
 	

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -38,6 +38,7 @@ import com.lilithsthrone.game.character.gender.GenderPronoun;
 import com.lilithsthrone.game.character.race.Subspecies;
 import com.lilithsthrone.game.inventory.clothing.AbstractClothing;
 import com.lilithsthrone.game.inventory.enchanting.TFEssence;
+import com.lilithsthrone.game.settings.PlayerPronouns;
 import com.lilithsthrone.game.sex.OrificeType;
 import com.lilithsthrone.game.sex.Sex;
 import com.lilithsthrone.game.sex.SexPace;
@@ -962,17 +963,10 @@ public class UtilText {
 				true,
 				false,
 				"(prefix)",
-				"Returns the name of the target, <b>automatically appending</b> 'the' to names that don't start with a capital letter. If you want the basic form of the name, pass in a space as an argument."
-				+ " If a prefix is provided, the prefix will be appended (with an automatic addition of a space) to non-capitalised names."){
+				"Returns the name of the target, <b>automatically prepending</b> 'the' to names that don't start with a capital letter. If you want the basic form of the name, pass in a space as an argument."
+				+ " If a prefix is provided, the prefix will be prepended (with an automatic addition of a space) to non-capitalised names."){
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(target.startsWith("npc") && character.isPlayer()) {
-					if(command.startsWith("N")) {
-						return "You";
-					} else {
-						return "you";
-					}
-				}
 				if(arguments!=null) {
 					return character.getName(arguments);
 				} else {
@@ -988,22 +982,15 @@ public class UtilText {
 				Util.newArrayListOfValues("namePos"),
 				true,
 				false,
-				"(real name)",
-				"Returns a possessive version of the name of the target, <b>automatically appending</b> 'the' to names that don't start with a capital letter."
-				+ " If you need the actual player name for third-person reference, pass a space as an argument.") {
+				"(prefix)",
+				"Returns a possessive version of the name of the target, <b>automatically prepending</b> 'the' to names that don't start with a capital letter. If you want the basic form of the name, pass in a space as an argument."
+				+ " If a prefix is provided, the prefix will be prepended (with an automatic addition of a space) to non-capitalised names.") {
 			@Override
 			public String parse(String command, String arguments, String target) {
 				if(arguments!=null) {
-					return character.getName() + "'s";
+					return character.getName(arguments) + "'s";
 				} else {
-					if(character.isPlayer()) {
-						if(command.startsWith("N")) {
-							return "Your";
-						} else {						 
-							return "your";
-						}
-					}
-					if(character.isPlayerKnowsName()) {
+					if(character.isPlayerKnowsName() || character.isPlayer()) {
 						return character.getName() + "'s";
 					}
 					return character.getName("the") + "'s";
@@ -1015,21 +1002,23 @@ public class UtilText {
 				Util.newArrayListOfValues("nameIs"),
 				false,
 				false,
-				"(real name)",
-				"Returns a contractive version of the name of the target, <b>automatically appending</b> 'the' to names that don't start with a capital letter."
-				+ " If you need the actual player name for third-person reference, pass a space as an argument.") {
+				"(contracted, prefix)",
+				"Returns the name of the target plus a verb, <b>automatically prepending</b> 'the' to names that don't start with a capital letter. If you want the basic form of the name, pass in a space as an argument."
+				+ " If a prefix is provided, the prefix will be prepended (with an automatic addition of a space) to non-capitalised names."
+				+ " If the 'contracted' argument is the string 'true', the verb is contracted") {
 			@Override
 			public String parse(String command, String arguments, String target) {
+				String[] args = arguments.split(", ");
+				String suffix = (args[0] == "true" ? "'s" : " is");
+				arguments = (args.length == 2 ? args[1] : null);
+				
 				if(arguments!=null) {
-					return character.getName() + "'s";
+					return character.getName() + suffix;
 				} else {
-					if(character.isPlayer()) {
-						return "you're";
+					if(character.isPlayerKnowsName() || character.isPlayer()) {
+						return character.getName() + suffix;
 					}
-					if(character.isPlayerKnowsName()) {
-						return character.getName() + "'s";
-					}
-					return character.getName("the") + "'s";
+					return character.getName("the") + suffix;
 				}
 			}
 		});
@@ -1038,21 +1027,23 @@ public class UtilText {
 				Util.newArrayListOfValues("nameHas"),
 				false,
 				false,
-				"(real name)",
-				"Returns a contractive version of the name of the target, <b>automatically appending</b> 'the' to names that don't start with a capital letter."
-				+ " If you need the actual player name for third-person reference, pass a space as an argument.") {
+				"(contracted, prefix)",
+				"Returns the name of the target plus a verb, <b>automatically prepending</b> 'the' to names that don't start with a capital letter. If you want the basic form of the name, pass in a space as an argument."
+				+ " If a prefix is provided, the prefix will be prepended (with an automatic addition of a space) to non-capitalised names."
+				+ " If the 'contracted' argument is the string 'true', the verb is contracted") {
 			@Override
 			public String parse(String command, String arguments, String target) {
+				String[] args = arguments.split(", ");
+				String suffix = (args[0] == "true" ? "'s" : " has");
+				arguments = (args.length == 2 ? args[1] : null);
+				
 				if(arguments!=null) {
-					return character.getName() + "'s";
+					return character.getName() + suffix;
 				} else {
-					if(character.isPlayer()) {
-						return "you've";
+					if(character.isPlayerKnowsName() || character.isPlayer()) {
+						return character.getName() + suffix;
 					}
-					if(character.isPlayerKnowsName()) {
-						return character.getName() + "'s";
-					}
-					return character.getName("the") + "'s";
+					return character.getName("the") + suffix;
 				}
 			}
 		});
@@ -1067,7 +1058,7 @@ public class UtilText {
 				"Returns a verb in the (probably) correct person for this character. A player might get 'wiggle' where an NPC would get 'wiggles'.") {
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if (character.isPlayer()) {
+				if (character.isPlayer() && Main.getProperties().playerPronouns != PlayerPronouns.THIRD_PERSON) {
 					return arguments;
 				} else if (arguments.endsWith("s")
 						||arguments.endsWith("x")
@@ -1104,8 +1095,8 @@ public class UtilText {
 				true,
 				false,
 				"(prefix)",
-				"Returns the name of the target, <b>automatically appending</b> 'the' to names that don't start with a capital letter. If you want the basic form of the name, pass in a space as an argument."
-				+ " If a prefix is provided, the prefix will be appended (with an automatic addition of a space) to non-capitalised names."){
+				"Returns the name of the target, <b>automatically prepending</b> 'the' to names that don't start with a capital letter. If you want the basic form of the name, pass in a space as an argument."
+				+ " If a prefix is provided, the prefix will be prepended (with an automatic addition of a space) to non-capitalised names."){
 			@Override
 			public String parse(String command, String arguments, String target) {
 				if(arguments!=null) {
@@ -1118,7 +1109,7 @@ public class UtilText {
 				}
 			}
 		});
-		
+
 		commandsList.add(new ParserCommand(
 				Util.newArrayListOfValues(
 						"pcName",
@@ -2635,6 +2626,114 @@ public class UtilText {
 					return "masculine";
 			}
 		});
+
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						"sheName",
+						"heName",
+						"youName"),
+				true,
+				true,
+				"(prefix)",
+				"If the target is the PC, returns either a pronoun or the PC's name depending on the pronoun settings."
+				+ " If the target is an NPC, returns the NPC's name.") {
+			@Override
+			public String parse(String command, String arguments, String target) {
+				if(!character.isPlayer() || Main.getProperties().playerPronouns == PlayerPronouns.THIRD_PERSON) {
+					if(arguments != null) {
+						return character.getName(arguments);
+					} else {
+						if(character.isPlayerKnowsName() || character.isPlayer()) {
+							return character.getName();
+						}
+						return character.getName("the");
+					}
+				} else {
+					return Gender.F_V_B_FEMALE.getSubjective();
+				}	
+			}
+		});
+
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						"hersName",
+						"hisHersName",
+						"yoursName"),
+				true,
+				true,
+				"(prefix)",
+				"If the target is the PC, returns either a pronoun or the PC's name depending on the pronoun settings."
+				+ " If the target is an NPC, returns the NPC's name.") {
+			@Override
+			public String parse(String command, String arguments, String target) {
+				if(!character.isPlayer() || Main.getProperties().playerPronouns == PlayerPronouns.THIRD_PERSON) {
+					if(arguments != null) {
+						return character.getName(arguments) + "'s";
+					} else {
+						if(character.isPlayerKnowsName() || character.isPlayer()) {
+							return character.getName() + "'s";
+						}
+						return character.getName("the") + "'s";
+					}
+				} else {
+					return Gender.F_V_B_FEMALE.getIndependentPossessive();
+				}	
+			}
+		});
+
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						"herName",
+						"hisName",
+						"yourName"),
+				true,
+				true,
+				"(prefix)",
+				"If the target is the PC, returns either a pronoun or the PC's name depending on the pronoun settings."
+				+ " If the target is an NPC, returns the NPC's name.") {
+			@Override
+			public String parse(String command, String arguments, String target) {
+				if(!character.isPlayer() || Main.getProperties().playerPronouns == PlayerPronouns.THIRD_PERSON) {
+					if(arguments != null) {
+						return character.getName(arguments) + "'s";
+					} else {
+						if(character.isPlayerKnowsName() || character.isPlayer()) {
+							return character.getName() + "'s";
+						}
+						return character.getName("the") + "'s";
+					}
+				} else {
+					return Gender.F_V_B_FEMALE.getDependentPossessive();
+				}	
+			}
+		});
+
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						"herObjName",
+						"himName",
+						"youObjName"),
+				true,
+				true,
+				"(prefix)",
+				"If the target is the PC, returns either a pronoun or the PC's name depending on the pronoun settings."
+				+ " If the target is an NPC, returns the NPC's name.") {
+			@Override
+			public String parse(String command, String arguments, String target) {
+				if(!character.isPlayer() || Main.getProperties().playerPronouns == PlayerPronouns.THIRD_PERSON) {
+					if(arguments != null) {
+						return character.getName(arguments);
+					} else {
+						if(character.isPlayerKnowsName() || character.isPlayer()) {
+							return character.getName();
+						}
+						return character.getName("the");
+					}
+				} else {
+					return Gender.F_V_B_FEMALE.getObjective();
+				}	
+			}
+		});
 		
 		commandsList.add(new ParserCommand(
 				Util.newArrayListOfValues(
@@ -2643,29 +2742,25 @@ public class UtilText {
 						"herPos",
 						"herHis",
 						"hisPos",
-						"hisHer"),
+						"hisHer",
+						"your"),
 				true,
 				true,
-				"(real pronoun)",
-				"Returns the correct gender-specific possessive pronoun for this character (your, her, his). By default, returns 'your' for player character."
-				+ " If you need the actual third-person player character pronoun, pass a space as an argument."){
+				"",
+				"Returns the correct gender-specific possessive pronoun for this character (your, her, his)."){
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments==null && character.isPlayer()) {
-					return "your";
-				} else {
-					if(character.isFeminine()) {
-						if(character.isPlayer()) {
-							return Gender.F_V_B_FEMALE.getPossessiveBeforeNoun();
-						} else {
-							return GenderPronoun.POSSESSIVE_BEFORE_NOUN.getFeminine();
-						}
+				if(character.isFeminine()) {
+					if(character.isPlayer()) {
+						return Gender.F_V_B_FEMALE.getDependentPossessive();
 					} else {
-						if(character.isPlayer()) {
-							return Gender.M_P_MALE.getPossessiveBeforeNoun();
-						} else {
-							return GenderPronoun.POSSESSIVE_BEFORE_NOUN.getMasculine();
-						}
+						return GenderPronoun.DEPENDENT_POSSESSIVE_PRONOUN.getFeminine();
+					}
+				} else {
+					if(character.isPlayer()) {
+						return Gender.M_P_MALE.getDependentPossessive();
+					} else {
+						return GenderPronoun.DEPENDENT_POSSESSIVE_PRONOUN.getMasculine();
 					}
 				}
 			}
@@ -2675,7 +2770,8 @@ public class UtilText {
 				Util.newArrayListOfValues(
 						"hers",
 						"hersHis",
-						"hisHers"),
+						"hisHers",
+						"yours"),
 				true,
 				true,
 				"",
@@ -2684,15 +2780,15 @@ public class UtilText {
 			public String parse(String command, String arguments, String target) {
 				if(character.isFeminine()) {
 					if(character.isPlayer()) {
-						return Gender.F_V_B_FEMALE.getPossessiveAlone();
+						return Gender.F_V_B_FEMALE.getIndependentPossessive();
 					} else {
-						return GenderPronoun.POSSESSIVE_ALONE.getFeminine();
+						return GenderPronoun.INDEPENDENT_POSSESSIVE_PRONOUN.getFeminine();
 					}
 				} else {
 					if(character.isPlayer()) {
-						return Gender.M_P_MALE.getPossessiveAlone();
+						return Gender.M_P_MALE.getIndependentPossessive();
 					} else {
-						return GenderPronoun.POSSESSIVE_ALONE.getMasculine();
+						return GenderPronoun.INDEPENDENT_POSSESSIVE_PRONOUN.getMasculine();
 					}
 				}
 			}
@@ -2702,30 +2798,27 @@ public class UtilText {
 				Util.newArrayListOfValues(
 						"him",
 						"herPro",
+						"herObj",
 						"herHim",
-						"himHer"),
+						"himHer",
+						"youObj"),
 				true,
 				true,
-				"(real pronoun)",
-				"Returns the correct pronoun for this character (you, him, her). By default, returns 'you' for player character."
-				+ " If you need the regular third-person player character pronoun, pass a space as an argument."){
+				"",
+				"Returns the correct pronoun for this character (you, him, her)."){
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments==null && character.isPlayer()) {
-					return "you";
-				} else {
-					if(character.isFeminine()) {
-						if(character.isPlayer()) {
-							return Gender.F_V_B_FEMALE.getThirdPerson();
-						} else {
-							return GenderPronoun.THIRD_PERSON.getFeminine();
-						}
+				if(character.isFeminine()) {
+					if(character.isPlayer()) {
+						return Gender.F_V_B_FEMALE.getObjective();
 					} else {
-						if(character.isPlayer()) {
-							return Gender.M_P_MALE.getThirdPerson();
-						} else {
-							return GenderPronoun.THIRD_PERSON.getMasculine();
-						}
+						return GenderPronoun.OBJECTIVE_PRONOUN.getFeminine();
+					}
+				} else {
+					if(character.isPlayer()) {
+						return Gender.M_P_MALE.getObjective();
+					} else {
+						return GenderPronoun.OBJECTIVE_PRONOUN.getMasculine();
 					}
 				}
 			}
@@ -2736,29 +2829,52 @@ public class UtilText {
 						"she",
 						"sheHe",
 						"he",
-						"heShe"),
+						"heShe",
+						"you"),
 				true,
 				true,
-				"(real pronoun)",
-				"Returns the correct pronoun for this character (you, she, he). By default, returns 'you' for player character."
-				+ " If you need the regular third-person player character pronoun, pass a space as an argument."){
+				"",
+				"Returns the correct pronoun for this character (you, she, he)."){
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments==null && character.isPlayer()) {
-					return "you";
-				} else {
-					if(character.isFeminine()) {
-						if(character.isPlayer()) {
-							return Gender.F_V_B_FEMALE.getSecondPerson();
-						} else {
-							return GenderPronoun.SECOND_PERSON.getFeminine();
-						}
+				if(character.isFeminine()) {
+					if(character.isPlayer()) {
+						return Gender.F_V_B_FEMALE.getSubjective();
 					} else {
-						if(character.isPlayer()) {
-							return Gender.M_P_MALE.getSecondPerson();
-						} else {
-							return GenderPronoun.SECOND_PERSON.getMasculine();
-						}
+						return GenderPronoun.SUBJECTIVE_PRONOUN.getFeminine();
+					}
+				} else {
+					if(character.isPlayer()) {
+						return Gender.M_P_MALE.getSubjective();
+					} else {
+						return GenderPronoun.SUBJECTIVE_PRONOUN.getMasculine();
+					}
+				}
+			}
+		});
+
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						"herself",
+						"himself",
+						"yourself"),
+				true,
+				true,
+				"",
+				"Returns the correct gender-specific reflexive pronoun for this character (yourself, herself, himself)."){
+			@Override
+			public String parse(String command, String arguments, String target) {
+				if(character.isFeminine()) {
+					if(character.isPlayer()) {
+						return Gender.F_V_B_FEMALE.getReflexive();
+					} else {
+						return GenderPronoun.REFLEXIVE_PRONOUN.getFeminine();
+					}
+				} else {
+					if(character.isPlayer()) {
+						return Gender.M_P_MALE.getReflexive();
+					} else {
+						return GenderPronoun.REFLEXIVE_PRONOUN.getMasculine();
 					}
 				}
 			}
@@ -2769,99 +2885,154 @@ public class UtilText {
 						"sheIs",
 						"sheHeIs",
 						"heIs",
-						"heSheIs"),
+						"heSheIs",
+						"youAre"),
 				true,
 				true,
-				"(real pronoun)",
-				"Returns the correct gender-specific pronoun contraction for this character (you're, she's, he's). By default, returns 'you're' for player character."
-				+ " If you need the regular third-person player character pronoun contraction, pass a space as an argument."){
+				"(contracted)",
+				"Returns the correct gender-specific pronoun plus verb for this character (you are, she is, he is)."
+				+ "Pass any argument to get the contracted version (you're, she's, he's)"){
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments==null && character.isPlayer()) {
-					return "you're";
+				PlayerPronouns pro = Main.getProperties().playerPronouns;
+
+				if(character.isPlayer() && pro != PlayerPronouns.THIRD_PERSON) {
+					String suffix = (pro == PlayerPronouns.FIRST_PERSON ?
+							(arguments == null ? " am" : "'m") :
+							(arguments == null ? " are" : "'re"));
+
+					return Gender.F_V_B_FEMALE.getSubjective() + suffix;
 				} else {
+					String suffix = (arguments == null ? " is" : "'s");
+
 					if(character.isFeminine()) {
 						if(character.isPlayer()) {
-							return Gender.F_V_B_FEMALE.getSecondPerson() + "'s";
+							return Gender.F_V_B_FEMALE.getSubjective() + suffix;
 						} else {
-							return GenderPronoun.SECOND_PERSON.getFeminine() + "'s";
+							return GenderPronoun.SUBJECTIVE_PRONOUN.getFeminine() + suffix;
 						}
 					} else {
 						if(character.isPlayer()) {
-							return Gender.M_P_MALE.getSecondPerson() + "'s";
+							return Gender.M_P_MALE.getSubjective() + suffix;
 						} else {
-							return GenderPronoun.SECOND_PERSON.getMasculine() + "'s";
+							return GenderPronoun.SUBJECTIVE_PRONOUN.getMasculine() + suffix;
 						}
 					}
 				}
 			}
 		});
-		
+
+		commandsList.add(new ParserCommand(
+				Util.newArrayListOfValues(
+						"sheNameIs",
+						"heNameIs",
+						"youNameAre"),
+				true,
+				true,
+				"(contracted, prefix)",
+				"If the target is the PC, returns either a pronoun or the PC's name depending on the pronoun settings, plus a verb."
+				+ " If the target is an NPC, returns the NPC's name plus a verb.") {
+			@Override
+			public String parse(String command, String arguments, String target) {
+				PlayerPronouns pro = Main.getProperties().playerPronouns;
+				String[] args = arguments.split(", ");
+
+				if(!character.isPlayer() || pro == PlayerPronouns.THIRD_PERSON) {
+					String suffix = (args[0] == "true" ? "'s" : " is");
+					arguments = (args.length == 2 ? args[1] : null);
+
+					if(arguments != null) {
+						return character.getName(arguments) + suffix;
+					} else {
+						if(character.isPlayerKnowsName() || character.isPlayer()) {
+							return character.getName() + suffix;
+						}
+						return character.getName("the") + suffix;
+					}
+				} else {
+					String suffix = (pro == PlayerPronouns.FIRST_PERSON ?
+						(args[0] == "true" ? "'m" : " am") :
+						(args[0] == "true" ? "'re" : " are"));
+
+					return Gender.F_V_B_FEMALE.getSubjective() + suffix;
+				}	
+			}
+		});
 		
 		commandsList.add(new ParserCommand(
 				Util.newArrayListOfValues(
 						"sheHas",
 						"sheHeHas",
 						"heHas",
-						"heSheHas"),
+						"heSheHas",
+						"youHave"),
 				true,
 				true,
-				"(real pronoun)",
-				"Returns the correct gender-specific pronoun contraction for this character (you've, she's, he's). By default, returns 'you've' for player character."
-				+ " If you need the regular third-person player character pronoun contraction, pass a space as an argument."){
+				"(contracted)",
+				"Returns the correct gender-specific pronoun contraction for this character (you've, she's, he's)."){
 			@Override
 			public String parse(String command, String arguments, String target) {
-				if(arguments==null && character.isPlayer()) {
-					return "you've";
+				PlayerPronouns pro = Main.getProperties().playerPronouns;
+
+				if(character.isPlayer() && pro != PlayerPronouns.THIRD_PERSON) {
+					String suffix = (arguments == null ? " have" : "'ve");
+
+					return Gender.F_V_B_FEMALE.getSubjective() + suffix;
 				} else {
+					String suffix = (arguments == null ? " is" : "'s");
+
 					if(character.isFeminine()) {
 						if(character.isPlayer()) {
-							return Gender.F_V_B_FEMALE.getSecondPerson() + "'s";
+							return Gender.F_V_B_FEMALE.getSubjective() + suffix;
 						} else {
-							return GenderPronoun.SECOND_PERSON.getFeminine() + "'s";
+							return GenderPronoun.SUBJECTIVE_PRONOUN.getFeminine() + suffix;
 						}
 					} else {
 						if(character.isPlayer()) {
-							return Gender.M_P_MALE.getSecondPerson() + "'s";
+							return Gender.M_P_MALE.getSubjective() + suffix;
 						} else {
-							return GenderPronoun.SECOND_PERSON.getMasculine() + "'s";
+							return GenderPronoun.SUBJECTIVE_PRONOUN.getMasculine() + suffix;
 						}
 					}
 				}
 			}
 		});
-		
+
 		commandsList.add(new ParserCommand(
 				Util.newArrayListOfValues(
-						"herself",
-						"himself"),
+						"sheNameHas",
+						"heNameHas",
+						"youNameHave"),
 				true,
 				true,
-				"",
-				"Returns correct gender-specific reflexive pronoun for this character (yourself, herself, himself). By default, returns 'yourself' for player character."
-						+ " If you need the regular reflexive player character pronoun, pass a space as an argument."){
-					@Override
-					public String parse(String command, String arguments, String target) {
-						if(arguments==null && character.isPlayer()) {
-							return "yourself";
-						} else {
-							if(character.isFeminine()) {
-								if(character.isPlayer()) {
-									return Gender.F_V_B_FEMALE.getThirdPerson()+"self";
-								} else {
-									return GenderPronoun.THIRD_PERSON.getFeminine()+"self";
-								}
-							} else {
-								if(character.isPlayer()) {
-									return Gender.M_P_MALE.getThirdPerson()+"self";
-								} else {
-									return GenderPronoun.THIRD_PERSON.getMasculine()+"self";
-								}
-							}
+				"(contracted, prefix)",
+				"If the target is the PC, returns either a pronoun or the PC's name depending on the pronoun settings, plus a verb."
+				+ " If the target is an NPC, returns the NPC's name plus a verb.") {
+			@Override
+			public String parse(String command, String arguments, String target) {
+				PlayerPronouns pro = Main.getProperties().playerPronouns;
+				String[] args = arguments.split(", ");
+
+				if(!character.isPlayer() || pro == PlayerPronouns.THIRD_PERSON) {
+					String suffix = (args[0] == "true" ? "'s" : " has");
+					arguments = (args.length == 2 ? args[1] : null);
+
+					if(arguments != null) {
+						return character.getName(arguments) + suffix;
+					} else {
+						if(character.isPlayerKnowsName() || character.isPlayer()) {
+							return character.getName() + suffix;
 						}
+						return character.getName("the") + suffix;
 					}
-				});
-		
+				} else {
+					String suffix = (args[0] == "true" ? "'ve" : " have");
+
+					return Gender.F_V_B_FEMALE.getSubjective() + suffix;
+				}	
+			}
+		});
+
 		// Clothing:
 		
 		commandsList.add(new ParserCommand(

--- a/src/com/lilithsthrone/game/settings/PlayerPronouns.java
+++ b/src/com/lilithsthrone/game/settings/PlayerPronouns.java
@@ -1,0 +1,17 @@
+package com.lilithsthrone.game.settings;
+
+public enum PlayerPronouns {
+	FIRST_PERSON("first person"),
+	SECOND_PERSON("second person"),
+	THIRD_PERSON("third person");
+
+	private String description;
+
+	private PlayerPronouns(String description) {
+		this.description = description;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+}

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -89,83 +89,83 @@ public class GenericOrgasms {
 				}
 				break;
 			case BACK_TO_WALL_FACING_TARGET:
-				orgasmText = "Realising that [npc1.sheIs] about to reach [npc1.her] climax, [npc1.name] [npc1.verb(step)] forwards, letting out [npc1.a_moan+] as [npc1.she] "
-				+ "[npc1.verb(press)] [npc2.name] back against the wall.";
+				orgasmText = "Realising that [npc1.sheIs( )] about to reach [npc1.her] climax, [npc1.sheName] [npc1.verb(step)] forwards, letting out [npc1.a_moan+] as [npc1.she] "
+				+ "[npc1.verb(press)] [npc2.herObjName] back against the wall.";
 				break;
 			case CHAIR_BOTTOM: case CHAIR_BOTTOM_LILAYA:
-				orgasmText = "Wrapping [npc1.her] [npc1.arms+] around [npc2.name], [npc1.name] [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(pull)] [npc2.herHim] down into [npc.her] lap.";
+				orgasmText = "Wrapping [npc1.her] [npc1.arms+] around [npc2.herObjName], [npc1.sheName] [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(pull)] [npc2.herHim] down into [npc.her] lap.";
 				break;
 			case CHAIR_TOP: case CHAIR_TOP_LILAYA:
-				orgasmText = "With [npc1.a_moan+], [npc1.name] [npc1.verb(sink)] down into [npc2.namePos] lap.";
+				orgasmText = "With [npc1.a_moan+], [npc1.sheName] [npc1.verb(sink)] down into [npc2.herName] lap.";
 				break;
 			case COWGIRL_ON_BACK:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] up and [npc1.verb(take)] hold of [npc2.name] waist, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] up and [npc1.verb(take)] hold of [npc2.herName] waist, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case COWGIRL_RIDING:
-				orgasmText = "[npc1.Name] [npc1.verb(look)] down at [npc2.name] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(look)] down at [npc2.herObjName] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to climax.";
 				break;
 			case DOGGY_BEHIND: case DOGGY_BEHIND_AMBER: case PET_MOUNTING_HUMPING:
-				orgasmText = "[npc1.Name] [npc1.verb(take)] hold of [npc2.namePos] waist, pulling [npc2.herHim] back into [npc1.her] groin and letting out [npc1.a_moan+].";
+				orgasmText = "[npc1.SheName] [npc1.verb(take)] hold of [npc2.herName] waist, pulling [npc2.herHim] back into [npc1.her] groin and letting out [npc1.a_moan+].";
 				break;
 			case DOGGY_BEHIND_ORAL:
-				orgasmText = "[npc1.Name] [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case DOGGY_INFRONT: case PET_ORAL_COCKED_LEG:
-				orgasmText = "[npc1.Name] [npc1.verb(shuffle)] forwards, pressing [npc1.her] groin up against [npc2.namePos] [npc2.face] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(shuffle)] forwards, pressing [npc1.her] groin up against [npc2.herName] [npc2.face] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case DOGGY_INFRONT_ANAL:
-				orgasmText = "[npc1.Name] [npc1.verb(shuffle)] backwards, pressing [npc1.her] [npc1.ass+] up against [npc2.namePos] [npc2.face+] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(shuffle)] backwards, pressing [npc1.her] [npc1.ass+] up against [npc2.herName] [npc2.face+] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case DOGGY_ON_ALL_FOURS: case DOGGY_ON_ALL_FOURS_SECOND: case DOGGY_ON_ALL_FOURS_AMBER: case PET_MOUNTING_ON_ALL_FOURS: case PET_ORAL_ON_ALL_FOURS:
-				orgasmText = "[npc1.Name] [npc1.verb(brace)] [npc1.herself] on all fours, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(brace)] [npc1.herself] on all fours, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case FACE_TO_WALL_AGAINST_WALL: case FACE_TO_WALL_AGAINST_WALL_SHOWER_PIX:
-				orgasmText = "[npc1.Name] [npc1.verb(brace)] [npc1.herself] against the wall in front of [npc2.herHim], letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(brace)] [npc1.herself] against the wall in front of [npc1.herHim], letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case FACE_TO_WALL_FACING_TARGET: case FACE_TO_WALL_FACING_TARGET_SHOWER_PIX:
-				orgasmText = "[npc1.Name] [npc1.verb(press)] [npc1.herself] into [npc2.namePos] back, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(press)] [npc1.herself] into [npc2.herName] back, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case HAND_SEX_DOM_ROSE: case HAND_SEX_SUB_ROSE:
-				orgasmText = "[npc1.Name] [npc1.verb(look)] into [npc2.namePos] [npc2.eyes+] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(reach)] [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(look)] into [npc2.herName] [npc2.eyes+] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(reach)] [npc1.her] climax.";
 				break;
 			case KNEELING_PERFORMING_ORAL: case KNEELING_PERFORMING_ORAL_CULTIST: case KNEELING_PERFORMING_ORAL_RALPH: case KNEELING_PERFORMING_ORAL_ZARANIX:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] up and [npc1.verb(place)] a [npc1.hand] on one of [npc2.namePos] [npc2.legs], before letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] up and [npc1.verb(place)] a [npc1.hand] on one of [npc2.herName] [npc2.legs], before letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case KNEELING_RECEIVING_ORAL: case KNEELING_RECEIVING_ORAL_CULTIST: case KNEELING_RECEIVING_ORAL_RALPH: case KNEELING_RECEIVING_ORAL_ZARANIX:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] down and [npc1.verb(place)] a [npc1.hand] on [npc2.namePos] head, before letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(reach)] [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] down and [npc1.verb(place)] a [npc1.hand] on [npc2.herName] head, before letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(reach)] [npc1.her] climax.";
 				break;
 			case MISSIONARY_ALTAR_KNEELING_BETWEEN_LEGS:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] up and [npc1.verb(place)] a [npc1.hand] on one of [npc2.namePos] [npc2.legs]], before letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] up and [npc1.verb(place)] a [npc1.hand] on one of [npc2.herName] [npc2.legs]], before letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case MISSIONARY_ALTAR_LYING_ON_ALTAR:
-				orgasmText = "[npc1.Name] [npc1.verb(look)] up into [npc2.namePos] [npc2.eyes] and [npc1.verb(let)] out [npc1.[a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(look)] up into [npc2.herName] [npc2.eyes] and [npc1.verb(let)] out [npc1.[a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case MISSIONARY_ALTAR_SEALED_KNEELING_BETWEEN_LEGS:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] up and [npc1.verb(place)] a [npc1.hand] on one of [npc2.namePos] [npc2.legs], before letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] up and [npc1.verb(place)] a [npc1.hand] on one of [npc2.herName] [npc2.legs], before letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc.her] climax.";
 				break;
 			case MISSIONARY_ALTAR_SEALED_LYING_ON_ALTAR:
-				orgasmText = "[npc1.Name] [npc1.verb(look)] up into [npc2.namePos] [npc2.eyes] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(look)] up into [npc2.herName] [npc2.eyes] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case MISSIONARY_ALTAR_SEALED_STANDING_BETWEEN_LEGS: case MISSIONARY_ALTAR_STANDING_BETWEEN_LEGS:
-				orgasmText = "[npc1.Name] [npc1.verb(look)] down into [npc2.namePos] [npc2.eyes] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(look)] down into [npc2.herName] [npc2.eyes] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case MISSIONARY_DESK_DOM_VICKY:
-				orgasmText = "[npc1.Name] [npc1.verb(look)] down into [npc2.namePos] [npc2.eyes] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(look)] down into [npc2.herName] [npc2.eyes] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case MISSIONARY_DESK_SUB_VICKY:
-				orgasmText = "[npc1.Name] [npc1.verb(look)] up into [npc2.namePos] [npc2.eyes] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(look)] up into [npc2.herName] [npc2.eyes] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case SIXTY_NINE_BOTTOM:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] up and [npc1.verb(grab)] [npc2.namePos] waist, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] up and [npc1.verb(grab)] [npc2.herName] waist, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case SIXTY_NINE_TOP:
-				orgasmText = "[npc1.Name] [npc1.verb(drop)] [npc1.her] [npc1.face+] down into [npc2.namePos] groin, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(drop)] [npc1.her] [npc1.face+] down into [npc2.herName] groin, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case STANDING_DOMINANT:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] around and [npc1.verb(grab)] [npc2.namePos] [npc2.ass+], pulling [npc2.herHim] into [npc1.herHim] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] around and [npc1.verb(grab)] [npc2.herName] [npc2.ass+], pulling [npc2.herHim] into [npc1.herHim] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case STANDING_SUBMISSIVE:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] up and [npc1.verb(grab)] [npc2.namePos] shoulders, leaning into [npc2.herHim] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] up and [npc1.verb(grab)] [npc2.herName] shoulders, leaning into [npc2.herHim] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case MASTURBATING_KNEELING:
 				if(characterOrgasming.isPlayer()) {
@@ -175,28 +175,28 @@ public class GenericOrgasms {
 				}
 				break;
 			case STOCKS_FUCKING:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] down and [npc1.verb(grab)] [npc2.namePos] waist, pulling [npc2.herHim] back into [npc1.herHim] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] down and [npc1.verb(grab)] [npc2.herName] waist, pulling [npc2.herHim] back into [npc1.herHim] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case STOCKS_LOCKED_IN_STOCKS:
-				orgasmText = "Unable to move, [npc1.name] [npc1.verb(wriggle)] around in the stocks and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "Unable to move, [npc1.sheName] [npc1.verb(wriggle)] around in the stocks and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case STOCKS_PERFORMING_ORAL:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] up and [npc1.verb(place)] a [npc1.hand] on one of [npc2.namePos] [npc2.legs], letting out [npc1.a_moan+] as [npc1.she] npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] up and [npc1.verb(place)] a [npc1.hand] on one of [npc2.herName] [npc2.legs], letting out [npc1.a_moan+] as [npc1.she] npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case STOCKS_RECEIVING_ORAL:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] down and [npc1.verb(place)] a [npc1.hand] on [npc2.namePos] head, letting out [npc1.a_moan+] as [npc1.she] npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] down and [npc1.verb(place)] a [npc1.hand] on [npc2.herName] head, letting out [npc1.a_moan+] as [npc1.she] npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case MILKING_STALL_FUCKING:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] down and [npc1.verb(grab)] [npc2.namePos] waist, pulling [npc2.herHim] back into [npc1.herHim] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] down and [npc1.verb(grab)] [npc2.herName] waist, pulling [npc2.herHim] back into [npc1.herHim] and letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case MILKING_STALL_LOCKED_IN_MILKING_STALL:
-				orgasmText = "Unable to move, [npc1.name] [npc1.verb(wriggle)] around in the stocks and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "Unable to move, [npc1.SheName] [npc1.verb(wriggle)] around in the stocks and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case MILKING_STALL_PERFORMING_ORAL:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] up and [npc1.verb(place)] a [npc1.hand] on one of [npc2.namePos] [npc2.legs], letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] up and [npc1.verb(place)] a [npc1.hand] on one of [npc2.herName] [npc2.legs], letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case MILKING_STALL_RECEIVING_ORAL:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] down and [npc1.verb(place)] a [npc1.hand] on [npc2.namePos] head, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] down and [npc1.verb(place)] a [npc1.hand] on [npc2.herName] head, letting out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case LICKING_PUSSY_ROXY:
 				orgasmText = "You let out a muffled [pc.moan] into Roxy's [roxy.pussy+] as you prepare to reach your climax.";
@@ -205,13 +205,13 @@ public class GenericOrgasms {
 				orgasmText = "[npc.Name] grinds [npc.her] [npc.pussy+] down against your face, letting out [npc.a_moan+] as [npc.she] prepares to reach [npc.her] climax.";
 				break;
 			case BREEDING_STALL_BACK:
-				orgasmText = "[npc1.Name] [npc1.verb(spread)] [npc1.her] [npc1.legs] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(spread)] [npc1.her] [npc1.legs] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case BREEDING_STALL_FRONT:
-				orgasmText = "[npc1.Name] [npc1.verb(spread)] [npc1.her] [npc1.legs] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
+				orgasmText = "[npc1.SheName] [npc1.verb(spread)] [npc1.her] [npc1.legs] and [npc1.verb(let)] out [npc1.a_moan+] as [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax.";
 				break;
 			case BREEDING_STALL_FUCKING:
-				orgasmText = "[npc1.Name] [npc1.verb(reach)] down and [npc1.verb(grab)] [npc2.namePos] waist, before stepping forwards and driving [npc1.her] [npc1.cock] deep into [npc2.name]'s [npc2.pussy+]."
+				orgasmText = "[npc1.SheName] [npc1.verb(reach)] down and [npc1.verb(grab)] [npc2.herName] waist, before stepping forwards and driving [npc1.her] [npc1.cock] deep into [npc2.name]'s [npc2.pussy+]."
 						+ " Letting out [npc1.a_moan+], [npc1.she] [npc1.verb(prepare)] to reach [npc1.her] climax, and pump [npc2.name]'s womb full of [npc1.cum+].";
 				break;
 		}
@@ -858,12 +858,12 @@ public class GenericOrgasms {
 						return getClothingCummedOnText(characterOrgasming, target, CoverableArea.ASS);
 					} else {
 						return UtilText.parse(characterOrgasming, target,
-								" all over [npc2.namePos] [npc2.ass+]."
-								+ " [npc1.Name] [npc1.verb(grin)] as [npc1.her] [npc1.cum+] splatters onto [npc2.namePos] naked backside, and"
+								" all over [npc2.herName] [npc2.ass+]."
+								+ " [npc1.SheName] [npc1.verb(grin)] as [npc1.her] [npc1.cum+] splatters onto [npc2.herName] naked backside, and"
 								+ (!characterOrgasming.isPlayer() && !target.isPlayer()
-								?" the [npc2.race]"
-								:" [npc2.she]")
-								+" can't help but let out [npc2.a_moan] as [npc2.she] [npc2.verb(feel)] it running down over [npc2.her] [npc2.asshole+].");
+								? " the [npc2.race]"
+								: " [npc2.she]")
+								+ " can't help but let out [npc2.a_moan] as [npc2.she] [npc2.verb(feel)] it running down over [npc2.her] [npc2.asshole+].");
 					}
 				case BACK:
 					target = Sex.getTargetedPartner(characterOrgasming);


### PR DESCRIPTION
This change adds an option for players to chose the pronouns (i.e. first, second or third person) used for their player character. This change only contains the framework (including parser changes), content will be adapted in future work.

The following commands have been added to the parser:

- `pc.youName`: Outputs either a subjective pronoun in first/second person or the PC name in third person.
  Example: I/you/Jane
- `pc.youObjName`: Outputs either an objective pronoun in first/second person or and the PC name in third person.
  Example: me/you/Jane
- `pc.yourName`: Outputs either a dependent possessive pronoun in first/second person or the PC name in third person.
  Example: my/your/Jane's
- `pc.yoursName`: Outputs either an independent possessive pronoun in first/second person or the PC name in third person.
  Example: mine/yours/Jane's
- `pc.inflect(root,first,second,third)`: Inflects a root depending on the pronoun settings.
  Example: `inflect(ha,ve,ve,s)` outputs "have", "have", and "has" in first, second, and third person respectively.
- `pc.inflectS(root)`: Inflects a root for the common case where the third person singular has a suffixed "s".
  Equivalent to `inflect(root,,,s)`.

The commands `you`, `youObj`, `your`, `yours`, and `yourself` have been added as aliases to `heShe`, `himHer`, `hisHer`, `hisHers`, and `himself`/`herself` respectively.

-----

- No new graphical assets are required.
- This change has been tested on version 0.2.5.8.
- I am Otter#4718 on discord.