### PR TITLE
Tooltip thread fix

### DIFF
--- a/src/com/lilithsthrone/controller/TooltipUpdateThread.java
+++ b/src/com/lilithsthrone/controller/TooltipUpdateThread.java
@@ -9,42 +9,33 @@ import javafx.application.Platform;
  * @version 0.1.7
  * @author Innoxia
  */
-public class TooltipUpdateThread extends Thread {
+public class TooltipUpdateThread {
 
 	public static boolean cancelThreads = false;
 
-	public double x, y;
-	
-	public TooltipUpdateThread() {
-		this(-1, -1);
-	}
-	
-	public TooltipUpdateThread(double xPosition, double yPosition) {
-		x = xPosition;
-		y = yPosition;
-	}
-
-	public void run() {
+	public static void updateToolTip(double xPosition, double yPosition) {
 		cancelThreads = false;
 
-		try {
-			sleep(50);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
+		// try {
+		// 	sleep(50);
+		// } catch (InterruptedException e) {
+		// 	e.printStackTrace();
+		// }
 
+		// While this probably isn't needed, since we run the game on the JavaFX thread most of the time
+		// I'm keeping it in just in case since JavaFX isn't threadsafe.
 		Platform.runLater(new Runnable() {
 			@Override
 			public void run() {
+
 				if (!cancelThreads) {
 					Main.mainController.getTooltip().show(Main.primaryStage);
 					
-					if(x != -1){
-						Main.mainController.getTooltip().setAnchorY(y);	
+					if(xPosition != -1){
+						Main.mainController.getTooltip().setAnchorY(yPosition);	
 					}
 				}
 			}
 		});
-
 	}
 }

--- a/src/com/lilithsthrone/controller/TooltipUpdateThread.java
+++ b/src/com/lilithsthrone/controller/TooltipUpdateThread.java
@@ -23,7 +23,7 @@ public class TooltipUpdateThread {
 		// }
 
 		// While this probably isn't needed, since we run the game on the JavaFX thread most of the time
-		// I'm keeping it in just in case since JavaFX isn't threadsafe.
+		// I'm keeping it in just in case since JavaFX isn't threadsafe. - Alaco
 		Platform.runLater(new Runnable() {
 			@Override
 			public void run() {

--- a/src/com/lilithsthrone/controller/eventListeners/InventoryTooltipEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/InventoryTooltipEventListener.java
@@ -549,8 +549,9 @@ public class InventoryTooltipEventListener implements EventListener {
 		}  else {
 			return;
 		}
+		
+		TooltipUpdateThread.updateToolTip(-1,-1);
 
-		(new Thread(new TooltipUpdateThread())).start();
 		// Main.mainController.getTooltip().show(Main.primaryStage);
 	}
 

--- a/src/com/lilithsthrone/controller/eventListeners/TooltipInformationEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/TooltipInformationEventListener.java
@@ -871,8 +871,8 @@ public class TooltipInformationEventListener implements EventListener {
 						+ "<div class='description'>" + description + "</div>"));
 			}
 		}
-
-		(new Thread(new TooltipUpdateThread())).start();
+		
+		TooltipUpdateThread.updateToolTip(-1,-1);
 	}
 	
 	private String getBodyPartDiv(String name, Race race, BodyCoveringType covering) {

--- a/src/com/lilithsthrone/controller/eventListeners/TooltipResponseDescriptionEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/TooltipResponseDescriptionEventListener.java
@@ -50,7 +50,8 @@ public class TooltipResponseDescriptionEventListener implements EventListener {
 				Main.mainController.getTooltip().setAnchorX(xPosition);
 				Main.mainController.getTooltip().setAnchorY(yPosition);
 				
-				(new Thread(new TooltipUpdateThread(xPosition, yPosition))).start();
+				TooltipUpdateThread.updateToolTip(xPosition,yPosition);
+
 			}
 		} else if (previousPage) {
 			if (Main.game.getResponsePage() != 0) {
@@ -71,7 +72,8 @@ public class TooltipResponseDescriptionEventListener implements EventListener {
 				Main.mainController.getTooltip().setAnchorX(xPosition);
 				Main.mainController.getTooltip().setAnchorY(yPosition);
 				
-				(new Thread(new TooltipUpdateThread(xPosition, yPosition))).start();
+				TooltipUpdateThread.updateToolTip(xPosition,yPosition);
+
 			}
 			
 		} else {
@@ -187,7 +189,7 @@ public class TooltipResponseDescriptionEventListener implements EventListener {
 				Main.mainController.getTooltip().setAnchorX(xPosition);
 				Main.mainController.getTooltip().setAnchorY(yPosition);
 				
-				(new Thread(new TooltipUpdateThread(xPosition, yPosition))).start();
+				TooltipUpdateThread.updateToolTip(xPosition,yPosition);
 				Main.mainController.setTooltipContent(UtilText.parse(tooltipSB.toString()));
 			}
 			

--- a/src/com/lilithsthrone/controller/eventListeners/information/CopyInfoEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/information/CopyInfoEventListener.java
@@ -28,6 +28,6 @@ public class CopyInfoEventListener implements EventListener {
 				+ Main.game.getCurrentDialogueNode().getAuthor()
 				+ "</b></div>");
 		
-		(new Thread(new TooltipUpdateThread())).start();
+		TooltipUpdateThread.updateToolTip(-1,-1);
 	}
 }


### PR DESCRIPTION
### Things to include in a large Pull Request:

- What is the purpose of the pull request?

Changes `ToolTipUpdateThread` to not create a separate thread each time the tooltip is displayed.

- Give a brief description of what you changed or added.

Before the process worked like this:
1. Create a new Java Thread
2. Wait 50ms
3. Tell the JavaFX thread to display the tooltip

Now it works like this:
1. Tell the JavaFX thread to display the tooltip


Also removed the 50ms wait since it would now cause the JavaFX thread to wait.

- Are any new graphical assets required?
No.
- Has this change been tested? If so, mention the version number that the test was based on.
Tested on 2.6.5
- So we have a better idea of who you are, what is your Discord Handle?
@Alaco
- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
