### PR TITLE
Fix slavery upkeep persisting across new games

### DIFF
--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -101,6 +101,7 @@ import com.lilithsthrone.game.dialogue.DialogueFlagValue;
 import com.lilithsthrone.game.dialogue.DialogueFlags;
 import com.lilithsthrone.game.dialogue.DialogueNodeOld;
 import com.lilithsthrone.game.dialogue.DialogueNodeType;
+import com.lilithsthrone.game.dialogue.SlaveryManagementDialogue;
 import com.lilithsthrone.game.dialogue.encounters.Encounter;
 import com.lilithsthrone.game.dialogue.eventLog.EventLogEntry;
 import com.lilithsthrone.game.dialogue.eventLog.SlaveryEventLogEntry;
@@ -197,6 +198,7 @@ public class Game implements Serializable, XMLSaving {
 		for (WorldType type : WorldType.values()) {
 			worlds.put(type, null);
 		}
+		SlaveryManagementDialogue.resetImportantCells();
 		startingDate = LocalDateTime.of(LocalDateTime.now().getYear(), LocalDateTime.now().getMonth(), LocalDateTime.now().getDayOfMonth(), 00, 00).plusYears(3);
 		minutesPassed = 20 * 60;
 		inCombat = false;
@@ -3155,7 +3157,8 @@ public class Game implements Serializable, XMLSaving {
 	}
 
 	public SlaveryUtil setSlaveryUtil(SlaveryUtil slaveryUtil) {
-		return this.slaveryUtil = slaveryUtil;
+		this.slaveryUtil = slaveryUtil;
+		return slaveryUtil;
 	}
 	
 	public DialogueNodeOld getDefaultDialogue() {

--- a/src/com/lilithsthrone/game/dialogue/SlaveryManagementDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/SlaveryManagementDialogue.java
@@ -475,6 +475,10 @@ public class SlaveryManagementDialogue {
 	
 	private static List<Cell> importantCells = new ArrayList<>();
 	
+	public static void resetImportantCells() {
+		importantCells = new ArrayList<>();
+	}
+	
 	public static List<Cell> getImportantCells() {
 		if(importantCells.isEmpty()) {
 			WorldType[] importantWorlds = new WorldType[] {WorldType.LILAYAS_HOUSE_GROUND_FLOOR, WorldType.LILAYAS_HOUSE_FIRST_FLOOR};


### PR DESCRIPTION
Fixes #531. Was caused by SlaveryManagementDialogue keeping a reference to all the cells within Lilaya's home, even after hitting new game (Thus also being a memory leak of sorts). Now creating a new game clears the list. It's not the most clean solution but I don't feel like digging the important cells cache out of the Slavery system for now.