### PR TITLE
Punctuation Fixes for Slime Queen Quest

### DIFF
--- a/res/txt/characters/submission/batCavernBat.xml
+++ b/res/txt/characters/submission/batCavernBat.xml
@@ -134,7 +134,7 @@
 		[npc.Name] collapses to the floor, letting out a defeated sigh as [npc.she] gazes up at you. Looking down at the vanquished [npc.race] before you, you see that [npc.she]'s got a desperate look of regret in [npc.her] eyes. Making pitiful little whining noises, [npc.she] tries to shuffle away from you, clearly worried about what your intentions might be.
 	</p>
 	<p>
-		[npc.speech(J-Just take my money and leave me alone!)], [npc.she] pleads, throwing some flames at your feet.
+		[npc.speech(J-Just take my money and leave me alone!)] [npc.she] pleads, throwing some flames at your feet.
 	</p>
 	<p>
 		You wonder if you should do as [npc.she] says, and leave [npc.herHim] alone. Then again, you <i>could</i> take advantage of [npc.her] weakened, vulnerable body...

--- a/res/txt/characters/submission/batCavernDefault.xml
+++ b/res/txt/characters/submission/batCavernDefault.xml
@@ -134,7 +134,7 @@
 		[npc.Name] collapses to the floor, letting out a defeated sigh as [npc.she] gazes up at you. Looking down at the vanquished [npc.race] before you, you see that [npc.she]'s got a desperate look of regret in [npc.her] eyes. Making pitiful little whining noises, [npc.she] tries to shuffle away from you, clearly worried about what your intentions might be.
 	</p>
 	<p>
-		[npc.speech(J-Just take my money and leave me alone!)], [npc.she] pleads, throwing some flames at your feet.
+		[npc.speech(J-Just take my money and leave me alone!)] [npc.she] pleads, throwing some flames at your feet.
 	</p>
 	<p>
 		You wonder if you should do as [npc.she] says, and leave [npc.herHim] alone. Then again, you <i>could</i> take advantage of [npc.her] weakened, vulnerable body...

--- a/res/txt/characters/submission/batCavernSlime.xml
+++ b/res/txt/characters/submission/batCavernSlime.xml
@@ -6,7 +6,7 @@
 		In your peripheral vision, you suddenly see a glowing [npc.skinColour] light starting to draw near. Turning towards it, you ready yourself for a fight, and within just a moment, the familiar figure of [npc.name] draws to a halt before you.
 	</p>
 	<p>
