### PR TITLE
Add Hair-Type to Slime Transformations in BodyChanging.java

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/BodyChanging.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/BodyChanging.java
@@ -364,6 +364,7 @@ public class BodyChanging {
 						
 						+"<div style='clear:left;'>"
 							+ CharacterModificationUtils.getSelfTransformAntennaChoiceDiv(slimeRaces)
+							+ CharacterModificationUtils.getSelfTransformHairChoiceDiv(slimeRaces)
 						+"</div>"
 						
 						+"<div style='clear:left;'>"


### PR DESCRIPTION
Adds the Hair Type change to the Slime Transformations, allowing a character to be changed to a 'Greater' whatever.

This permits greater Angels without cheating, as well as Greater Morphs via the Biojuice Canister and a Slime Elixer (Arcane Boosted to Flesh).

Compiled and tested in-game (2.6.5); successful for Angel, Demon, Imp, Reindeer, Canine, Equine, Alligator and Wolf Morphs (Sloths, Orangutans, Breakfast Cereals...) all the -Morphs work with this.