### PR TITLE
Fix orgasm descriptions mention player's name

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -691,6 +691,7 @@ public class UtilText {
 				
 				if (endIndex != 0) {
 					resultBuilder.append(input.substring(startedParsingSegmentAt, startIndex));
+					UtilText.specialNPCList = specialNPC;
 					String subResult = (currentParseMode == ParseMode.CONDITIONAL
 							? parseConditionalSyntaxNew(target, command, arguments, conditionalTrue, conditionalFalse)
 							: parseSyntaxNew(target, command, arguments, specialNPC)


### PR DESCRIPTION
fixed by always setting npc list (because conditional commands wouldn't do this)

See also discord: 

So basically as far as I see it you start in getCumQuantityDescription
there you want to parse the  #IFnpc1.isPlayer#THENyour#ELSE[npc1.name]'s#ENDIF
then you go to the parser with the UtilText.parse call(edited)
there you quickly find the #IF and the rest, so you go to conditional syntax parsing...
npc1 is not the player, when you in parseConditionSyntaxNew try to find the parsing target from the tag "npc1" via ParserTag.NPC, so npc1.isPlayer is false
then you parse the ELSE segment, which is a non-conditional
so we go to parseSyntaxNew
the first thing we do there is update the character list------
with a single character.
...
gotcha.
Imagine two characters orgasm, one after the other
First pix
pix is not a player, blah blah blah blah
so print name
also, set special npc list to pix.
Next, the player
call parser with npclist (pc),
npc1 is STILL not the player because we haven't updated the list
then we need to print the name, so we update the npc list....
and then npc1 is the player so you get the player's name.
The solutionnnnnnn
Either conditional syntax parsing ALSO needs to set the special npc list
or sex scenes need to... hmmh
that'd be complicated, convincing the sex scenes to ALL provide the proper list of characters
Now for the finale
Why is this my fault, why do we see it only now?(edited)
I converted UtilText.parse from recursive to iterative.
When you parse recursively, you find nested conditionals, and then parse those.
so the deepest part is parsed first.
When you parse iteratively, you parse the first whole command that you find
so the first command is parsed first.
If the most nested command was a simple command, and the first command was a conditional command....
Then when parsing recursively, you'd first set the npc list because the first command you parse is a normal one
And when parsing iteratively, you'd first perform the conditional command without updating the npc list because conditional commands don't update the npc list.
In short, I hate parsers
and I hate the global static variables everywhere for making things complicated
