### PR TITLE
Fixes that all characters could get pregnant even although that's not supposed to happen

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -10090,6 +10090,10 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 			pregnancyChance /= 2;
 		}
 		
+		if (!isAbleToBeImpregnated()) {
+			pregnancyChance = 0;
+		}
+		
 		if(pregnancyChance>1) {
 			pregnancyChance=1;
 		}
@@ -15697,5 +15701,7 @@ public abstract class GameCharacter implements Serializable, XMLSaving {
 	public String getWingPronoun() {
 		return body.getWing().getType().getPronoun();
 	}
+	
+	public abstract boolean isAbleToBeImpregnated();
 
 }

--- a/src/com/lilithsthrone/game/character/PlayerCharacter.java
+++ b/src/com/lilithsthrone/game/character/PlayerCharacter.java
@@ -643,4 +643,9 @@ public class PlayerCharacter extends GameCharacter implements XMLSaving {
 				+ description
 				+ "</p>";
 	}
+
+	@Override
+	public boolean isAbleToBeImpregnated() {
+		return true;
+	}
 }

--- a/src/com/lilithsthrone/game/character/npc/NPC.java
+++ b/src/com/lilithsthrone/game/character/npc/NPC.java
@@ -672,6 +672,7 @@ public abstract class NPC extends GameCharacter implements XMLSaving {
 	 * 
 	 * @return
 	 */
+	@Override
 	public boolean isAbleToBeImpregnated() {
 		return false;
 	}

--- a/src/com/lilithsthrone/game/character/npc/dominion/Nyan.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Nyan.java
@@ -205,6 +205,11 @@ public class Nyan extends NPC {
 	public boolean isUnique() {
 		return true;
 	}
+	
+	@Override
+	public boolean isAbleToBeImpregnated() {
+		return true;
+	}
 
 	@Override
 	public void dailyReset() {

--- a/src/com/lilithsthrone/game/character/npc/dominion/Pix.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Pix.java
@@ -126,6 +126,11 @@ public class Pix extends NPC {
 	}
 	
 	@Override
+	public boolean isAbleToBeImpregnated() {
+		return true;
+	}
+	
+	@Override
 	public void changeFurryLevel(){
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/dominion/Vicky.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Vicky.java
@@ -210,6 +210,11 @@ public class Vicky extends NPC {
 	public boolean isUnique() {
 		return true;
 	}
+	
+	@Override
+	public boolean isAbleToBeImpregnated() {
+		return true;
+	}
 
 	@Override
 	public void dailyReset() {

--- a/src/com/lilithsthrone/game/character/npc/misc/GenericSexualPartner.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/GenericSexualPartner.java
@@ -206,6 +206,11 @@ public class GenericSexualPartner extends NPC {
 	}
 	
 	@Override
+	public boolean isAbleToBeImpregnated() {
+		return true;
+	}
+	
+	@Override
 	public void changeFurryLevel(){
 	}
 	


### PR DESCRIPTION
NPC's have the method "isAbleToBeImpregnated", and it wasn't used. This allowed #674 to happen.