-		[npc.speech(Ooh! It's you again!)] [npc.she] giggles, clearly high on mushrooms again, [npc.speech(Look! You went and got me all pregnant!)]
+		[npc.speech(Ooh! It's you again!)] [npc.she] giggles, clearly high on mushrooms again. [npc.speech(Look! You went and got me all pregnant!)]
 	</p>
 	<p>
 		You look down at [npc.her] swollen belly, but before you can make a comment, [npc.she] continues, [npc.speech(So, I'm gonna need some cash from you, ok? I'm no going to take no for an answer.)]
@@ -22,7 +22,7 @@
 		In your peripheral vision, you suddenly see a glowing [npc.skinColour] light starting to draw near. Turning towards it, you ready yourself for a fight, and within just a moment, the familiar figure of [npc.name] draws to a halt before you.
 	</p>
 	<p>
-		[npc.speech(Ooh! It's you again!)] [npc.she] giggles, clearly high on mushrooms again, [npc.speech(Look! I'm still pregnant with our kids!)]
+		[npc.speech(Ooh! It's you again!)] [npc.she] giggles, clearly high on mushrooms again. [npc.speech(Look! I'm still pregnant with our kids!)]
 	</p>
 	<p>
 		You look down at [npc.her] swollen belly, but before you can make a comment, [npc.she] continues, [npc.speech(So, I'm gonna need some cash from you, ok? I'm no going to take no for an answer.)]
@@ -38,7 +38,7 @@
 		In your peripheral vision, you suddenly see a glowing [npc.skinColour] light starting to draw near. Turning towards it, you ready yourself for a fight, and within just a moment, the familiar figure of [npc.name] draws to a halt before you.
 	</p>
 	<p>
-		[npc.speech(Ooh! It's you again!)] [npc.she] giggles, clearly high on mushrooms again, [npc.speech(I'm gonna need some cash from you, ok? I spent all my flames on buying some 'shrooms from my friend, and now I need more for... umm... more 'shrooms!)]
+		[npc.speech(Ooh! It's you again!)] [npc.she] giggles, clearly high on mushrooms again. [npc.speech(I'm gonna need some cash from you, ok? I spent all my flames on buying some 'shrooms from my friend, and now I need more for... umm... more 'shrooms!)]
 	</p>
 	<p>
 		You can tell that [npc.name] is willing to fight, and you only have a moment in which to decide what to do...
@@ -51,7 +51,7 @@
 		In your peripheral vision, you suddenly see a glowing [npc.skinColour] light starting to draw near. Turning towards it, you ready yourself for a fight, and within just a moment, [npc.a_fullRace(true)] draws to a halt before you.
 	</p>
 	<p>
-		[npc.speech(Ooh! A poor innocent traveller wandering through my magical realm!)] [npc.she] giggles, clearly high on mushrooms, [npc.speech(I'm gonna need some cash from you, ok? I spent all my flames on buying some 'shrooms from my friend, and now I need more for... umm... more 'shrooms!)]
+		[npc.speech(Ooh! A poor innocent traveller wandering through my magical realm!)] [npc.she] giggles, clearly high on mushrooms. [npc.speech(I'm gonna need some cash from you, ok? I spent all my flames on buying some 'shrooms from my friend, and now I need more for... umm... more 'shrooms!)]
 	</p>
 	<p>
 		You can tell that [npc.name] is willing to fight, and you only have a moment in which to decide what to do...
@@ -144,7 +144,7 @@
 		[npc.Name] collapses to the floor, letting out a defeated sigh as [npc.she] gazes up at you. Looking down at the vanquished [npc.race] before you, you see that [npc.she]'s got a desperate look of regret in [npc.her] eyes. Making pitiful little whining noises, [npc.she] tries to shuffle away from you, clearly worried about what your intentions might be.
 	</p>
 	<p>
-		[npc.speech(J-Just take my money and leave me alone!)], [npc.she] pleads, throwing some flames at your feet.
+		[npc.speech(J-Just take my money and leave me alone!)] [npc.she] pleads, throwing some flames at your feet.
 	</p>
 	<p>
 		You wonder if you should do as [npc.she] says, and leave [npc.herHim] alone. Then again, you <i>could</i> take advantage of [npc.her] weakened, vulnerable body...

--- a/res/txt/places/submission/batCaverns.xml
+++ b/res/txt/places/submission/batCaverns.xml
@@ -6,7 +6,7 @@
 		This area of the bat caverns is home to the staircase that leads back up to Submission. A wooden sign next to the staircase warns any traveller against consuming the mushrooms found in certain parts of the caverns. A picture of some glowing blue mushrooms is displayed next to this warning, and beneath that, there's some information that identifies this particular fungi to be an exception. Apparently, it's the only edible type of mushroom that grows down here, and is highly sought-after by the slimes which inhabit these caverns. Apparently, eating these mushrooms has caused the slimes down here to glow, and also causes them to experience psychedelic effects, which makes their behaviour highly unpredictable.
 	</p>
 	<p>
-		Looking up towards the top of the staircase, you see the relatively-bright lighting of Submission's tunnels shining down to illuminate the top dozen or so steps.
+		Looking up towards the top of the staircase, you see the relatively bright lighting of Submission's tunnels shining down to illuminate the top dozen or so steps.
 		 Perhaps because of that ever-present source of light, this area seems entirely deserted...
 	</p>
 	]]>
@@ -14,7 +14,7 @@
 	
 	<htmlContent tag="CAVERN_DARK"><![CDATA[
 	<p>
-		The thick, inky blackness of the bat caverns is kept at bay by the softly glowing moss beneath your feet. With every step, a new pool of the low light blooms outward as the previous one fades, allowing you to see out to roughly fifteen metres all around you. Above your head, the cavern's roof is so high that all you can see is a blanket of completely-impenetrable darkness. Occasionally you think you hear a sound, a high-pitched keening, from somewhere up there, but you try not to think too hard about it.
+		The thick, inky blackness of the bat caverns is kept at bay by the softly glowing moss beneath your feet. With every step, a new pool of the low light blooms outward as the previous one fades, allowing you to see out to roughly fifteen metres all around you. Above your head, the cavern's roof is so high that all you can see is a blanket of completely impenetrable darkness. Occasionally you think you hear a sound, a high-pitched keening, from somewhere up there, but you try not to think too hard about it.
 	</p>
 	<p>
 		There's an ever-present dripping sound that echoes from everywhere and nowhere, giving the caverns its own ambient, if unfocused, melody. The air is also surprisingly fresh, clean and cool; not at all what you'd expect from a typical cave. Indeed, the fresh air down here is certainly chilly enough to raise goosebumps on any exposed skin and harden nipples beneath clothing. 
@@ -69,7 +69,7 @@
 		A slow-moving underground river carves its way through the bat caverns, and it's beside this body of water that you find yourself travelling. While the river's surface is illuminated by the bioluminescent lichen, the light is too dim to penetrate the cool, dark depths, and you wonder what sort of creatures, if any, would call such an inhospitable place home.
 	</p>
 	<p>
-		The cavern's roof slopes down before you, and the path that you were walking on suddenly comes to an abrupt halt as it meets a solid wall of stone. The river to your side drops away into a pitch-black abyss, and by the light of the lichen underfoot, you see that a finely-meshed metal grate has been built to save anyone from being swept down into the bottomless depths below.
+		The cavern's roof slopes down before you, and the path that you were walking on suddenly comes to an abrupt halt as it meets a solid wall of stone. The river to your side drops away into a pitch-black abyss, and by the light of the lichen underfoot, you see that a finely meshed metal grate has been built to save anyone from being swept down into the bottomless depths below.
 	</p>
 	<p>
 		With no way forwards, you'll have to turn around and double-back on yourself...

--- a/res/txt/places/submission/slimeQueensLair.xml
+++ b/res/txt/places/submission/slimeQueensLair.xml
@@ -344,7 +344,7 @@
 	
 	<htmlContent tag="ROOM"><![CDATA[
 	<p>
-		Just like the rest of the tower, the stone walls of this bedroom are covered in tapestries, and a thick burgundy rug covers most of the floor. On one side of the room stands a neatly-made four-poster bed, and opposite to that, a small fire flickers happily away in a stone hearth.
+		Just like the rest of the tower, the stone walls of this bedroom are covered in tapestries, and a thick burgundy rug covers most of the floor. On one side of the room stands a neatly made four-poster bed, and opposite to that, a small fire flickers happily away in a stone hearth.
 	</p>
 	<p>
 		From the pile of clothes on top of one of the room's dressers, it's obvious that this bedroom is in regular use, but after a cursory look around the place, you discover that there's nothing of any interest being stored in here.
@@ -415,14 +415,14 @@
 		[slimeRoyalGuard.speech(Is that so?)] [slimeRoyalGuard.name] laughs, his huge, barrel-like chest reverberating from his deafening roar as he booms, [slimeRoyalGuard.speech(I don't know how you got past the two downstairs, but your trespassing ends here! None can defeat the mighty [slimeRoyalGuard.name]!)]
 	</p>
 	<p>
-		As if to prove his point, the huge purple slime grips his sword in both hands, and, turning to one side, he thrusts the blade out into mid-air, before turning it back and performing a perfectly-horizontal slice. You're alarmed by how agile [slimeRoyalGuard.name] appears to be, despite his huge size, and before you can think about what to do next, he steps forwards, booming once more as he points his sword at you. [slimeRoyalGuard.speech(Defend yourself, [pc.name]!)]
+		As if to prove his point, the huge purple slime grips his sword in both hands, and, turning to one side, he thrusts the blade out into mid-air, before turning it back and performing a perfectly horizontal slice. You're alarmed by how agile [slimeRoyalGuard.name] appears to be, despite his huge size, and before you can think about what to do next, he steps forwards, booming once more as he points his sword at you. [slimeRoyalGuard.speech(Defend yourself, [pc.name]!)]
 	</p>
 	]]>
 	</htmlContent>
 	
 	<htmlContent tag="SLIME_ROYAL_GUARD_BEGIN_SEX_AS_DOM"><![CDATA[
 	<p>
-		You can't resist the sight of [slimeRoyalGuard.name]'s huge, muscular figure sitting on the stone bench before you. The way his broad, strong chest rises and falls with ever breath has you captivated, and before you're able to stop yourself, you're stepping forwards and reaching down to take hold of his arm. As he looks up at you, you pull him to his feet, and, stepping forwards, you plant a passionate kiss on his slightly-parted lips.
+		You can't resist the sight of [slimeRoyalGuard.name]'s huge, muscular figure sitting on the stone bench before you. The way his broad, strong chest rises and falls with ever breath has you captivated, and before you're able to stop yourself, you're stepping forwards and reaching down to take hold of his arm. As he looks up at you, you pull him to his feet, and, stepping forwards, you plant a passionate kiss on his slightly parted lips.
 	</p>
 	<p>
 		[slimeRoyalGuard.Name] reaches around to pull you close to him, but, not wanting to let him take control, you quickly break off the kiss, before grabbing hold of his wrists and warning him, [pc.speech(Don't forget, [slimeRoyalGuard.name], <i>I'm</i> the one in charge here.)] 
@@ -435,7 +435,7 @@
 	
 	<htmlContent tag="SLIME_ROYAL_GUARD_BEGIN_SEX_AS_SUB"><![CDATA[
 	<p>
-		You can't resist the sight of [slimeRoyalGuard.name]'s huge, muscular figure sitting on the stone bench before you. The way his broad, strong chest rises and falls with ever breath has you captivated, and before you're able to stop yourself, you're stepping forwards and sitting down next to him. As he looks over at you, you lean into his chest, before planting a passionate kiss on his slightly-parted lips.
+		You can't resist the sight of [slimeRoyalGuard.name]'s huge, muscular figure sitting on the stone bench before you. The way his broad, strong chest rises and falls with ever breath has you captivated, and before you're able to stop yourself, you're stepping forwards and sitting down next to him. As he looks over at you, you lean into his chest, before planting a passionate kiss on his slightly parted lips.
 	</p>
 	<p>
 		[slimeRoyalGuard.Name] reaches around to pull you close to him, and, perfectly content to let him take control, you gently break off the kiss, before [pc.moaning] [pc.speech(Oh yes, [slimeRoyalGuard.name], take me! Take me now!)] 
@@ -735,7 +735,7 @@
 		The room in front of you is similar in many ways to the rest of the tower, with the walls covered in tapestries, a burgundy rug underfoot, and rudimentary wooden chandeliers hanging from the ceiling's wooden beams. What sets this particular room apart, however, is the colossal four-poster bed on the left-hand-side of the room. It's by far the largest bed you've ever seen, and from a quick estimate, you guess that it's well over fifteen feet in length.
 	</p>
 	<p>
-		Along with this abnormally-sized piece of furniture, there's another feature of this room which catches your attention. In the far right corner, you see a decoratively-carved wooden wall, no higher than two feet, and measuring roughly ten feet on each of its square sides. The interior of this enclosure has been tiled to form a huge bath, and is currently filled with a considerable amount of translucent pink liquid.
+		Along with this abnormally sized piece of furniture, there's another feature of this room which catches your attention. In the far right corner, you see a decoratively carved wooden wall, no higher than two feet, and measuring roughly ten feet on each of its square sides. The interior of this enclosure has been tiled to form a huge bath, and is currently filled with a considerable amount of translucent pink liquid.
 	</p>
 	<p>
 		Glancing around the room, you don't see any sign of the Slime Queen, and, highly suspicious of the bath's slimy pink contents, you slowly make your way towards it. As you approach, you see several pieces of gold jewellery scattered around the bath's floor. In the middle of all of these, there's a small, glowing pink core, confirming that the bath's contents are concealing the slime that you've been seeking.
@@ -787,7 +787,7 @@
 		The Slime Queen's room is similar in many ways to the rest of the tower, with the walls covered in tapestries, a burgundy rug underfoot, and rudimentary wooden chandeliers hanging from the ceiling's wooden beams. What sets this particular room apart, however, is the colossal four-poster bed on the left-hand-side of the room. It's by far the largest bed you've ever seen, and from a quick estimate, you guess that it's well over fifteen feet in length.
 	</p>
 	<p>
-		Along with this abnormally-sized piece of furniture, there's another feature of this room which is out of the ordinary. In the far right corner, you see a decoratively-carved wooden wall, no higher than two feet, and measuring roughly ten feet on each of its square sides. The interior of this enclosure has been tiled to form a huge bath, and is currently filled with a considerable amount of translucent pink liquid.
+		Along with this abnormally sized piece of furniture, there's another feature of this room which is out of the ordinary. In the far right corner, you see a decoratively carved wooden wall, no higher than two feet, and measuring roughly ten feet on each of its square sides. The interior of this enclosure has been tiled to form a huge bath, and is currently filled with a considerable amount of translucent pink liquid.
 	</p>
 	<p>
 		Relaxing in this pool of pink slime is Catherine, who jumps to her feet as she sees you enter. Making no attempt to cover her huge, naked body, she cries, [slimeQueen.speech(~Aah!~ You've returned! I-I knew you wouldn't be able to resist your lustful impulses for long!)]

--- a/res/txt/places/submission/slimeQueensLair.xml
+++ b/res/txt/places/submission/slimeQueensLair.xml
@@ -37,7 +37,7 @@
 	</p>
 	<p>
 		[slimeFire.Name] spins around, grinning as [slimeFire.he] sees you come to a halt in front of [slimeFire.him]. Unashamedly naked, and sporting a huge erection, [slimeFire.he] places [slimeFire.his] [slimeFire.hands] on [slimeFire.his] [slimeFire.hips] and calls out to you.
-		 [slimeFire.speech(Hey [pc.name]! Her Majesty's ordered us to let you come and go as you please, but you've got time to have some fun, right? #IFgame.incestOn#THENSis'#ELSE[slimeIce.name]#ENDIF over here was just begging for me to fu-)]
+		 [slimeFire.speech(Hey, [pc.name]! Her Majesty's ordered us to let you come and go as you please, but you've got time to have some fun, right? #IFgame.incestOn#THENSis'#ELSE[slimeIce.name]#ENDIF over here was just begging for me to fu-)]
 	</p>
 	<p>
 		[slimeIce.speech([slimeFire.Name]!)] [slimeIce.name] shouts, cutting her #IFgame.incestOn#THENbrother#ELSElover#ENDIF off. [slimeIce.speech(I-I mean, I may have said some things... B-But that's no reason to shout it out for everyone to hear!)]
@@ -63,7 +63,7 @@
 		[slimeFire.Name] and [slimeIce.name] are still standing guard beside the wooden barricade, and as you approach, [slimeIce.name] catches sight of you, and squeaks, [slimeIce.speech(#IFgame.incestOn#THENB-Brother!#ELSE[slimeFire.Name]!#ENDIF [pc.Name] is back!)]
 	</p>
 	<p>
-		[slimeFire.Name] turns and smiles at you, waving you past as he grins, [slimeFire.speech(Carry on through! Oh, and if you want to have some fun, just say so! #IFgame.incestOn#THENSis'#ELSE[slimeIce.Name]#ENDIF and I are always up for a good fuck!)]
+		[slimeFire.Name] turns and smiles at you, waving you past as he grins. [slimeFire.speech(Carry on through! Oh, and if you want to have some fun, just say so! #IFgame.incestOn#THENSis'#ELSE[slimeIce.Name]#ENDIF and I are always up for a good fuck!)]
 	</p>
 	<p>
 		You wonder if you should take [slimeFire.name] up on his offer, or decline and continue on your way...
@@ -102,7 +102,7 @@
 		Before you can respond, the slime-girl nervously starts hopping around on her feet, stammering, [slimeIce.speech([slimeFire.Name]! [pc.She] saw us! A-And I was a-about to... Y-You know!)]
 	</p>
 	<p>
-		[slimeFire.speech(Calm down, [slimeIce.name]. I don't care who sees us doing those things, but right now, we need to remember our duty! We must protect the Queen!)] The slime-boy, '[slimeFire.name]' says to his #IFgame.incestOn#THENsister#ELSEpartner#ENDIF, before turning to you. [slimeFire.speech(Don't make me ask again. Who are you?!)]
+		[slimeFire.speech(Calm down, [slimeIce.name]. I don't care who sees us doing those things, but right now, we need to remember our duty! We must protect the Queen!)] the slime-boy, '[slimeFire.name]' says to his #IFgame.incestOn#THENsister#ELSEpartner#ENDIF, before turning to you. [slimeFire.speech(Don't make me ask again. Who are you?!)]
 	</p>
 	<p>
 		As you prepare to respond, [slimeIce.name] grabs a sword and buckler for herself, and you notice that the blades of each of the slimes' weapons match their body colours. It looks like both of them are ready for a fight, and you choose your next words carefully as you step forwards...
@@ -112,7 +112,7 @@
 	
 	<htmlContent tag="GUARD_POST_SEX_SIDE_BY_SIDE"><![CDATA[
 	<p>
-		[pc.speech(I could do with having some fun.)] You say, smiling at the slime #IFgame.incestOn#THENsiblings#ELSElovers#ENDIF. Stepping forwards, you take hold of [slimeFire.name]'s shoulders, before pushing him down onto his hands and knees before you.
+		[pc.speech(I could do with having some fun,)] you say, smiling at the slime #IFgame.incestOn#THENsiblings#ELSElovers#ENDIF. Stepping forwards, you take hold of [slimeFire.name]'s shoulders, before pushing him down onto his hands and knees before you.
 	</p>
 	<p>
 		[slimeIce.speech(~Ah!~ #IFgame.incestOn#THENB-Brother!#ELSE[slimeFire.Name]!#ENDIF)] [slimeIce.name] stutters, stepping forwards to make sure her lover is ok. As she does so, you take hold of her wrist, and, with a firm tug, pull her down beside her #IFgame.incestOn#THENbrother#ELSElover#ENDIF. Stepping around behind the two slimes, you can't help but grin as you find yourself looking down on their naked asses as they bump into one another.
@@ -125,7 +125,7 @@
 	
 	<htmlContent tag="GUARD_POST_SEX_SPITROASTED"><![CDATA[
 	<p>
-		[pc.speech(I could do with having some fun.)] You say, smiling at the slime #IFgame.incestOn#THENsiblings#ELSElovers#ENDIF. Stepping forwards, you take hold of [slimeFire.name]'s hand, before turning around and guiding it down onto your [pc.ass+]. Immediately, he gives it a firm squeeze, which causes you to let out a desperate [pc.moan] and drop down onto all fours in front of him. Just as you'd hoped, he sinks to his knees behind you, ready to fuck you in the doggy-style position.
+		[pc.speech(I could do with having some fun,)] you say, smiling at the slime #IFgame.incestOn#THENsiblings#ELSElovers#ENDIF. Stepping forwards, you take hold of [slimeFire.name]'s hand, before turning around and guiding it down onto your [pc.ass+]. Immediately, he gives it a firm squeeze, which causes you to let out a desperate [pc.moan] and drop down onto all fours in front of him. Just as you'd hoped, he sinks to his knees behind you, ready to fuck you in the doggy-style position.
 	</p>
 	<p>
 		[slimeIce.speech(~Ah!~ I-I want some fun too!)] [slimeIce.name] whines, stepping forwards and sinking to her knees in front of you. Placing her hands on your head, she shuffles forwards, presenting her slimy pussy to your mouth as she moans, [slimeIce.speech(~Mmmm!~ Come on! Get your tongue in here!)]
@@ -191,7 +191,7 @@
 	<p>
 		Curious about the #IFgame.incestOn#THENslime siblings'#ELSEslimes'#ENDIF history, and how they came to serve the Slime Queen, you decide to ask them about it. [pc.speech(So, how did you two end up working here?)]
 	</p>
-		[slimeFire.speech(Well, #IFgame.incestOn#THENsis'#ELSE[slimeIce.name]#ENDIF and I used to work up in Submission, at the Gambling Den. I was one of the security, while #IFgame.incestOn#THENsis'#ELSE[slimeIce.name]#ENDIF used to referee that pregnancy roulette game they've got going in there.)]
+		[slimeFire.speech(Well, #IFgame.incestOn#THENsis'#ELSE[slimeIce.name]#ENDIF and I used to work up in Submission, at the Gambling Den. I was one of the security, while #IFgame.incestOn#THENsis'#ELSE[slimeIce.name]#ENDIF used to referee that pregnancy roulette game they've got going in there,)]
 		 [slimeFire.name] responds, crossing his arms and leaning back against the wooden barricade as he tells his story. [slimeFire.speech(A lot of the other guards gave me a hard time, just because #IFgame.incestOn#THENI wasn't afraid of giving my sis' what it is she likes the most#ELSEI'd always spend my breaks giving [slimeIce.name] a good fuck#ENDIF. Isn't that right, [slimeIce.name]?)]
 	</p>
 	<p>
@@ -219,7 +219,7 @@
 		[slimeFire.speech(That's right!)] [slimeFire.name] laughs. [slimeFire.speech(My #IFgame.incestOn#THENsis'#ELSE[slimeIce.name]#ENDIF can do anything if she puts her mind to it, and now she's even almost as good as me! Well, that's our story, such as it is...)]
 	</p>
 	<p>
-		[pc.speech(Thanks for sharing it with me.)] You respond, your curiosity sated.
+		[pc.speech(Thanks for sharing it with me,)] you respond, your curiosity sated.
 	</p>
 	]]>
 	</htmlContent>
@@ -254,7 +254,7 @@
 		[slimeIce.speech(~Aah!~ #IFgame.incestOn#THENB-Brother!#ELSE[slimeFire.name]!#ENDIF I can't carry on...)] [slimeIce.name] moans, before sinking to the floor and reaching down between her legs.
 	</p>
 	<p>
-		[slimeFire.Name] seems to be in a similar state of affairs, and as you step towards the defeated #IFgame.incestOn#THENslime siblings#ELSEslimes#ENDIF, he drops down on one knee panting, [slimeFire.speech(We... We surrender... No more...)]
+		[slimeFire.Name] seems to be in a similar state of affairs, and as you step towards the defeated #IFgame.incestOn#THENslime siblings#ELSEslimes#ENDIF, he drops down on one knee, panting, [slimeFire.speech(We... We surrender... No more...)]
 	</p>
 	<p>
 		With your powerful arcane aura clearly causing these two slimes to be overwhelmed with lust, you wonder if you should take advantage of the situation, or continue on your way through the Slime Queen's tower...
@@ -277,7 +277,7 @@
 	
 	<htmlContent tag="GUARD_POST_SEX_SPITROASTED_UPON_DEFEAT"><![CDATA[
 	<p>
-		In one swift move, [slimeFire.name] throws you to the floor, laughing [slimeFire.speech(That's right, get down on all fours so me and #IFgame.incestOn#THENsis'#ELSE[slimeIce.name]#ENDIF can have some fun!)]
+		In one swift move, [slimeFire.name] throws you to the floor, laughing, [slimeFire.speech(That's right, get down on all fours so me and #IFgame.incestOn#THENsis'#ELSE[slimeIce.name]#ENDIF can have some fun!)]
 	</p>
 	<p>
 		Before you can react, [slimeFire.name] drops down onto his knees behind you, before grabbing hold of your [pc.hips+] and grinding his [slimeFire.cock+] against your [pc.ass+]. Seeing her #IFgame.incestOn#THENbrother#ELSElover#ENDIF take such a bold move, [slimeIce.name] quickly steps forwards, before dropping down onto her knees right in front of your face. Shuffling forwards, she presents her [slimeIce.pussy+] to you, and moans, [slimeIce.speech(Come on! Get that tongue working already!)]
@@ -293,7 +293,7 @@
 		The #IFgame.incestOn#THENslime siblings#ELSEslimes#ENDIF both step back, allowing you to sink to the floor as you're completely overcome with exhaustion. You aren't given much time to rest, however, as after just a moment you're seized by [slimeFire.name], before being hauled to your feet.
 	</p>
 	<p>
-		[slimeIce.speech(Here's your stuff.)] [slimeIce.name] says, shoving your things into your [pc.arms].
+		[slimeIce.speech(Here's your stuff,)] [slimeIce.name] says, shoving your things into your [pc.arms].
 	</p>
 	<p>
 		With that, [slimeFire.name] half-carries, half-drags you to the front door of the tower, before releasing you and stepping back. [slimeFire.speech(Maybe this'll teach you a lesson about trespassing!)]
@@ -370,10 +370,10 @@
 		Up ahead, you see [slimeRoyalGuard.name] swinging his huge sword back and forth as he charges up and down the corridor. He catches sight of you as you approach, and, slinging the sword over his shoulder, he steps forwards and bars the way as he calls out to you, [slimeRoyalGuard.speech(Ah! If it isn't [pc.name], coming to challenge the mighty [slimeRoyalGuard.name]!)]
 	</p>
 	<p>
-		Coming to a halt in front of the [slimeRoyalGuard.race], you smile as you reply, [pc.speech(Hello again [slimeRoyalGuard.name]. You're as energetic as ever, I see.)]
+		Coming to a halt in front of the [slimeRoyalGuard.race], you smile as you reply, [pc.speech(Hello again, [slimeRoyalGuard.name]. You're as energetic as ever, I see.)]
 	</p>
 	<p>
-		[slimeRoyalGuard.speech(Why of course!)] [slimeRoyalGuard.name] cries out, [slimeRoyalGuard.speech(There's no time to be resting! Not while there are still combat techniques to be learned!)]
+		[slimeRoyalGuard.speech(Why of course!)] [slimeRoyalGuard.name] cries out. [slimeRoyalGuard.speech(There's no time to be resting! Not while there are still combat techniques to be learned!)]
 	</p>
 	<p>
 		As if to demonstrate his resolve, [slimeRoyalGuard.name] suddenly grasps his sword in both hands, and, spinning around, he darts forwards, before slicing and thrusting into mid-air as shows off his ability to wield his weapon. Once he's done, he turns back to you, panting slightly as he issues a challenge, [slimeRoyalGuard.speech(Her royal Highness has instructed me to allow you to come and go as you please, but she never forbade me from issuing challenges! If you'd like to have a little sparring match, I'd love to put my moves to the test! What do you say?)]
@@ -457,10 +457,10 @@
 		[slimeRoyalGuard.name]'s smile disappears, and he frowns as he continues, [slimeRoyalGuard.speech(After a while, I gave up on trying to impress her, and travelled from the Foloi Fields to find adventure in Dominion.)]
 	</p>
 	<p>
-		[pc.speech(And that's when you met Catherine?)] You ask.
+		[pc.speech(And that's when you met Catherine?)] you ask.
 	</p>
 	<p>
-		[slimeRoyalGuard.speech(That's right.)] [slimeRoyalGuard.name] replies, [slimeRoyalGuard.speech(Soon after arriving in the city, I realised that the lowlifes who haunt the alleyways wouldn't ever be able to challenge my skill with the sword, so, after hearing that Submission was more dangerous, I travelled down there in search of worthy opponents. Fate must have decreed that we meet, for I found her Highness in the very first tunnel that I decided to explore.)]
+		[slimeRoyalGuard.speech(That's right,)] [slimeRoyalGuard.name] replies. [slimeRoyalGuard.speech(Soon after arriving in the city, I realised that the lowlifes who haunt the alleyways wouldn't ever be able to challenge my skill with the sword, so, after hearing that Submission was more dangerous, I travelled down there in search of worthy opponents. Fate must have decreed that we meet, for I found her Highness in the very first tunnel that I decided to explore.)]
 	</p>
 	<p>
 		At this point, you see [slimeRoyalGuard.name]'s cheeks turn a slightly darker shade of purple, and he shuffles about on his feet a little as he continues, [slimeRoyalGuard.speech(She'd just run into a pair of rat-boys, you see, who were about to have their way with her... Needless to say, I quickly gave them a sound beating, and once I'd seen them off, I turned to help her Highness. S-She had the wrong idea at first, and thought that I wanted to ~Ahem!~ 'ravish' her.)]
@@ -469,25 +469,25 @@
 		Knowing what Catherine is like, you nod in understanding, imagining how the situation must have played out. [slimeRoyalGuard.name] quickly moves on, and continues with his tale, [slimeRoyalGuard.speech(After I'd explained that I was simply protecting her, I helped her to her feet. She was so happy to have been saved, she immediately hugged me, which caught me completely off guard. Still weakened from her ordeal, she accidentally collapsed on top of me, and before I knew what was happening, I'd been sucked into her body!)]
 	</p>
 	<p>
-		[pc.speech(So this is how you became a slime?)] You ask, seeing where this is going.
+		[pc.speech(So this is how you became a slime?)] you ask, seeing where this is going.
 	</p>
 	<p>
-		[slimeRoyalGuard.speech(That's right.)] [slimeRoyalGuard.name] replies, [slimeRoyalGuard.speech(By the time her Highness managed to spit me out, I'd already swallowed down litres of her slime. Needless to say, and as you've already guessed, her body's transformative properties quickly turned me into the slime you see today.)]
+		[slimeRoyalGuard.speech(That's right,)] [slimeRoyalGuard.name] replies. [slimeRoyalGuard.speech(By the time her Highness managed to spit me out, I'd already swallowed down litres of her slime. Needless to say, and as you've already guessed, her body's transformative properties quickly turned me into the slime you see today.)]
 	</p>
 	<p>
-		[pc.speech(So you decided to protect the one who'd transformed you?)] You ask, curious to find out how this led to [slimeRoyalGuard.name] becoming Catherine's guard.
+		[pc.speech(So you decided to protect the one who'd transformed you?)] you ask, curious to find out how this led to [slimeRoyalGuard.name] becoming Catherine's guard.
 	</p>
 	<p>
-		[slimeRoyalGuard.speech(Well, at first, I was shocked and angry, but her Highness was so distressed by what she'd done, I couldn't stay mad at her for long. She insisted on following me back up to Dominion, calling me 'her heroic knight', and saying that it was fate that led me to her.)] [slimeRoyalGuard.name] recalls, smiling at the memory. [slimeRoyalGuard.speech(By the time I'd gathered enough flames to have a solidification potion made, I'd seen enough of her Highness's antics to realise that she needs someone to protect her. Having grown used to this form, I decided to stay as a slime, and pledged to protect her Highness for as long as she wanted me to.)]
+		[slimeRoyalGuard.speech(Well, at first, I was shocked and angry, but her Highness was so distressed by what she'd done, I couldn't stay mad at her for long. She insisted on following me back up to Dominion, calling me 'her heroic knight', and saying that it was fate that led me to her,)] [slimeRoyalGuard.name] recalls, smiling at the memory. [slimeRoyalGuard.speech(By the time I'd gathered enough flames to have a solidification potion made, I'd seen enough of her Highness's antics to realise that she needs someone to protect her. Having grown used to this form, I decided to stay as a slime, and pledged to protect her Highness for as long as she wanted me to.)]
 	</p>
 	<p>
-		[pc.speech(At this point, Catherine wasn't calling herself the 'Slime Queen' though, right?)] You ask, wondering when that happened.
+		[pc.speech(At this point, Catherine wasn't calling herself the 'Slime Queen' though, right?)] you ask, wondering when that happened.
 	</p>
 	<p>
 		[slimeRoyalGuard.speech(It was shortly after I'd pledged myself to her that she started doing that,)] [slimeRoyalGuard.name] admits. [slimeRoyalGuard.speech(She grew rather attached to the idea of me being her knight, and decided that forcing her slime transformation onto others made her their queen. Although I was reluctant to carry out some of her more erratic orders at first, I'd already sworn to obey her, and helped her to transform her first subjects.)]
 	</p>
 	<p>
-		[pc.speech(Thanks for sharing your story with me.)] You say, your curiosity sated.
+		[pc.speech(Thanks for sharing your story with me,)] you say, your curiosity sated.
 	</p>
 	]]>
 	</htmlContent>
@@ -510,13 +510,13 @@
 	
 	<htmlContent tag="ROYAL_GUARD_POST_ADMIRE_INSTRUCT"><![CDATA[
 	<p>
-		From your fighting experience, you're able to identify several key mistakes that [slimeRoyalGuard.name] made in his demonstration, and, putting on your most commanding tone, you express your concerns. [pc.speech(On your third turn, you dropped your guard, exposing yourself to an attack from your left. Then when you repeated that move for a second time later on in your performance, you failed once again to keep your head and left-side protected.)]
+		From your fighting experience, you're able to identify several key mistakes that [slimeRoyalGuard.name] made in his demonstration, and, putting on your most commanding tone, you express your concerns, [pc.speech(On your third turn, you dropped your guard, exposing yourself to an attack from your left. Then when you repeated that move for a second time later on in your performance, you failed once again to keep your head and left-side protected.)]
 	</p>
 	<p>
 		[slimeRoyalGuard.speech(W-What?)] [slimeRoyalGuard.name] stutters, caught off guard by your sudden critique. [slimeRoyalGuard.speech(But I was leading into-)]
 	</p>
 	<p>
-		[pc.speech(You were leading into getting yourself hit.)] you say, cutting the [slimeRoyalGuard.race] off. [pc.speech(And that wasn't your only mistake. You have a habit of lowering your guard before every strike. While your average untrained opponent won't pick up on it, you're telegraphing each and every one of your moves, leaving yourself open to a counter-attack. You're also far too reliant on overhead swings, and when you do attempt to strike from a different position, your footwork gets pretty sloppy.)]
+		[pc.speech(You were leading into getting yourself hit,)] you say, cutting the [slimeRoyalGuard.race] off. [pc.speech(And that wasn't your only mistake. You have a habit of lowering your guard before every strike. While your average untrained opponent won't pick up on it, you're telegraphing each and every one of your moves, leaving yourself open to a counter-attack. You're also far too reliant on overhead swings, and when you do attempt to strike from a different position, your footwork gets pretty sloppy.)]
 	</p>
 	<p>
 		[slimeRoyalGuard.speech(W-Well, I don't have anyone to train with,)] [slimeRoyalGuard.name] tries to explain, [slimeRoyalGuard.speech(so I don't notice these things when I'm practising by myself.)]
@@ -541,7 +541,7 @@
 		[slimeRoyalGuard.speech(What... What's that?)] [slimeRoyalGuard.name] asks, still panting as he tries to get his breath back.
 	</p>
 	<p>
-		[pc.speech(It's an issue with your favourite stance, where you strike from above. Show me it again.)] you say, preparing to deliver a decisive strike.
+		[pc.speech(It's an issue with your favourite stance, where you strike from above. Show me it again,)] you say, preparing to deliver a decisive strike.
 	</p>
 	<p>
 		[slimeRoyalGuard.speech(Like this?)] the [slimeRoyalGuard.race] asks, raising his sword above his head.
@@ -553,13 +553,13 @@
 		As [slimeRoyalGuard.name] starts to do as you command, you prepare to make your move. Half-way through his turn, with his back towards you, you strike. Dashing forwards, you reach up to grab his arms, twisting them and forcing him to drop his sword before pinning them behind his back. Before he can react to your move, you hook one leg in front of his, and with a forceful shove, you tackle [slimeRoyalGuard.name] to the ground. As his chest hits the solid floor, you drive your weight into his back, completely winding him as you grapple him into a choke-hold.
 	</p>
 	<p>
-		[pc.speech(This is the final thing you're lacking.)] you explain to [slimeRoyalGuard.name] as you pin him to the floor, [pc.speech(You lack the awareness of what your enemy is trying to do. You allowed me to trick you into wearing yourself out, and now you've been defeated before even landing a single hit.)]
+		[pc.speech(This is the final thing you're lacking,)] you explain to [slimeRoyalGuard.name] as you pin him to the floor. [pc.speech(You lack the awareness of what your enemy is trying to do. You allowed me to trick you into wearing yourself out, and now you've been defeated before even landing a single hit.)]
 	</p>
 	<p>
 		Completely overcome by your sudden move, [slimeRoyalGuard.name] isn't even able to offer a response, and, sensing that he's not going to be in fighting condition again fro some time, you release your hold on him and step back.
 	</p>
 	<p>
-		[slimeRoyalGuard.Name] pushes himself up onto his hands and knees, before crawling over to one side of the corridor and collapsing down onto a stone bench. [slimeRoyalGuard.speech(You... You got me...)] He pants, slouching down in defeat.
+		[slimeRoyalGuard.Name] pushes himself up onto his hands and knees, before crawling over to one side of the corridor and collapsing down onto a stone bench. [slimeRoyalGuard.speech(You... You got me...)] he pants, slouching down in defeat.
 	</p>
 	<p>
 		With [slimeRoyalGuard.name] defeated, you could take advantage of him, or choose to continue on towards your final goal of meeting the Slime Queen...
@@ -578,7 +578,7 @@
 		After a few minutes of this, [slimeRoyalGuard.name] finishes his display and turns back towards you. You make sure to let him catch you staring at his body, and, looking longingly into his eyes, you sigh, [pc.speech(The queen sure is lucky to have you as her guard... I bet she calls you for some private assistance all the time...)]
 	</p>
 	<p>
-		[slimeRoyalGuard.speech(I-It's nothing like that!)] [slimeRoyalGuard.name] stutters, [slimeRoyalGuard.speech(I just protect her, t-that's all!)]
+		[slimeRoyalGuard.speech(I-It's nothing like that!)] [slimeRoyalGuard.name] stutters. [slimeRoyalGuard.speech(I just protect her, t-that's all!)]
 	</p>
 	<p>
 		[pc.speech(So you mean you're free to have some fun, hmm?)] you ask, winking at the [slimeRoyalGuard.race] and biting your lip. 
@@ -597,7 +597,7 @@
 		[slimeRoyalGuard.speech(W-Well I-I'd love to but-)] [slimeRoyalGuard.name] starts, but you quickly step forwards and press a finger to his lips.
 	</p>
 	<p>
-		[pc.speech(You don't need to make any excuses.)] you say, looking down at the [slimeRoyalGuard.race]'s crotch and letting out a delighted cry as you see the distinctive shape of an erection pressing out beneath the fabric of his clothes. [pc.speech(How about you show me your skill with your other sword?)]
+		[pc.speech(You don't need to make any excuses,)] you say, looking down at the [slimeRoyalGuard.race]'s crotch and letting out a delighted cry as you see the distinctive shape of an erection pressing out beneath the fabric of his clothes. [pc.speech(How about you show me your skill with your other sword?)]
 	</p>
 	<p>
 		Unable to resist your advances any longer, [slimeRoyalGuard.name] places his blade to one side, before taking hold of your [pc.arms] and pulling you into a passionate kiss. You let out a happy, muffled [pc.moan] as you feel his tongue slide into your mouth, and, closing your eyes, you tilt your head to one side and press yourself against the [slimeRoyalGuard.race] as you return his kiss.
@@ -693,7 +693,7 @@
 		[slimeRoyalGuard.Name] steps back, allowing you to sink to the floor as you're completely overcome with exhaustion. You aren't given much time to rest, however, as after just a moment the [slimeRoyalGuard.race] reaches down and pulls you to your feet.
 	</p>
 	<p>
-		[slimeRoyalGuard.speech(Here's your stuff.)] he says, before shoving your things into your [pc.arms].
+		[slimeRoyalGuard.speech(Here's your stuff,)] he says, before shoving your things into your [pc.arms].
 	</p>
 	<p>
 		With that, [slimeRoyalGuard.name] half-carries, half-drags you back down the corridor, down the spiral stairs, and over to the front door of the tower, before releasing you and stepping back. [slimeRoyalGuard.speech(I hope you've learned your lesson!)]
@@ -716,7 +716,7 @@
 		[slimeRoyalGuard.Name] steps back, allowing you to sink to the floor as you're completely overcome with exhaustion.
 	</p>
 	<p>
-		[slimeRoyalGuard.speech(Hah! That was fun!)] He laughs, [slimeRoyalGuard.speech(Let me know if you want to go again!)]
+		[slimeRoyalGuard.speech(Hah! That was fun!)] He laughs. [slimeRoyalGuard.speech(Let me know if you want to go again!)]
 	</p>
 	]]>
 	</htmlContent>
@@ -744,7 +744,7 @@
 		So as not to be caught off-guard and dragged into the bath, you step back, before calling out, [pc.speech(It's no use hiding! I know you're in there, Slime Queen!)]
 	</p>
 	<p>
-		[slimeQueen.speech(~Aah!~)] a surprised, yet slightly erotic, cry calls out from the bath, [slimeQueen.speech(You found me!)]
+		[slimeQueen.speech(~Aah!~)] a surprised, yet slightly erotic, cry calls out from the bath. [slimeQueen.speech(You found me!)]
 	</p>
 	<p>
 		Before you can respond, the bath's surface starts to push upwards, carrying a golden tiara, earrings, and necklace up from the tiled floor. The distinctive shape of a woman's head quickly forms out of the slime, and you watch, ready to defend yourself from any attack, as the rest of the Queen's naked body starts to take shape.
@@ -756,22 +756,22 @@
 		You instinctively step back as the slime before you continues to grow in height. Eight feet... Nine... Ten... Her growth shows no sign of stopping as she backs away from you, making no attempt to cover up her [slimeQueen.breastSize], [slimeQueen.cupSize]-cup breasts and [slimeQueen.pussy+].
 	</p>
 	<p>
-		[slimeQueen.speech(~Aaah!~)] she cries again, as she finished growing up to a final twelve-feet in height, [slimeQueen.speech(H-How did you get past my guards?! W-What do you want?)]
+		[slimeQueen.speech(~Aaah!~)] she cries again, as she finished growing up to a final twelve-feet in height. [slimeQueen.speech(H-How did you get past my guards?! W-What do you want?)]
 	</p>
 	<p>
 		Despite her immense size, the Slime Queen shows no sign of aggression, and almost trips over the edge of the bath as she attempts to manoeuvre her way towards her bed. Worried that she might try to draw strength from the considerable amount of pink goo still left in the bath, you give the Slime Queen some space, allowing her to rush over and hide behind her huge bed.
 	</p>
 	<p>
-		Sensing that the Queen isn't going to fight, you step forwards and start to answer her question. [pc.speech(Let's just say that your guards won't be bothering us. As to what it is I want, I-)]
+		Sensing that the Queen isn't going to fight, you step forwards and start to answer her question, [pc.speech(Let's just say that your guards won't be bothering us. As to what it is I want, I-)]
 	</p>
 	<p>
-		[slimeQueen.speech(I knew it!)] the Slime Queen cries, [slimeQueen.speech(you struck them down, and then had your wicked way with them, didn't you?!)]
+		[slimeQueen.speech(I knew it!)] the Slime Queen cries. [slimeQueen.speech(You struck them down, and then had your wicked way with them, didn't you?!)]
 	</p>
 	<p>
 		[pc.speech(Well, I-)] you start to explain, but the colossal Slime Queen suddenly jumps to her feet, before pressing the back of her hand to her forehead and swooning.
 	</p>
 	<p>
-		[slimeQueen.speech(~Ah!~ Say no more! I know that you cut your way through them, intent on storming my personal bed chambers, where you'd claim your reward and ravish my supple, defenceless body!)] She cries, falling backwards onto her bed in such a position that she's presenting her exposed pussy to you. [slimeQueen.speech(Y-You monster! To think I, Catherine, the Queen of all Slimes, am about to be despoiled by an invading [pc.race]! M-Mercy! I beg of you!)]
+		[slimeQueen.speech(~Ah!~ Say no more! I know that you cut your way through them, intent on storming my personal bed chambers, where you'd claim your reward and ravish my supple, defenceless body!)] she cries, falling backwards onto her bed in such a position that she's presenting her exposed pussy to you. [slimeQueen.speech(Y-You monster! To think I, Catherine, the Queen of all Slimes, am about to be despoiled by an invading [pc.race]! M-Mercy! I beg of you!)]
 	</p>
 	<p>
 		Despite her words, Catherine shows no hint of trying to run or protect herself from you. Quite on the contrary, she spreads her legs and slips one of her hands down to part her [slimeQueen.labia+], moaning as she does so, [slimeQueen.speech(No! Please! Don't ruin me! You can't do this to royalty!)]
@@ -806,16 +806,16 @@
 	
 	<htmlContent tag="SLIME_QUEEN_CONVINCE"><![CDATA[
 	<p>
-		[pc.speech(Please calm down,)] you say, [pc.speech(I'm here on behalf of Submission's enforcers. Your subjects up in the tunnels have been causing quite a problem, what with transforming everyone into slimes and all. I'm here to put an end to it.)]
+		[pc.speech(Please calm down,)] you say. [pc.speech(I'm here on behalf of Submission's enforcers. Your subjects up in the tunnels have been causing quite a problem, what with transforming everyone into slimes and all. I'm here to put an end to it.)]
 	</p>
 	<p>
-		[slimeQueen.speech(S-So you're not going to ravish me?)] Catherine whines, sitting up on her bed and sulking, [slimeQueen.speech(You just want me to stop my subjects from transforming people?)]
+		[slimeQueen.speech(S-So you're not going to ravish me?)] Catherine whines, sitting up on her bed and sulking. [slimeQueen.speech(You just want me to stop my subjects from transforming people?)]
 	</p>
 	<p>
 		[pc.speech(That's right. Why are you doing this anyway? There are plenty of slimes in Submission already.)]
 	</p>
 	<p>
-		[slimeQueen.speech(Mmm... Well...)] the Slime Queen mumbles, looking down at her feet as she kicks them back and forth, [slimeQueen.speech(I was kind of hoping to attract someone like you... I thought that if I made a nuisance of myself, a sexy, strong [pc.hero] would storm my tower, beat my guards, and...)] Catherine shudders in delight, [slimeQueen.speech(<i>ravish</i> me...)]
+		[slimeQueen.speech(Mmm... Well...)] the Slime Queen mumbles, looking down at her feet as she kicks them back and forth. [slimeQueen.speech(I was kind of hoping to attract someone like you... I thought that if I made a nuisance of myself, a sexy, strong [pc.hero] would storm my tower, beat my guards, and...)] Catherine shudders in delight, [slimeQueen.speech(<i>ravish</i> me...)]
 	</p>
 	<p>
 		You can't help but let out a sigh as you hear the Slime Queen's ridiculous reason for wanting to transform people into slimes. [pc.speech(So you were only ordering your subjects to do this in order to get someone to defeat you?)]
@@ -824,7 +824,7 @@
 		[slimeQueen.speech(W-Well, it is kind of nice gaining more followers, but yeah. That's why I was doing this.)] Catherine looks up and pouts. [slimeQueen.speech(But now that you've finally come, you're not even going to have your way with me! That's not fair...)]
 	</p>
 	<p>
-		[pc.speech(I'm sure that there are plenty of people out there who are seeking revenge for being turned into slimes.)] you say, [pc.speech(And one of them is bound to want to 'ravish' you when they finally find you. I'm not asking you to leave your tower or stop calling yourself the Slime Queen, I just need you to stop telling your subjects to transform people. And if you're supplying them with those 'biojuice canisters', you need to stop that too.)]
+		[pc.speech(I'm sure that there are plenty of people out there who are seeking revenge for being turned into slimes,)] you say. [pc.speech(And one of them is bound to want to 'ravish' you when they finally find you. I'm not asking you to leave your tower or stop calling yourself the Slime Queen, I just need you to stop telling your subjects to transform people. And if you're supplying them with those 'biojuice canisters', you need to stop that too.)]
 	</p>
 	<p>
 		[slimeQueen.speech(F-Fine... I guess I don't have much say in the matter, now that my guards have failed me. I'll stop telling my subjects to transform people, and will only use the distillery to make Slime Quenchers from now on.)] Catherine whines, before suddenly throwing you a cheeky smile and continuing, [slimeQueen.speech(Do you wanna know how I've been making them?)]
@@ -833,19 +833,19 @@
 		[pc.speech(I think I can guess...)] you say, realising that Catherine's slimy body is the exact same colour as the liquid within the 'biojuice canisters'.
 	</p>
 	<p>
-		[slimeQueen.speech(~Mhm!~ That's right.)] Catherine giggles, sliding two of her fingers into her exposed pussy, [slimeQueen.speech(I spend all day in that bath, drinking water and letting my body convert it into more of my yummy slime! The distillery downstairs splits the transformative and non-transformative parts, and that's how we make Slime Quencher!)]
+		[slimeQueen.speech(~Mhm!~ That's right.)] Catherine giggles, sliding two of her fingers into her exposed pussy. [slimeQueen.speech(I spend all day in that bath, drinking water and letting my body convert it into more of my yummy slime! The distillery downstairs splits the transformative and non-transformative parts, and that's how we make Slime Quencher!)]
 	</p>
 	<p>
-		[pc.speech(And from now on, you'll throw the transformative part away.)] You firmly state, crossing your [pc.arms] and frowning at Catherine.
+		[pc.speech(And from now on, you'll throw the transformative part away,)] you firmly state, crossing your [pc.arms] and frowning at Catherine.
 	</p>
 	<p>
 		[slimeQueen.speech(Yes, I will, but there's a little problem. I don't really have any way to contact my subjects, and I've distributed quite a few of those canisters by now. I won't make any more, but I don't think your problem's going to disappear any time soon...)]
 	</p>
 	<p>
-		[pc.speech(Fine. At least there's not going to be any more encouragement from you from now on.)] you sigh, [pc.speech(Now, I'm going to need some proof for the enforcers that you won't be a problem anymore.)]
+		[pc.speech(Fine. At least there's not going to be any more encouragement from you from now on.)] You sigh. [pc.speech(Now, I'm going to need some proof for the enforcers that you won't be a problem anymore.)]
 	</p>
 	<p>
-		[slimeQueen.speech(Hmm, you can have this, I guess.)] Catherine says, taking off her crown and throwing it to you. [slimeQueen.speech(It's kind of uncomfortable to wear, so I was thinking of getting rid of it anyway.)]
+		[slimeQueen.speech(Hmm, you can have this, I guess,)] Catherine says, taking off her crown and throwing it to you. [slimeQueen.speech(It's kind of uncomfortable to wear, so I was thinking of getting rid of it anyway.)]
 	</p>
 	<p>
 		As you catch the crown, Catherine lies back on her bed, spreading her legs once more and sighing, [slimeQueen.speech(Now, if you'll excuse me, I'll just lie here for a while, all defenceless and innocent, hoping that you don't change your mind and decide to have your wicked way with me...)]
@@ -858,7 +858,7 @@
 	
 	<htmlContent tag="SLIME_QUEEN_FORCE"><![CDATA[
 	<p>
-		[pc.speech(If that's how you want it, then fine.)] you snarl, stepping up to the bed and grabbing the Slime Queen's arm. With a rough yank, you pull her up so that she's in a sitting position, before putting on your most menacing tone and continuing, [pc.speech(You're going to put an end to your subjects transforming people up in the tunnels!)]
+		[pc.speech(If that's how you want it, then fine,)] you snarl, stepping up to the bed and grabbing the Slime Queen's arm. With a rough yank, you pull her up so that she's in a sitting position, before putting on your most menacing tone and continuing, [pc.speech(You're going to put an end to your subjects transforming people up in the tunnels!)]
 	</p>
 	<p>
 		[slimeQueen.speech(Y-Yes! I-I'll do whatever you ask!)] Catherine cries, failing to conceal the aroused tone of her voice. [slimeQueen.speech(I'll just make the Slime Quenchers from now on! N-No more of the transformatives, I promise!)]
@@ -870,7 +870,7 @@
 		[slimeQueen.speech(Mmm... Well...)] the Slime Queen mumbles, [slimeQueen.speech(I was kind of hoping to attract someone like you... I thought that if I made a nuisance of myself, a sexy, strong [pc.hero] would storm my tower, beat my guards, and...)] Catherine shudders in delight, [slimeQueen.speech(<i>ravish</i> me...)]
 	</p>
 	<p>
-		[pc.speech(What kind of reason is that?! You're going to tell your subjects to stop this nonsense.)] you say, roughly tugging on the Slime Queen's arm to emphasise your point.
+		[pc.speech(What kind of reason is that?! You're going to tell your subjects to stop this nonsense,)] you say, roughly tugging on the Slime Queen's arm to emphasise your point.
 	</p>
 	<p>
 		[slimeQueen.speech(W-Well, I don't really have any way to contact my subjects, and I've distributed quite a few of those canisters by now... I-I won't make any more, but I don't think your problem's going to disappear any time soon...)]
@@ -879,10 +879,10 @@
 		You let out a frustrated sigh as the Slime Queen tells you this. [pc.speech(But you're the only one who can make them, right? And now that you're not going to make any more, at least it can't continue forever.)]
 	</p>
 	<p>
-		[slimeQueen.speech(~Mhmm~ T-That's right.)] Catherine giggles, sliding her free hand down to rub at her exposed pussy, [slimeQueen.speech(I-I spend all day in that bath, drinking water and letting my body convert it into more of my yummy slime! The distillery downstairs splits the transformative and non-transformative parts, and that's how we make Slime Quencher!)]
+		[slimeQueen.speech(~Mhmm~ T-That's right.)] Catherine giggles, sliding her free hand down to rub at her exposed pussy. [slimeQueen.speech(I-I spend all day in that bath, drinking water and letting my body convert it into more of my yummy slime! The distillery downstairs splits the transformative and non-transformative parts, and that's how we make Slime Quencher!)]
 	</p>
 	<p>
-		[pc.speech(Enough.)] you snap, tightening your grip as you continue, [pc.speech(I'm going to need some proof for the enforcers that you won't be a problem anymore.)]
+		[pc.speech(Enough,)] you snap, tightening your grip as you continue, [pc.speech(I'm going to need some proof for the enforcers that you won't be a problem anymore.)]
 	</p>
 	<p>
 		[slimeQueen.speech(M-My crown...)] Catherine mutters, dropping her head down a little. [slimeQueen.speech(A-As a sign of my submission, y-you should take my crown.)]
@@ -898,7 +898,7 @@
 	
 	<htmlContent tag="SLIME_QUEEN_SUBMIT"><![CDATA[
 	<p>
-		[pc.speech(Actually, I'm here to help.)] you say, stepping towards the Slime Queen's bed.
+		[pc.speech(Actually, I'm here to help,)] you say, stepping towards the Slime Queen's bed.
 	</p>
 	<p>
 		[slimeQueen.speech(H-Help?)] she asks, sitting up and looking at you with a puzzled expression on her face. [slimeQueen.speech(You aren't here to put an end to my reign?)]
@@ -907,19 +907,19 @@
 		[pc.speech(No, I want to help you transform as many people in Submission into slimes as possible.)]
 	</p>
 	<p>
-		[slimeQueen.speech(O-Oh! Well, t-thank you...)] the Slime Queen mumbles, [slimeQueen.speech(But I should probably let you know why I'm doing all this first... You see, by ordering my subjects to make more people into slimes, I was kind of hoping to attract someone like you... I thought that if I made a nuisance of myself, a sexy, strong [pc.hero] would storm my tower, beat my guards, and...)] Catherine shudders in delight, [slimeQueen.speech(<i>ravish</i> me...)]
+		[slimeQueen.speech(O-Oh! Well, t-thank you...)] the Slime Queen mumbles. [slimeQueen.speech(But I should probably let you know why I'm doing all this first... You see, by ordering my subjects to make more people into slimes, I was kind of hoping to attract someone like you... I thought that if I made a nuisance of myself, a sexy, strong [pc.hero] would storm my tower, beat my guards, and...)] Catherine shudders in delight, [slimeQueen.speech(<i>ravish</i> me...)]
 	</p>
 	<p>
-		[pc.speech(Whatever your motive, I just want there to be more slimes.)] you say. [pc.speech(So what can I do to help?)]
+		[pc.speech(Whatever your motive, I just want there to be more slimes,)] you say. [pc.speech(So what can I do to help?)]
 	</p>
 	<p>
-		[slimeQueen.speech(Mmm... Well... It would be kind of anti-climatic if the enforcers stormed my tower and simply arrested me. I'm sure they wouldn't want to ravish me, which would be just awful.)] Catherine whines, before suddenly having an idea. [slimeQueen.speech(Oh! If you could get the enforcers to stop investigating the slime problem, then only strong adventurers would come seeking me out! Oh, and I guess there'd be more slimes, as my subjects wouldn't be getting arrested as much...)]
+		[slimeQueen.speech(Mmm... Well... It would be kind of anticlimactic if the enforcers stormed my tower and simply arrested me. I'm sure they wouldn't want to ravish me, which would be just awful,)] Catherine whines, before suddenly having an idea. [slimeQueen.speech(Oh! If you could get the enforcers to stop investigating the slime problem, then only strong adventurers would come seeking me out! Oh, and I guess there'd be more slimes, as my subjects wouldn't be getting arrested as much...)]
 	</p>
 	<p>
 		[pc.speech(So you need me to convince the enforcers that you're not a problem? I can do that, but I'll need some proof to show them that you've been dealt with.)]
 	</p>
 	<p>
-		[slimeQueen.speech(Hmm, you can have this, I guess.)] Catherine says, taking off her crown and throwing it to you. [slimeQueen.speech(It's kind of uncomfortable to wear, so I was thinking of getting rid of it anyway.)]
+		[slimeQueen.speech(Hmm, you can have this, I guess,)] Catherine says, taking off her crown and throwing it to you. [slimeQueen.speech(It's kind of uncomfortable to wear, so I was thinking of getting rid of it anyway.)]
 	</p>
 	<p>
 		As you catch the crown, Catherine lies back on her bed, spreading her legs once more and sighing, [slimeQueen.speech(Now, if you'll excuse me, I'll just lie here for a while, all defenceless and innocent, hoping that you don't change your mind and decide to have your wicked way with me...)]
@@ -964,7 +964,7 @@
 		Quickly stripping off, you take hold of the Slime Queen's hand and pull her along with you as you step forwards into the bath's warm, slimy contents. Catherine immediately sinks down into the slime, letting out a relaxed sigh as you sit down next to her.
 	</p>
 	<p>
-		[slimeQueen.speech(You must be tired from travelling all this way to see me. Please, let me wash you.)] she sighs, sliding around behind you before starting to rub her slimy hands all over your back.
+		[slimeQueen.speech(You must be tired from travelling all this way to see me. Please, let me wash you,)] she sighs, sliding around behind you before starting to rub her slimy hands all over your back.
 	</p>
 	<p>
 		Her warm touch instantly puts you at ease, and, once she's finished with your back, you lean back into Catherine, using her [slimeQueen.breastSize] breasts as a cushion as you let out a contented sigh. The Slime Queen giggles as she hugs you close to her, and, running her hands up and down the length of your body, she submissively cleans you with her warm pink slime.
@@ -989,7 +989,7 @@
 		Quickly stripping off, you take hold of the Slime Queen's hand and pull her along with you as you step forwards into the bath's warm, slimy contents. Catherine immediately sinks down into the slime, letting out a relaxed sigh as you sit down next to her.
 	</p>
 	<p>
-		[slimeQueen.speech(You must be tired from travelling all this way to see me. Please, let me wash you.)] she sighs, sliding around behind you before starting to rub her slimy hands all over your back.
+		[slimeQueen.speech(You must be tired from travelling all this way to see me. Please, let me wash you,)] she sighs, sliding around behind you before starting to rub her slimy hands all over your back.
 	</p>
 	<p>
 		Her warm touch instantly puts you at ease, and, once she's finished with your back, you lean back into Catherine, using her [slimeQueen.breastSize] breasts as a cushion as you let out a contented sigh. The Slime Queen giggles as she hugs you close to her, and, running her hands up and down the length of your body, she submissively cleans you with her warm pink slime.
@@ -1033,7 +1033,7 @@
 		Grinning at the Slime Queen, you can't help but question her satisfied sigh. [pc.speech(But I thought you didn't want to be 'ravished'?)]
 	</p>
 	<p>
-		[slimeQueen.speech(O-Oh! T-That's right!)] Catherine stutters, [slimeQueen.speech(I-I meant to say; Oh no! Now that you've had your wicked way with me, nobody will respect me any more! To think, the queen of all slimes was ravished like a common whore!)]
+		[slimeQueen.speech(O-Oh! T-That's right!)] Catherine stutters. [slimeQueen.speech(I-I meant to say; Oh no! Now that you've had your wicked way with me, nobody will respect me any more! To think, the queen of all slimes was ravished like a common whore!)]
 	</p>
 	<p>
 		Shaking your head at Catherine's remarks, you gather your things and wonder what to do next...
@@ -1049,7 +1049,7 @@
 		Grinning at the Slime Queen, you can't help but reply, [pc.speech(Well, the one who's being 'ravished' doesn't really get a say in the matter, does she?)]
 	</p>
 	<p>
-		[slimeQueen.speech(W-Well, you could have at least let me cum once!)] Catherine stutters, [slimeQueen.speech(The next time you decide to have your wicked way with me, make sure I get to have some fun too!)]
+		[slimeQueen.speech(W-Well, you could have at least let me cum once!)] Catherine stutters. [slimeQueen.speech(The next time you decide to have your wicked way with me, make sure I get to have some fun too!)]
 	</p>
 	<p>
 		Shaking your head at Catherine's remarks, you gather your things and wonder what to do next...
@@ -1065,28 +1065,28 @@
 		[slimeQueen.speech(Mmm...)] Catherine hums, sitting up on her bed. [slimeQueen.speech(Well, I used to be a normal slime-girl, and would attack people in Submission's tunnels, before letting them beat me and have their way with me. After a while of this, I started to think that it would be more fun if I looked really intimidating, so that when I got beaten, it would be extra humiliating to be ravished by my opponents. To this end, I started forcing myself to drink loads of water, so that I'd get really big and scary-looking!)]
 	</p>
 	<p>
-		[pc.speech(Well, that explains your size.)] you comment.
+		[pc.speech(Well, that explains your size,)] you comment.
 	</p>
 	<p>
 		[slimeQueen.speech(Yeah, and then once I'd grown really big, I thought I'd look even more threatening if I was like the slimes down here in the Bat Caverns. You know, what with the glowing and all. So I came down here and started eating the glowing mushrooms, but all they did was make my inside bits glow, see?)] Catherine explains, reaching down to spread her pussy and show you her glowing-pink insides. [slimeQueen.speech(I soon got bored of the taste though, so before my whole body started glowing, I travelled back up to Submission to have some fun!)]
 	</p>
 	<p>
-		[pc.speech(I'm guessing that's how your slime became transformative. The mushrooms down here seem to have some weird effects on slimes.)] you interject.
+		[pc.speech(I'm guessing that's how your slime became transformative. The mushrooms down here seem to have some weird effects on slimes,)] you interject.
 	</p>
 	<p>
-		[slimeQueen.speech(Yeah, I guess so too. At the time, however, I had no idea that my slime could do that. I soon found out about it though, as after I'd thrown my first fight to a pair of rat-boys in the tunnels, I kind of accidentally transformed [slimeRoyalGuard.name] into a slime...)] Catherine blushes, looking embarrassed as she recounts this part of her tale, [slimeQueen.speech(He'd just saved me, you see, and I went to give him a really big, annoying hug, in an attempt to frustrate him into wanting to take advantage of me. Well, I was still weak from my fight, and accidentally collapsed on top of him. By the time I managed to spit him out, he'd already swallowed a lot of my slime, and right there before my eyes, he transformed into a slime!)]
+		[slimeQueen.speech(Yeah, I guess so too. At the time, however, I had no idea that my slime could do that. I soon found out about it though, as after I'd thrown my first fight to a pair of rat-boys in the tunnels, I kind of accidentally transformed [slimeRoyalGuard.name] into a slime...)] Catherine blushes, looking embarrassed as she recounts this part of her tale. [slimeQueen.speech(He'd just saved me, you see, and I went to give him a really big, annoying hug, in an attempt to frustrate him into wanting to take advantage of me. Well, I was still weak from my fight, and accidentally collapsed on top of him. By the time I managed to spit him out, he'd already swallowed a lot of my slime, and right there before my eyes, he transformed into a slime!)]
 	</p>
 	<p>
 		[pc.speech(So how did that lead into you being the Slime Queen?)] you ask. 
 	</p>
 	<p>
-		[slimeQueen.speech(Ah, well, I was feeling so guilty at having transformed [slimeRoyalGuard.name], that I started following him around and offering to help him find a way to turn back. I kept on calling him 'my heroic knight' to try and make him feel better, and I think he kind of got used to it.)] Catherine explains, [slimeQueen.speech(He ended up getting kind of attached to me, and instead of transforming back to how he used to be, he decided to offer me his service as my knight. It was at that point he started calling me his 'Queen', and the name kind of stuck.)]
+		[slimeQueen.speech(Ah, well, I was feeling so guilty at having transformed [slimeRoyalGuard.name], that I started following him around and offering to help him find a way to turn back. I kept on calling him 'my heroic knight' to try and make him feel better, and I think he kind of got used to it,)] Catherine explains. [slimeQueen.speech(He ended up getting kind of attached to me, and instead of transforming back to how he used to be, he decided to offer me his service as my knight. It was at that point he started calling me his 'Queen', and the name kind of stuck.)]
 	</p>
 	<p>
 		[pc.speech(So that's when you decided to build this tower and gather new subjects?)]
 	</p>
 	<p>
-		[slimeQueen.speech(That's right!)] Catherine giggles, [slimeQueen.speech(It was all so much fun! Well, up until I realised that all of the intruders were getting defeated by my guards... All I wanted was a different adventurer each day, coming to claim me as their prize!)]
+		[slimeQueen.speech(That's right!)] Catherine giggles. [slimeQueen.speech(It was all so much fun! Well, up until I realised that all of the intruders were getting defeated by my guards... All I wanted was a different adventurer each day, coming to claim me as their prize!)]
 	</p>
 	<p>
 		With Catherine's story now told, and your curiosity sated, you wonder what to do next...

--- a/res/txt/places/submission/submissionPlaces.xml
+++ b/res/txt/places/submission/submissionPlaces.xml
@@ -29,10 +29,10 @@
 	<htmlContent tag="CLAIRE_INFO_SUBMISSION_SOCIETY"><![CDATA[
 	<p>
 		Wanting to know a little more about this underground world, you approach the short cat-girl messenger and call out a greeting,
-		 [pc.speech(Hi Claire!)]
+		 [pc.speech(Hi, Claire!)]
 	</p>
 	<p>
-		[claire.speech(Oh, hello again [pc.name]!)]
+		[claire.speech(Oh, hello again, [pc.name]!)]
 		 Claire cheerfully calls out.
 		 [claire.speech(What can I do for you this time?)]
 	</p>
@@ -45,7 +45,7 @@
 		 [claire.speech(You know, not many people really ask about that sort of thing, but I so happen to be an expert on Submission history and customs!)]
 	</p>
 	<p>
-		You can't help but smile as the small cat-girl proudly pushes her huge breasts out and places her hands on her absurdly-wide hips.
+		You can't help but smile as the small cat-girl proudly pushes her huge breasts out and places her hands on her absurdly wide hips.
 		 Looking straight into your eyes, she continues,
 		 [claire.speech(There are five main types of residents down here; rat-morphs, alligator-morphs, slimes, imps, and bat-morphs. That's not to say those are the only races down here, however. You can find all the same races as you would up in Dominion, but it's those five who make up the vast majority of the population.)]
 		 Claire wags her finger at you as she moves on.
@@ -58,20 +58,20 @@
 	</p>
 	<p>
 		[pc.speech(And the bat-morphs?)]
-		 You ask.
+		 you ask.
 	</p>
 	<p>
-		[claire.speech(Ah, yes, it's very rare for us to have to deal with any bat-morphs, as almost all of them stay down in the Bat Caverns. Thanks to their echolocation, they're not bothered by the dark, and have tunnelled out roosts up in the high ceilings of the caves down there.)]
+		[claire.speech(Ah, yes, it's very rare for us to have to deal with any bat-morphs, as almost all of them stay down in the Bat Caverns. Thanks to their echolocation, they're not bothered by the dark, and have tunnelled out roosts up in the high ceilings of the caves down there,)]
 		 Claire replies, proudly smiling as she reels off all of this information.
 		 [claire.speech(About half of Submission's slime population lives down there as well. Apparently, they love the taste of the bioluminescent plants that thrive in some areas, and a lot of slimes have eaten so much that their bodies have ended up glowing as well!)]
 	</p>
 	<p>
-		[pc.speech(I see. Thanks for all the information, Claire.)]
-		 You say, smiling at the short-statured cat-girl.
+		[pc.speech(I see. Thanks for all the information, Claire,)]
+		 you say, smiling at the short-statured cat-girl.
 	</p>
 	<p>
 		[claire.speech(You're welcome! Let me know if there's anything else, ok?)]
-		 She replies, before hurrying off to continue with her work.
+		 she replies, before hurrying off to continue with her work.
 	</p>
 	]]>
 	</htmlContent>
@@ -79,7 +79,7 @@
 	<htmlContent tag="CLAIRE_INFO_LYSSIETH"><![CDATA[
 	<p>
 		As you start to walk over towards the small cat-girl messenger, she sees you approaching and puts her paperwork to one side.
-		 [claire.speech(Hello [pc.name]! Is there something I can do for you?)]
+		 [claire.speech(Hello, [pc.name]! Is there something I can do for you?)]
 	</p>
 	<p>
 		[pc.speech(I just wanted to ask you what you know about Lyssieth,)]
@@ -115,23 +115,23 @@
 	<htmlContent tag="CLAIRE_INFO_TELEPORTATION"><![CDATA[
 	<p>
 		You walk up behind the small, busty cat-girl and call out,
-		 [pc.speech(Hi Claire!)]
+		 [pc.speech(Hi, Claire!)]
 	</p>
 	<p>
 		The diminutive messenger spins around, causing her huge breasts to swing from side-to-side.
 		 As she sees that it's you, she happily replies,
-		 [claire.speech(Hello [pc.name]! Can I help you?)]
+		 [claire.speech(Hello, [pc.name]! Can I help you?)]
 	</p>
 	<p>
 		[pc.speech(I was wondering if you could tell me any more about your 'level three clearance'. You said that it allows you to teleport? I've never seen anything like that up in Dominion.)]
 	</p>
 	<p>
-		Claire grins in delight as you mention the thing that she's most proud of, and immediately thrusts her disproportionately-large breasts out towards you in order to show off the bright gold badge that's pinned to her chest.
+		Claire grins in delight as you mention the thing that she's most proud of, and immediately thrusts her disproportionately large breasts out towards you in order to show off the bright gold badge that's pinned to her chest.
 		 [claire.speech(That's right! I'm allowed to use our teleportation stations to travel between the Enforcer Posts in order to quickly deliver messages! Usually, only high-ranking or demonic enforcers are given a clearance level of three or higher, you know?)]
 	</p>
 	<p>
-		[pc.speech(That's pretty impressive. You must have worked hard for that.)]
-		 You reply, hoping to encourage the little cat-girl to reveal some more information about teleportation.
+		[pc.speech(That's pretty impressive. You must have worked hard for that,)]
+		 you reply, hoping to encourage the little cat-girl to reveal some more information about teleportation.
 	</p>
 	<p>
 		[claire.speech(That I did! I worked super hard to become the very best messenger in Submission, and it finally all paid off! You know, these teleportation stations aren't really supposed to be public knowledge, but I can't expect people to believe that I'm running from Post to Post, now, can I?)]
@@ -154,7 +154,7 @@
 	</p>
 	<p>
 		Claire immediately spins around, and, upon seeing that it's you, she grins and places her hands on her huge hips.
-		 [claire.speech(Hi [pc.name]! What can I do for you?)]
+		 [claire.speech(Hi, [pc.name]! What can I do for you?)]
 	</p>
 	<p>
 		[pc.speech(Well, I've got some information on the slimes that are transforming people out in Submission's tunnels.)]
@@ -174,7 +174,7 @@
 	</p>
 	<p>
 		[pc.speech(Perhaps she isn't in the tunnels?)]
-		 You offer.
+		 you offer.
 	</p>
 	<p>
 		[claire.speech(Well, that's no good for us then.)]
@@ -183,7 +183,7 @@
 	</p>
 	<p>
 		[pc.speech(So you want me to go down there and find evidence of the Slime Queen?)]
-		 You ask, guessing where this conversation is headed.
+		 you ask, guessing where this conversation is headed.
 	</p>
 	<p>
 		[claire.speech(W-What? No! It's far too dangerous!)] Claire quickly replies, flustered by your response. [claire.speech(There are bat-morphs which can swoop down on you at any moment, aggressive slimes who'd just love to attack you, and the whole place is completely pitch-black! Well, there are patches of bioluminescent fungi, but it's still really dark and scary down there!)]
@@ -195,7 +195,7 @@
 		[claire.speech(W-Well, yes. I don't like to tell anyone, as I don't want to encourage people to seek out danger, but we do have a twenty-thousand flame reward for anyone who's able to put an end to this slime transformation problem.)] Claire says, wringing her hands with worry. [claire.speech(So if you're able to find and convince this Queen to stop, you'll have earned that reward. But please don't go looking for danger down there! I need to get back on with work now, but promise me you'll be careful before I go!)]
 	</p>
 	<p>
-		[pc.speech(Don't worry so much.)] You reply. [pc.speech(I'm always careful.)]
+		[pc.speech(Don't worry so much,)] you reply. [pc.speech(I'm always careful.)]
 	</p>
 	<p>
 		With a sigh of relief, Claire turns and rushes off to fetch your one-thousand flame reward, and, after returning to hand it over to you, she returns to her work. You wonder if it'd be worth risking a visit to the Bat Caverns. After all, if you were able to find and subdue this 'Slime Queen', you'd earn twenty-thousand flames...
@@ -205,31 +205,31 @@
 	
 	<htmlContent tag="CLAIRE_INFO_SLIME_QUEEN_REPORT_BACK"><![CDATA[
 	<p>
-		Wanting to report on your success with dealing with the Slime Queen, you walk up to where Claire is working and call out to her, [pc.speech(Hi Claire!)]
+		Wanting to report on your success with dealing with the Slime Queen, you walk up to where Claire is working and call out to her, [pc.speech(Hi, Claire!)]
 	</p>
 	<p>
-		The little cat-girl spins around, looking confused at first, but then grinning as she catches sight of you. Placing her paperwork to one side, she places her hands on her huge hips and greets you, [claire.speech(Hi [pc.name]! You've been staying safe, right?)]
+		The little cat-girl spins around, looking confused at first, but then grinning as she catches sight of you. Placing her paperwork to one side, she places her hands on her huge hips and greets you, [claire.speech(Hi, [pc.name]! You've been staying safe, right?)]
 	</p>
 	<p>
-		[pc.speech(Well, sort of.)] you reply, [pc.speech(I did kind of go down into the Bat Caverns and find the Slime Queen though...)]
+		[pc.speech(Well, sort of,)] you reply. [pc.speech(I did kind of go down into the Bat Caverns and find the Slime Queen though...)]
 	</p>
 	<p>
 		[claire.speech(Y-You what?!)] Claire shouts, puffing up her chest and wagging a finger at you. [claire.speech(I told you that was too dangerous!)]
 	</p>
 	<p>
-		[pc.speech(Well, dangerous or not, I did as you asked.)] you reply, holding up the Slime Queen's crown for Claire to see. [pc.speech(I put an end to her plans of transforming everyone in Submission to slimes, and I brought her crown back as proof.)]
+		[pc.speech(Well, dangerous or not, I did as you asked,)] you reply, holding up the Slime Queen's crown for Claire to see. [pc.speech(I put an end to her plans of transforming everyone in Submission to slimes, and I brought her crown back as proof.)]
 	</p>
 	<p>
 		[claire.speech(Really? She actually existed? And you managed to stop her?)] Claire asks, returning her hands to her hips once more. [claire.speech(That's amazing... Where did you find her?)]
 	</p>
 	<p>
-		[pc.speech(She's living in a tower, built on an island in the middle of an underground lake.)] you reply. [pc.speech(She said that she doesn't have any way to contact the people who claim to be her subjects, so she can't ask them to stop. She did, however, promise to stop producing those transformative 'Biojuice Canisters'.)]
+		[pc.speech(She's living in a tower, built on an island in the middle of an underground lake,)] you reply. [pc.speech(She said that she doesn't have any way to contact the people who claim to be her subjects, so she can't ask them to stop. She did, however, promise to stop producing those transformative 'Biojuice Canisters'.)]
 	</p>
 	<p>
-		[claire.speech(You've been such a huge help.)] Claire sighs, [claire.speech(With the sheer number of new cases of forced slime transformations, we were close to breaking point. You've no idea how much this is going to help us out. Let me get that reward I promised!)]
+		[claire.speech(You've been such a huge help.)] Claire sighs. [claire.speech(With the sheer number of new cases of forced slime transformations, we were close to breaking point. You've no idea how much this is going to help us out. Let me get that reward I promised!)]
 	</p>
 	<p>
-		You watch as Claire hurries off into one of the back rooms, and, just a moment later, returns with a bag of coins in her hand. [claire.speech(Here you are!)] she squeaks, [claire.speech(Thank you so much, [pc.name]!)]
+		You watch as Claire hurries off into one of the back rooms, and, just a moment later, returns with a bag of coins in her hand. [claire.speech(Here you are!)] she squeaks. [claire.speech(Thank you so much, [pc.name]!)]
 	</p>
 	<p>
 		[pc.speech(You're welcome.)] you reply, smiling at the little cat-girl.
@@ -242,34 +242,34 @@
 	
 	<htmlContent tag="CLAIRE_INFO_SLIME_QUEEN_REPORT_BACK_LIE"><![CDATA[
 	<p>
-		Wanting to make your fictitious report that the Slime Queen has been dealt with, you walk up to where Claire is working and call out to her, [pc.speech(Hi Claire!)]
+		Wanting to make your fictitious report that the Slime Queen has been dealt with, you walk up to where Claire is working and call out to her, [pc.speech(Hi, Claire!)]
 	</p>
 	<p>
 		The little cat-girl spins around, looking confused at first, but then grinning as she catches sight of you. Placing her paperwork to one side, she places her hands on her huge hips and greets you, [claire.speech(Hi [pc.name]! You've been staying safe, right?)]
 	</p>
 	<p>
-		[pc.speech(Well, sort of.)] you reply, [pc.speech(I did kind of go down into the Bat Caverns and find the Slime Queen though...)]
+		[pc.speech(Well, sort of,)] you reply, [pc.speech(I did kind of go down into the Bat Caverns and find the Slime Queen though...)]
 	</p>
 	<p>
 		[claire.speech(Y-You what?!)] Claire shouts, puffing up her chest and wagging a finger at you. [claire.speech(I told you that was too dangerous!)]
 	</p>
 	<p>
-		[pc.speech(Well, dangerous or not, I did as you asked.)] you reply, holding up the Slime Queen's crown for Claire to see. [pc.speech(I put an end to her plans of transforming everyone in Submission to slimes, and I brought her crown back as proof.)]
+		[pc.speech(Well, dangerous or not, I did as you asked,)] you reply, holding up the Slime Queen's crown for Claire to see. [pc.speech(I put an end to her plans of transforming everyone in Submission to slimes, and I brought her crown back as proof.)]
 	</p>
 	<p>
 		[claire.speech(Really? She actually existed? And you managed to stop her?)] Claire asks, returning her hands to her hips once more. [claire.speech(That's amazing... Where did you find her?)]
 	</p>
 	<p>
-		[pc.speech(She was hiding in one of those bioluminescent mushroom caverns.)] you lie, not wanting the enforcers to find Catherine. [pc.speech(She said that she doesn't have any way to contact the people who claim to be her subjects, so she can't ask them to stop. She did, however, promise to stop producing those transformative 'Biojuice Canisters'.)]
+		[pc.speech(She was hiding in one of those bioluminescent mushroom caverns,)] you lie, not wanting the enforcers to find Catherine. [pc.speech(She said that she doesn't have any way to contact the people who claim to be her subjects, so she can't ask them to stop. She did, however, promise to stop producing those transformative 'Biojuice Canisters'.)]
 	</p>
 	<p>
-		[claire.speech(You've been such a huge help.)] Claire sighs, [claire.speech(With the sheer number of new cases of forced slime transformations, we were close to breaking point. You've no idea how much this is going to help us out. Let me get that reward I promised!)]
+		[claire.speech(You've been such a huge help.)] Claire sighs. [claire.speech(With the sheer number of new cases of forced slime transformations, we were close to breaking point. You've no idea how much this is going to help us out. Let me get that reward I promised!)]
 	</p>
 	<p>
-		You watch as Claire hurries off into one of the back rooms, and, just a moment later, returns with a bag of coins in her hand. [claire.speech(Here you are!)] she squeaks, [claire.speech(Thank you so much, [pc.name]!)]
+		You watch as Claire hurries off into one of the back rooms, and, just a moment later, returns with a bag of coins in her hand. [claire.speech(Here you are!)] she squeaks. [claire.speech(Thank you so much, [pc.name]!)]
 	</p>
 	<p>
-		[pc.speech(You're welcome.)] you reply, smiling at the little cat-girl.
+		[pc.speech(You're welcome,)] you reply, smiling at the little cat-girl.
 	</p>
 	<p>
 		[claire.speech(Well, back to work for me! Stay out of trouble!)] Claire happily says, before turning around and getting back to her paperwork. You step away from the busy cat-girl, wondering what to do next...
@@ -450,7 +450,7 @@
 	</p>
 	<p>
 		[pc.speech(Well, I was hoping to speak with Lyssieth. She does live here, right?)]
-		 You ask.
+		 you ask.
 	</p>
 	<p>
 		[genericFemale.speech(Her Highness isn't receiving visitors at the moment. You'd better turn around and leave. Now.)]

--- a/res/txt/places/submission/tunnelSlime.xml
+++ b/res/txt/places/submission/tunnelSlime.xml
@@ -3,7 +3,7 @@
 
 	<htmlContent tag="ATTACK_INTRO"><![CDATA[
 	<p>
-		As you travel down the gloomy, twisting tunnels of Submission, the sounds of dripping water and slowly-creaking pipes echo off the stone walls to either side of you.
+		As you travel down the gloomy, twisting tunnels of Submission, the sounds of dripping water and slowly creaking pipes echo off the stone walls to either side of you.
 		 Due to this continuous background noise, the quiet splashing of a slime's footsteps as [npc.she] sneaks up on you are all but completely concealed.
 		 It isn't until the slime is within ten metres that you suddenly become aware of [npc.herHis] presence, and you quickly spin around to find yourself looking at [npc.a_fullRace(true)]!
 	</p>
@@ -39,7 +39,7 @@
 	
 	<htmlContent tag="TRANSFORMER_PLAYER_SLIME_SLIME_NO_SEX"><![CDATA[
 	<p>
-		[npc.speech(Well, you stay safe out there.)]
+		[npc.speech(Well, you stay safe out there,)]
 		 [npc.Name] says, before turning to leave.
 		 [npc.speech(I've gotta find more people to turn into slimes. The Queen said we're supposed to do at least five a day, and I'm only on three so far!)]
 	</p>
@@ -60,7 +60,7 @@
 	</p>
 	<p>
 		[pc.speech(What kind of Queen is ordering people to be transformed into slimes?)]
-		 You ask, stepping back and preparing yourself for a fight.
+		 you ask, stepping back and preparing yourself for a fight.
 	</p>
 	<p>
 		[npc.speech(Well, duh! The Slime Queen of course! Perhaps once I've turned you into a new subject of hers, you'll get to meet her some day!)]
@@ -68,7 +68,7 @@
 	</p>
 	<p>
 		[pc.speech(So she's the one behind all these slime transformations?)]
-		 You ask, remembering what Claire told you about the increase in slime transformations, and about the one-thousand flame reward for any information about it. 
+		 you ask, remembering what Claire told you about the increase in slime transformations, and about the one-thousand flame reward for any information about it. 
 	</p>
 	<p>
 		[npc.speech(Well, that's pretty obvious, isn't it? But if you think I'm going to tell you any more about her, then you're as stupid as you look!)]
@@ -106,7 +106,7 @@
 	</p>
 	<p>
 		[pc.speech(What do you want?)]
-		 You ask in a stern tone, instinctively crouching down a little as you prepare to defend yourself.
+		 you ask in a stern tone, instinctively crouching down a little as you prepare to defend yourself.
 	</p>
 	<p>
 		[npc.speech(Your money, duh. Have you never been mugged before? Now hand it over. There's no need for this to turn ugly.)]
@@ -121,7 +121,7 @@
 		 [pc.speech(I'm not interested. I need to get going now, goodbye.)]
 	</p>
 	<p>
-		[npc.speech(Well, whatever.)]
+		[npc.speech(Well, whatever,)]
 		 [npc.Name] says, before turning and making [npc.her] exit. Having dealt with [npc.name], you similarly turn around and continue on your way.
 	</p>
 	]]>
@@ -315,7 +315,7 @@
 	
 	<htmlContent tag="TRANSFORMED"><![CDATA[
 	<p>
-		[pc.speech(Ok, I'll become a slime...)] You say, eyeing the canister of pink liquid in [npc.name]'s hand.
+		[pc.speech(Ok, I'll become a slime...)] you say, eyeing the canister of pink liquid in [npc.name]'s hand.
 	</p>
 	<p>
 		Grinning, [npc.name] steps forwards, before reaching out to grab your [pc.arm]. Sliding up against you, [npc.she] brings [npc.her] face to within inches of yours, and sneers,
@@ -448,7 +448,7 @@
 	</p>
 	<p>
 		[pc.speech(Sure...)]
-		 You pant, trying to recover enough energy to stand without assistance.
+		 you pant, trying to recover enough energy to stand without assistance.
 	</p>
 	]]>
 	</htmlContent>

--- a/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/BatCavernAttackerDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/BatCavernAttackerDialogue.java
@@ -126,7 +126,7 @@ public class BatCavernAttackerDialogue {
 							+ " [npc.She] reaches down to [npc.her] crotch and starts stroking [npc.herself], making pitiful little whining noises as [npc.she] squirms on the floor."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(Aaah! What are you waiting for?! Come fuck me!)], [npc.she] pleads, biting [npc.her] [npc.lip] as [npc.she] continues touching [npc.herself]."
+							+ "[npc.speech(Aaah! What are you waiting for?! Come fuck me!)] [npc.she] pleads, biting [npc.her] [npc.lip] as [npc.she] continues touching [npc.herself]."
 						+ "</p>"
 						+ "<p>"
 							+ "You wonder if you should indulge [npc.her] request."
@@ -142,7 +142,7 @@ public class BatCavernAttackerDialogue {
 							+ " Making pitiful little whining noises, [npc.she] tries to shuffle away from you, clearly worried about what your intentions are."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(J-Just take my money and leave me alone!)], [npc.she] pleads, throwing [npc.her] "+(Main.game.getActiveNPC().isFeminine()?"purse":"wallet")+" at your feet."
+							+ "[npc.speech(J-Just take my money and leave me alone!)] [npc.she] pleads, throwing [npc.her] "+(Main.game.getActiveNPC().isFeminine()?"purse":"wallet")+" at your feet."
 						+ "</p>"
 						+ "<p>"
 							+ "You wonder if you should do as [npc.she] says, and leave [npc.herHim] alone."
@@ -393,7 +393,7 @@ public class BatCavernAttackerDialogue {
 							+ "<p>"
 								+ "[npc.speech(You're my perfect little "
 											+Main.game.getActiveNPC().getPreferredBodyDescription("b")
-											+ " now! Don't forget bitch, <i>I'm</i> the one in charge!)] [npc.she] growls, before pulling you into a forceful kiss."
+											+ " now! Don't forget, bitch, <i>I'm</i> the one in charge!)] [npc.she] growls, before pulling you into a forceful kiss."
 							+ "</p>");
 					
 				} else {
@@ -406,12 +406,12 @@ public class BatCavernAttackerDialogue {
 								+ "[npc.speech(Hah! That was too easy!)] [npc.she] says, before leaning down and pushing you to the ground."
 							+ "</p>"
 							+ "<p>"
-								+ "As [npc.she] pins you to the floor, [npc.she] produces a curious little bottle from somewhere out of sight, and shakes it from side to side, grinning,"
+								+ "As [npc.she] pins you to the floor, [npc.she] produces a curious little bottle from somewhere out of sight, and shakes it from side to side, grinning."
 								+ " [npc.speech(I think you could do with some <i>improvements</i>! I'm going to turn you into my perfect "+Main.game.getActiveNPC().getPreferredBodyDescription("b")+"!)]"
 							+ "</p>"
 							+ "<p>"
 								+ "[npc.She] pulls out the little stopper from the top of the bottle, and as you open your mouth to protest, [npc.she] suddenly shoves the neck past your [pc.lips+]."
-								+ " As the sickly-sweet fluid pours out into your mouth, you let out a muffled whine; the only act of resistance that you're able to summon in your current state."
+								+ " As the sickly sweet fluid pours out into your mouth, you let out a muffled whine; the only act of resistance that you're able to summon in your current state."
 							+ "</p>"
 							+ "<p>"
 								+ "[npc.speech(Come on! Swallow it all down already!)] [npc.she] growls, throwing the now-empty vessel to one side as [npc.she] tries to force you to swallow the strange fluid..."
@@ -432,7 +432,7 @@ public class BatCavernAttackerDialogue {
 								+ "Pulling you to your feet, [npc.name] starts grinding [npc.herself] up against you, [npc.moaning] into your [pc.ear] as [npc.she] starts groping your body."
 							+ "</p>"
 							+ "<p>"
-								+ "[npc.speech(Don't try anything bitch! <i>I'm</i> the one in charge here!)] [npc.she] growls, before pulling you into a forceful kiss."
+								+ "[npc.speech(Don't try anything, bitch! <i>I'm</i> the one in charge here!)] [npc.she] growls, before pulling you into a forceful kiss."
 							+ "</p>");
 				
 			} else {
@@ -479,7 +479,7 @@ public class BatCavernAttackerDialogue {
 							Util.Value<String, AbstractItem> potion = Main.game.getActiveNPC().generateTransformativePotion();
 							Main.game.getTextStartStringBuilder().append(
 									"<p>"
-										+ "[npc.Name] steps back, grinning down at you as you obediently swallow the strange liquid,"
+										+ "[npc.Name] steps back, grinning down at you as you obediently swallow the strange liquid."
 										+ " [npc.speech(Good [pc.girl]! "+potion.getKey()+")]"
 									+ "</p>"
 									+ "<p>"
@@ -602,7 +602,7 @@ public class BatCavernAttackerDialogue {
 							+ " Reluctantly, you do as [npc.she] says, and, after giving [npc.herHim] some of your cash, [npc.she] shoves you down to the floor once more."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(This money of yours is going to pay for your next potion!)] [npc.she] growls down at you, [npc.speech(Come back and pay me another visit, <i>or else</i>! And don't you dare refuse to swallow next time!)]"
+							+ "[npc.speech(This money of yours is going to pay for your next potion!)] [npc.she] growls down at you. [npc.speech(Come back and pay me another visit, <i>or else</i>! And don't you dare refuse to swallow next time!)]"
 						+ "</p>"
 						+ "<p>"
 							+ "With that, [npc.she] turns around and runs off, leaving you to recover from your ordeal and continue on your way..."
@@ -711,7 +711,7 @@ public class BatCavernAttackerDialogue {
 							+ " Reluctantly, you do as [npc.she] says, and, after giving [npc.herHim] some of your cash, [npc.she] roughly pushes you to the floor once more."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(You're not good enough for me to be interested in you just yet!)] [npc.she] growls down at you, [npc.speech(Come back and pay me another visit, <i>or else</i>! I'm going to turn you into my perfect little "
+							+ "[npc.speech(You're not good enough for me to be interested in you just yet!)] [npc.she] growls down at you. [npc.speech(Come back and pay me another visit, <i>or else</i>! I'm going to turn you into my perfect little "
 								+Main.game.getActiveNPC().getPreferredBodyDescription("b")+"!)]"
 						+ "</p>"
 						+ "<p>"
@@ -896,7 +896,7 @@ public class BatCavernAttackerDialogue {
 					"<p>"
 						+ "As [npc.name] steps back and sorts [npc.her] clothes out, you sink to the floor, totally worn out from [npc.her] dominant treatment of you."
 						+ " [npc.She] looks down at you, and you glance up to see a very satisfied smile cross [npc.her] face."
-						+ " [npc.She] leans down and pats you on the head,"
+						+ " [npc.She] leans down and pats you on the head."
 						+ " [npc.speech(We should do this again some time!)]"
 					+ "</p>"
 					+ "<p>"

--- a/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/BatCavernBatAttackerDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/BatCavernBatAttackerDialogue.java
@@ -126,7 +126,7 @@ public class BatCavernBatAttackerDialogue {
 							+ " [npc.She] reaches down to [npc.her] crotch and starts stroking [npc.herself], making pitiful little whining noises as [npc.she] squirms on the floor."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(Aaah! What are you waiting for?! Come fuck me!)], [npc.she] pleads, biting [npc.her] [npc.lip] as [npc.she] continues touching [npc.herself]."
+							+ "[npc.speech(Aaah! What are you waiting for?! Come fuck me!)] [npc.she] pleads, biting [npc.her] [npc.lip] as [npc.she] continues touching [npc.herself]."
 						+ "</p>"
 						+ "<p>"
 							+ "You wonder if you should indulge [npc.her] request."
@@ -142,7 +142,7 @@ public class BatCavernBatAttackerDialogue {
 							+ " Making pitiful little whining noises, [npc.she] tries to shuffle away from you, clearly worried about what your intentions are."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(J-Just take my money and leave me alone!)], [npc.she] pleads, throwing [npc.her] "+(Main.game.getActiveNPC().isFeminine()?"purse":"wallet")+" at your feet."
+							+ "[npc.speech(J-Just take my money and leave me alone!)] [npc.she] pleads, throwing [npc.her] "+(Main.game.getActiveNPC().isFeminine()?"purse":"wallet")+" at your feet."
 						+ "</p>"
 						+ "<p>"
 							+ "You wonder if you should do as [npc.she] says, and leave [npc.herHim] alone."
@@ -393,7 +393,7 @@ public class BatCavernBatAttackerDialogue {
 							+ "<p>"
 								+ "[npc.speech(You're my perfect little "
 											+Main.game.getActiveNPC().getPreferredBodyDescription("b")
-											+ " now! Don't forget bitch, <i>I'm</i> the one in charge!)] [npc.she] growls, before pulling you into a forceful kiss."
+											+ " now! Don't forget, bitch, <i>I'm</i> the one in charge!)] [npc.she] growls, before pulling you into a forceful kiss."
 							+ "</p>");
 					
 				} else {
@@ -411,7 +411,7 @@ public class BatCavernBatAttackerDialogue {
 							+ "</p>"
 							+ "<p>"
 								+ "[npc.She] pulls out the little stopper from the top of the bottle, and as you open your mouth to protest, [npc.she] suddenly shoves the neck past your [pc.lips+]."
-								+ " As the sickly-sweet fluid pours out into your mouth, you let out a muffled whine; the only act of resistance that you're able to summon in your current state."
+								+ " As the sickly sweet fluid pours out into your mouth, you let out a muffled whine; the only act of resistance that you're able to summon in your current state."
 							+ "</p>"
 							+ "<p>"
 								+ "[npc.speech(Come on! Swallow it all down already!)] [npc.she] growls, throwing the now-empty vessel to one side as [npc.she] tries to force you to swallow the strange fluid..."
@@ -432,7 +432,7 @@ public class BatCavernBatAttackerDialogue {
 								+ "Pulling you to your feet, [npc.name] starts grinding [npc.herself] up against you, [npc.moaning] into your [pc.ear] as [npc.she] starts groping your body."
 							+ "</p>"
 							+ "<p>"
-								+ "[npc.speech(Don't try anything bitch! <i>I'm</i> the one in charge here!)] [npc.she] growls, before pulling you into a forceful kiss."
+								+ "[npc.speech(Don't try anything, bitch! <i>I'm</i> the one in charge here!)] [npc.she] growls, before pulling you into a forceful kiss."
 							+ "</p>");
 				
 			} else {
@@ -479,7 +479,7 @@ public class BatCavernBatAttackerDialogue {
 							Util.Value<String, AbstractItem> potion = Main.game.getActiveNPC().generateTransformativePotion();
 							Main.game.getTextStartStringBuilder().append(
 									"<p>"
-										+ "[npc.Name] steps back, grinning down at you as you obediently swallow the strange liquid,"
+										+ "[npc.Name] steps back, grinning down at you as you obediently swallow the strange liquid."
 										+ " [npc.speech(Good [pc.girl]! "+potion.getKey()+")]"
 									+ "</p>"
 									+ "<p>"
@@ -602,7 +602,7 @@ public class BatCavernBatAttackerDialogue {
 							+ " Reluctantly, you do as [npc.she] says, and, after giving [npc.herHim] some of your cash, [npc.she] shoves you down to the floor once more."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(This money of yours is going to pay for your next potion!)] [npc.she] growls down at you, [npc.speech(Come back and pay me another visit, <i>or else</i>! And don't you dare refuse to swallow next time!)]"
+							+ "[npc.speech(This money of yours is going to pay for your next potion!)] [npc.she] growls down at you. [npc.speech(Come back and pay me another visit, <i>or else</i>! And don't you dare refuse to swallow next time!)]"
 						+ "</p>"
 						+ "<p>"
 							+ "With that, [npc.she] turns around and runs off, leaving you to recover from your ordeal and continue on your way..."
@@ -711,7 +711,7 @@ public class BatCavernBatAttackerDialogue {
 							+ " Reluctantly, you do as [npc.she] says, and, after giving [npc.herHim] some of your cash, [npc.she] roughly pushes you to the floor once more."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(You're not good enough for me to be interested in you just yet!)] [npc.she] growls down at you, [npc.speech(Come back and pay me another visit, <i>or else</i>! I'm going to turn you into my perfect little "
+							+ "[npc.speech(You're not good enough for me to be interested in you just yet!)] [npc.she] growls down at you. [npc.speech(Come back and pay me another visit, <i>or else</i>! I'm going to turn you into my perfect little "
 								+Main.game.getActiveNPC().getPreferredBodyDescription("b")+"!)]"
 						+ "</p>"
 						+ "<p>"
@@ -896,7 +896,7 @@ public class BatCavernBatAttackerDialogue {
 					"<p>"
 						+ "As [npc.name] steps back and sorts [npc.her] clothes out, you sink to the floor, totally worn out from [npc.her] dominant treatment of you."
 						+ " [npc.She] looks down at you, and you glance up to see a very satisfied smile cross [npc.her] face."
-						+ " [npc.She] leans down and pats you on the head,"
+						+ " [npc.She] leans down and pats you on the head."
 						+ " [npc.speech(We should do this again some time!)]"
 					+ "</p>"
 					+ "<p>"

--- a/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/BatCavernSlimeAttackerDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/BatCavernSlimeAttackerDialogue.java
@@ -366,7 +366,7 @@ public class BatCavernSlimeAttackerDialogue {
 								+ "Pulling you to your feet, [npc.name] starts grinding [npc.herself] up against you, [npc.moaning] into your [pc.ear] as [npc.she] starts groping your body."
 							+ "</p>"
 							+ "<p>"
-								+ "[npc.speech(You're my perfect little " +Main.game.getActiveNPC().getPreferredBodyDescription("b") + " now! Don't forget bitch, <i>I'm</i> the one in charge!)] [npc.she] growls, before pulling you into a forceful kiss."
+								+ "[npc.speech(You're my perfect little " +Main.game.getActiveNPC().getPreferredBodyDescription("b") + " now! Don't forget, bitch, <i>I'm</i> the one in charge!)] [npc.she] growls, before pulling you into a forceful kiss."
 							+ "</p>");
 					
 				} else {
@@ -379,12 +379,12 @@ public class BatCavernSlimeAttackerDialogue {
 								+ "[npc.speech(Hah! That was too easy!)] [npc.she] says, before leaning down and pushing you to the ground."
 							+ "</p>"
 							+ "<p>"
-								+ "As [npc.she] pins you to the floor, [npc.she] produces a curious little bottle from somewhere out of sight, and shakes it from side to side, grinning,"
+								+ "As [npc.she] pins you to the floor, [npc.she] produces a curious little bottle from somewhere out of sight, and shakes it from side to side, grinning."
 								+ " [npc.speech(I think you could do with some <i>improvements</i>! I'm going to turn you into my perfect "+Main.game.getActiveNPC().getPreferredBodyDescription("b")+"!)]"
 							+ "</p>"
 							+ "<p>"
 								+ "[npc.She] pulls out the little stopper from the top of the bottle, and as you open your mouth to protest, [npc.she] suddenly shoves the neck past your [pc.lips+]."
-								+ " As the sickly-sweet fluid pours out into your mouth, you let out a muffled whine; the only act of resistance that you're able to summon in your current state."
+								+ " As the sickly sweet fluid pours out into your mouth, you let out a muffled whine; the only act of resistance that you're able to summon in your current state."
 							+ "</p>"
 							+ "<p>"
 								+ "[npc.speech(Come on! Swallow it all down already!)] [npc.she] growls, throwing the now-empty vessel to one side as [npc.she] tries to force you to swallow the strange fluid..."
@@ -405,7 +405,7 @@ public class BatCavernSlimeAttackerDialogue {
 								+ "Pulling you to your feet, [npc.name] starts grinding [npc.herself] up against you, [npc.moaning] into your [pc.ear] as [npc.she] starts groping your body."
 							+ "</p>"
 							+ "<p>"
-								+ "[npc.speech(Don't try anything bitch! <i>I'm</i> the one in charge here!)] [npc.she] growls, before pulling you into a forceful kiss."
+								+ "[npc.speech(Don't try anything, bitch! <i>I'm</i> the one in charge here!)] [npc.she] growls, before pulling you into a forceful kiss."
 							+ "</p>");
 				
 			} else {
@@ -575,7 +575,7 @@ public class BatCavernSlimeAttackerDialogue {
 							+ " Reluctantly, you do as [npc.she] says, and, after giving [npc.herHim] some of your cash, [npc.she] shoves you down to the floor once more."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(This money of yours is going to pay for your next potion!)] [npc.she] growls down at you, [npc.speech(Come back and pay me another visit, <i>or else</i>! And don't you dare refuse to swallow next time!)]"
+							+ "[npc.speech(This money of yours is going to pay for your next potion!)] [npc.she] growls down at you. [npc.speech(Come back and pay me another visit, <i>or else</i>! And don't you dare refuse to swallow next time!)]"
 						+ "</p>"
 						+ "<p>"
 							+ "With that, [npc.she] turns around and runs off, leaving you to recover from your ordeal and continue on your way..."
@@ -684,7 +684,7 @@ public class BatCavernSlimeAttackerDialogue {
 							+ " Reluctantly, you do as [npc.she] says, and, after giving [npc.herHim] some of your cash, [npc.she] roughly pushes you to the floor once more."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(You're not good enough for me to be interested in you just yet!)] [npc.she] growls down at you, [npc.speech(Come back and pay me another visit, <i>or else</i>! I'm going to turn you into my perfect little "
+							+ "[npc.speech(You're not good enough for me to be interested in you just yet!)] [npc.she] growls down at you. [npc.speech(Come back and pay me another visit, <i>or else</i>! I'm going to turn you into my perfect little "
 								+Main.game.getActiveNPC().getPreferredBodyDescription("b")+"!)]"
 						+ "</p>"
 						+ "<p>"
@@ -869,7 +869,7 @@ public class BatCavernSlimeAttackerDialogue {
 					"<p>"
 						+ "As [npc.name] steps back and sorts [npc.her] clothes out, you sink to the floor, totally worn out from [npc.her] dominant treatment of you."
 						+ " [npc.She] looks down at you, and you glance up to see a very satisfied smile cross [npc.her] face."
-						+ " [npc.She] leans down and pats you on the head,"
+						+ " [npc.She] leans down and pats you on the head."
 						+ " [npc.speech(We should do this again some time!)]"
 					+ "</p>"
 					+ "<p>"

--- a/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/TunnelAttackDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/TunnelAttackDialogue.java
@@ -184,7 +184,7 @@ public class TunnelAttackDialogue {
 							+ " [npc.She] reaches down to [npc.her] crotch and starts stroking [npc.herself], making pitiful little whining noises as [npc.she] squirms on the floor."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(Aaah! What are you waiting for?! Come fuck me!)], [npc.she] pleads, biting [npc.her] [npc.lip] as [npc.she] continues touching [npc.herself]."
+							+ "[npc.speech(Aaah! What are you waiting for?! Come fuck me!)] [npc.she] pleads, biting [npc.her] [npc.lip] as [npc.she] continues touching [npc.herself]."
 						+ "</p>"
 						+ "<p>"
 							+ "You wonder if you should indulge [npc.her] request."
@@ -200,7 +200,7 @@ public class TunnelAttackDialogue {
 							+ " Making pitiful little whining noises, [npc.she] tries to shuffle away from you, clearly worried about what your intentions are."
 						+ "</p>"
 						+ "<p>"
-							+ "[npc.speech(J-Just take my money and leave me alone!)], [npc.she] pleads, throwing [npc.her] "+(Main.game.getActiveNPC().isFeminine()?"purse":"wallet")+" at your feet."
+							+ "[npc.speech(J-Just take my money and leave me alone!)] [npc.she] pleads, throwing [npc.her] "+(Main.game.getActiveNPC().isFeminine()?"purse":"wallet")+" at your feet."
 						+ "</p>"
 						+ "<p>"
 							+ "You wonder if you should do as [npc.she] says, and leave [npc.herHim] alone."
@@ -451,7 +451,7 @@ public class TunnelAttackDialogue {
 							+ "<p>"
 								+ "[npc.speech(You're my perfect little "
 											+Main.game.getActiveNPC().getPreferredBodyDescription("b")
-											+ " now! Don't forget bitch, <i>I'm</i> the one in charge!)] [npc.she] growls, before pulling you into a forceful kiss."
+											+ " now! Don't forget, bitch, <i>I'm</i> the one in charge!)] [npc.she] growls, before pulling you into a forceful kiss."
 							+ "</p>");
 					
 				} else {
@@ -469,7 +469,7 @@ public class TunnelAttackDialogue {
 							+ "</p>"
 							+ "<p>"
 								+ "[npc.She] pulls out the little stopper from the top of the bottle, and as you open your mouth to protest, [npc.she] suddenly shoves the neck past your [pc.lips+]."
-								+ " As the sickly-sweet fluid pours out into your mouth, you let out a muffled whine; the only act of resistance that you're able to summon in your current state."
+								+ " As the sickly sweet fluid pours out into your mouth, you let out a muffled whine; the only act of resistance that you're able to summon in your current state."
 							+ "</p>"
 							+ "<p>"
 								+ "[npc.speech(Come on! Swallow it all down already!)] [npc.she] growls, throwing the now-empty vessel to one side as [npc.she] tries to force you to swallow the strange fluid..."
@@ -954,7 +954,7 @@ public class TunnelAttackDialogue {
 					"<p>"
 						+ "As [npc.name] steps back and sorts [npc.her] clothes out, you sink to the floor, totally worn out from [npc.her] dominant treatment of you."
 						+ " [npc.She] looks down at you, and you glance up to see a very satisfied smile cross [npc.her] face."
-						+ " [npc.She] leans down and pats you on the head,"
+						+ " [npc.She] leans down and pats you on the head."
 						+ " [npc.speech(We should do this again some time!)]"
 					+ "</p>"
 					+ "<p>"

--- a/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/TunnelSlimeDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/TunnelSlimeDialogue.java
@@ -70,7 +70,7 @@ public class TunnelSlimeDialogue {
 						return new ResponseCombat("Fight",
 								"You aren't going to stand for [npc.name] transforming people into slimes. Teach [npc.herHim] a lesson!", Main.game.getActiveNPC(),
 								Util.newHashMapOfValues(
-										new Value<>(Main.game.getPlayer(), "[pc.speech(You aren't going to be stalking these tunnels on my watch!)] You shout, launching into an attack!"),
+										new Value<>(Main.game.getPlayer(), "[pc.speech(You aren't going to be stalking these tunnels on my watch!)] you shout, launching into an attack!"),
 										new Value<>(slime(), "[npc.speech(Traitor! You'll pay for this!)] [npc.Name] cries out as [npc.she] prepares to defend [npc.herself].")));
 						
 					} else if (index == 2) {

--- a/src/com/lilithsthrone/game/dialogue/places/submission/SlimeQueensLair.java
+++ b/src/com/lilithsthrone/game/dialogue/places/submission/SlimeQueensLair.java
@@ -227,7 +227,7 @@ public class SlimeQueensLair {
 							"Fight your way past these slimes!",
 							Util.newArrayListOfValues(Main.game.getSlimeGuardFire(), Main.game.getSlimeGuardIce()),
 							Util.newHashMapOfValues(
-									new Value<>(Main.game.getPlayer(), "[pc.speech(If it's a fight you want, it's a fight you're going to get!)] You cry out, ready to fight the slime siblings."),
+									new Value<>(Main.game.getPlayer(), "[pc.speech(If it's a fight you want, it's a fight you're going to get!)] you cry out, ready to fight the slime siblings."),
 									new Value<>(Main.game.getSlimeGuardFire(), "[slimeFire.speech(Sis' and I are gonna have so much fun with you!)] [slimeFire.name] sneers, gripping his fire-enchanted sword in one hand."),
 									new Value<>(Main.game.getSlimeGuardIce(), "[slimeIce.speech(You'll be sorry!)] [slimeIce.name] calls out, stepping up beside her brother as she prepares to fight."))){
 						@Override
@@ -635,7 +635,7 @@ public class SlimeQueensLair {
 							Util.newArrayListOfValues(Main.game.getSlimeRoyalGuard()),
 							Util.newHashMapOfValues(
 									new Value<>(Main.game.getPlayer(), "[pc.speech(Fine, I'll spar with you,)] you say, readying yourself for a fight, [pc.speech(but remember what you said about your body being mine when you lose!)]"),
-									new Value<>(Main.game.getSlimeRoyalGuard(), "[slimeRoyalGuard.speech(Hah!)] [slimeRoyalGuard.name] booms, [slimeRoyalGuard.speech(I'm looking forwards to claiming my prize!)]")));
+									new Value<>(Main.game.getSlimeRoyalGuard(), "[slimeRoyalGuard.speech(Hah!)] [slimeRoyalGuard.name] booms. [slimeRoyalGuard.speech(I'm looking forwards to claiming my prize!)]")));
 				} else {
 					return null;
 				}
@@ -646,8 +646,8 @@ public class SlimeQueensLair {
 							"Defend yourself against [slimeRoyalGuard.name].",
 							Util.newArrayListOfValues(Main.game.getSlimeRoyalGuard()),
 							Util.newHashMapOfValues(
-									new Value<>(Main.game.getPlayer(), "[pc.speech(I've fought and defeated mightier foes than you!)] You cry out, readying yourself for a fight."),
-									new Value<>(Main.game.getSlimeRoyalGuard(), "[slimeRoyalGuard.speech(No-one is mightier than I!)] [slimeRoyalGuard.name] bellows in response, [slimeRoyalGuard.speech(Prepare to be defeated!)]")));
+									new Value<>(Main.game.getPlayer(), "[pc.speech(I've fought and defeated mightier foes than you!)] you cry out, readying yourself for a fight."),
+									new Value<>(Main.game.getSlimeRoyalGuard(), "[slimeRoyalGuard.speech(No-one is mightier than I!)] [slimeRoyalGuard.name] bellows in response. [slimeRoyalGuard.speech(Prepare to be defeated!)]")));
 					
 				} else if(index==2) {
 					if(Main.game.getSlimeRoyalGuard().getFoughtPlayerCount()>0) {
@@ -708,7 +708,7 @@ public class SlimeQueensLair {
 						"Defend yourself against [slimeRoyalGuard.name].",
 						Util.newArrayListOfValues(Main.game.getSlimeRoyalGuard()),
 						Util.newHashMapOfValues(
-								new Value<>(Main.game.getPlayer(), "[pc.speech(Very well, I'll fight you.)] You say, stepping back and preparing for combat."),
+								new Value<>(Main.game.getPlayer(), "[pc.speech(Very well, I'll fight you,)] you say, stepping back and preparing for combat."),
 								new Value<>(Main.game.getSlimeRoyalGuard(), "[slimeRoyalGuard.speech(Excellent! Now, defend yourself!)] [slimeRoyalGuard.name] booms, before moving forwards to attack.")));
 				
 			} else if(index==2) {
@@ -763,7 +763,7 @@ public class SlimeQueensLair {
 						"Now that you've worn [slimeRoyalGuard.name] out, [slimeRoyalGuard.he] should be easier to beat!",
 						Util.newArrayListOfValues(Main.game.getSlimeRoyalGuard()),
 						Util.newHashMapOfValues(
-								new Value<>(Main.game.getPlayer(), "[pc.speech(Sure, I'll take you on.)] you reply, reading yourself for a fight."),
+								new Value<>(Main.game.getPlayer(), "[pc.speech(Sure, I'll take you on,)] you reply, reading yourself for a fight."),
 								new Value<>(Main.game.getSlimeRoyalGuard(), "[slimeRoyalGuard.speech(Prepare... Prepare to... defend yourself!)] [slimeRoyalGuard.name] pants, struggling to catch his breath.")));
 				
 			} else if(index==2) {


### PR DESCRIPTION
We're getting there.

Dialogue punctuation corrections for the Slime Queen quest and some other stuff around Submission. I'll look into the Gambling Den another time.
I'm sure I missed some, and there're the usual debates about whether something should be considered a dialogue tag or not. In which case it's mostly up to preference.

I don't know why it keeps creating an extra empty line after `</dialogue> `at the end of the .txt files and I can't seem to make it stop doing that.