### PR TITLE
Fixed ToolTipThread to not create a new thread with evvery display

### DIFF
--- a/src/com/lilithsthrone/controller/TooltipUpdateThread.java
+++ b/src/com/lilithsthrone/controller/TooltipUpdateThread.java
@@ -13,18 +13,7 @@ public class TooltipUpdateThread extends Thread {
 
 	public static boolean cancelThreads = false;
 
-	public double x, y;
-	
-	public TooltipUpdateThread() {
-		this(-1, -1);
-	}
-	
-	public TooltipUpdateThread(double xPosition, double yPosition) {
-		x = xPosition;
-		y = yPosition;
-	}
-
-	public void run() {
+	public static void updateToolTip(double xPosition, double yPosition) {
 		cancelThreads = false;
 
 		try {
@@ -33,18 +22,20 @@ public class TooltipUpdateThread extends Thread {
 			e.printStackTrace();
 		}
 
+		// While this probably isn't needed, since we run the game on the JavaFX thread most of the time
+		// I'm keeping it in just in case since JavaFX isn't threadsafe.
 		Platform.runLater(new Runnable() {
 			@Override
 			public void run() {
+
 				if (!cancelThreads) {
 					Main.mainController.getTooltip().show(Main.primaryStage);
 					
-					if(x != -1){
-						Main.mainController.getTooltip().setAnchorY(y);	
+					if(xPosition != -1){
+						Main.mainController.getTooltip().setAnchorY(yPosition);	
 					}
 				}
 			}
 		});
-
 	}
 }

--- a/src/com/lilithsthrone/controller/eventListeners/InventoryTooltipEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/InventoryTooltipEventListener.java
@@ -550,7 +550,7 @@ public class InventoryTooltipEventListener implements EventListener {
 			return;
 		}
 
-		(new Thread(new TooltipUpdateThread())).start();
+		TooltipUpdateThread.updateToolTip(-1,-1);
 		// Main.mainController.getTooltip().show(Main.primaryStage);
 	}
 

--- a/src/com/lilithsthrone/controller/eventListeners/TooltipInformationEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/TooltipInformationEventListener.java
@@ -872,7 +872,7 @@ public class TooltipInformationEventListener implements EventListener {
 			}
 		}
 
-		(new Thread(new TooltipUpdateThread())).start();
+		TooltipUpdateThread.updateToolTip(-1,-1);
 	}
 	
 	private String getBodyPartDiv(String name, Race race, BodyCoveringType covering) {

--- a/src/com/lilithsthrone/controller/eventListeners/TooltipResponseDescriptionEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/TooltipResponseDescriptionEventListener.java
@@ -50,7 +50,7 @@ public class TooltipResponseDescriptionEventListener implements EventListener {
 				Main.mainController.getTooltip().setAnchorX(xPosition);
 				Main.mainController.getTooltip().setAnchorY(yPosition);
 				
-				(new Thread(new TooltipUpdateThread(xPosition, yPosition))).start();
+				TooltipUpdateThread.updateToolTip(xPosition,yPosition);
 			}
 		} else if (previousPage) {
 			if (Main.game.getResponsePage() != 0) {
@@ -71,7 +71,7 @@ public class TooltipResponseDescriptionEventListener implements EventListener {
 				Main.mainController.getTooltip().setAnchorX(xPosition);
 				Main.mainController.getTooltip().setAnchorY(yPosition);
 				
-				(new Thread(new TooltipUpdateThread(xPosition, yPosition))).start();
+				TooltipUpdateThread.updateToolTip(xPosition,yPosition);
 			}
 			
 		} else {
@@ -187,7 +187,7 @@ public class TooltipResponseDescriptionEventListener implements EventListener {
 				Main.mainController.getTooltip().setAnchorX(xPosition);
 				Main.mainController.getTooltip().setAnchorY(yPosition);
 				
-				(new Thread(new TooltipUpdateThread(xPosition, yPosition))).start();
+				TooltipUpdateThread.updateToolTip(xPosition,yPosition);
 				Main.mainController.setTooltipContent(UtilText.parse(tooltipSB.toString()));
 			}
 			

--- a/src/com/lilithsthrone/controller/eventListeners/information/CopyInfoEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/information/CopyInfoEventListener.java
@@ -28,6 +28,6 @@ public class CopyInfoEventListener implements EventListener {
 				+ Main.game.getCurrentDialogueNode().getAuthor()
 				+ "</b></div>");
 		
-		(new Thread(new TooltipUpdateThread())).start();
+		TooltipUpdateThread.updateToolTip(-1,-1);
 	}
 }


### PR DESCRIPTION
### Things to include in a large Pull Request:

- What is the purpose of the pull request?
Change `ToolTipUpdateThread` to not create a new Java thread with every Tooltip display
- Give a brief description of what you changed or added.
Changed the Tooltips to not run on a new thread every time, and instead run on the JavaFX thread.
- Are any new graphical assets required?
No
- Has this change been tested? If so, mention the version number that the test was based on.
Tested on 2.6.5 and on the `dev` branch
- So we have a better idea of who you are, what is your Discord Handle?
@Alaco
- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
