### PR TITLE
Fix encyclopedia weapon colours

### DIFF
--- a/src/com/lilithsthrone/controller/eventListeners/InventoryTooltipEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/InventoryTooltipEventListener.java
@@ -256,7 +256,7 @@ public class InventoryTooltipEventListener implements EventListener {
 
 					+ "<div class='subTitle'>" + Util.capitaliseSentence(dt.getName()) + "</div>"
 
-					+ "<div class='picture full'>" + genericWeapon.getSVGImage() + "</div>");
+					+ "<div class='picture full'>" + genericWeapon.getSVGImage(dt, null, null) + "</div>");
 
 			Main.mainController.setTooltipContent(UtilText.parse(tooltipSB.toString()));
 


### PR DESCRIPTION
I'm not sure that passing null for the primary and secondary colours is correct, but I can see the different colours in encyclopedia now. Fixes #668.