### PR TITLE
Add configuration of NPCs sexual orientation encounter rates

### DIFF
--- a/src/com/lilithsthrone/controller/MainControllerInitMethod.java
+++ b/src/com/lilithsthrone/controller/MainControllerInitMethod.java
@@ -94,6 +94,7 @@ import com.lilithsthrone.game.character.persona.NameTriplet;
 import com.lilithsthrone.game.character.persona.PersonalityTrait;
 import com.lilithsthrone.game.character.persona.PersonalityWeight;
 import com.lilithsthrone.game.character.persona.SexualOrientation;
+import com.lilithsthrone.game.character.persona.SexualOrientationPreference;
 import com.lilithsthrone.game.character.race.FurryPreference;
 import com.lilithsthrone.game.character.race.Subspecies;
 import com.lilithsthrone.game.combat.DamageType;
@@ -4065,6 +4066,21 @@ public class MainControllerInitMethod {
 					if (((EventTarget) MainController.document.getElementById(preference+"_"+g)) != null) {
 						((EventTarget) MainController.document.getElementById(preference+"_"+g)).addEventListener("click", e -> {
 							Main.getProperties().genderPreferencesMap.put(g, preference.getValue());
+							Main.saveProperties();
+							Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+						}, false);
+					}
+				}
+			}
+		}
+
+		// Sexual orientation preferences:
+		if (Main.game.getCurrentDialogueNode() == OptionsDialogue.ORIENTATION_PREFERENCE) {
+			for (SexualOrientation o : SexualOrientation.values()) {
+				for(SexualOrientationPreference preference : SexualOrientationPreference.values()) {
+					if (((EventTarget) MainController.document.getElementById(preference+"_"+o)) != null) {
+						((EventTarget) MainController.document.getElementById(preference+"_"+o)).addEventListener("click", e -> {
+							Main.getProperties().orientationPreferencesMap.put(o, preference.getValue());
 							Main.saveProperties();
 							Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
 						}, false);

--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -28,6 +28,7 @@ import com.lilithsthrone.game.character.gender.AndrogynousIdentification;
 import com.lilithsthrone.game.character.gender.Gender;
 import com.lilithsthrone.game.character.gender.GenderNames;
 import com.lilithsthrone.game.character.gender.GenderPronoun;
+import com.lilithsthrone.game.character.persona.SexualOrientation;
 import com.lilithsthrone.game.character.race.FurryPreference;
 import com.lilithsthrone.game.character.race.Race;
 import com.lilithsthrone.game.character.race.Subspecies;
@@ -91,6 +92,7 @@ public class Properties implements Serializable {
 	public Map<GenderPronoun, String> genderPronounFemale, genderPronounMale;
 	
 	public Map<Gender, Integer> genderPreferencesMap;
+	public Map<SexualOrientation, Integer> orientationPreferencesMap;
 	private Map<Subspecies, FurryPreference> subspeciesFeminineFurryPreferencesMap, subspeciesMasculineFurryPreferencesMap;
 	private Map<Subspecies, SubspeciesPreference> subspeciesFemininePreferencesMap, subspeciesMasculinePreferencesMap;
 	
@@ -135,6 +137,11 @@ public class Properties implements Serializable {
 		genderPreferencesMap = new EnumMap<>(Gender.class);
 		for(Gender g : Gender.values()) {
 			genderPreferencesMap.put(g, g.getGenderPreferenceDefault().getValue());
+		}
+
+		orientationPreferencesMap = new EnumMap<>(SexualOrientation.class);
+		for(SexualOrientation o : SexualOrientation.values()) {
+			orientationPreferencesMap.put(o, o.getOrientationPreferenceDefault().getValue());
 		}
 		
 		forcedTFPreference = FurryPreference.NORMAL;
@@ -329,6 +336,22 @@ public class Properties implements Serializable {
 				
 				Attr value = doc.createAttribute("value");
 				value.setValue(String.valueOf(genderPreferencesMap.get(g).intValue()));
+				element.setAttributeNode(value);
+			}
+
+			// Sexual orientation preferences:
+			Element orientationPreferences = doc.createElement("orientationPreferences");
+			properties.appendChild(orientationPreferences);
+			for (SexualOrientation o : SexualOrientation.values()) {
+				Element element = doc.createElement("preference");
+				orientationPreferences.appendChild(element);
+				
+				Attr orientation = doc.createAttribute("orientation");
+				orientation.setValue(o.toString());
+				element.setAttributeNode(orientation);
+				
+				Attr value = doc.createAttribute("value");
+				value.setValue(String.valueOf(orientationPreferencesMap.get(o).intValue()));
 				element.setAttributeNode(value);
 			}
 			
@@ -685,6 +708,21 @@ public class Properties implements Serializable {
 					}
 				}
 				
+				// Sexual orientation preferences:
+				nodes = doc.getElementsByTagName("orientationPreferences");
+				element = (Element) nodes.item(0);
+				if(element!=null && element.getElementsByTagName("preference")!=null) {
+					for(int i=0; i<element.getElementsByTagName("preference").getLength(); i++){
+						Element e = ((Element)element.getElementsByTagName("preference").item(i));
+						
+						try {
+							if(!e.getAttribute("orientation").isEmpty()) {
+								orientationPreferencesMap.put(SexualOrientation.valueOf(e.getAttribute("orientation")), Integer.valueOf(e.getAttribute("value")));
+							}
+						} catch(IllegalArgumentException ex){
+						}
+					}
+				}
 				
 				// Race preferences:
 				nodes = doc.getElementsByTagName("subspeciesPreferences");

--- a/src/com/lilithsthrone/game/character/persona/SexualOrientation.java
+++ b/src/com/lilithsthrone/game/character/persona/SexualOrientation.java
@@ -8,19 +8,20 @@ import com.lilithsthrone.utils.Colour;
  * @author Innoxia
  */
 public enum SexualOrientation {
+	ANDROPHILIC("androphilic", Colour.MASCULINE, SexualOrientationPreference.THREE_AVERAGE),
 
-	ANDROPHILIC("androphilic", Colour.MASCULINE),
+	GYNEPHILIC("gynephilic",Colour.FEMININE, SexualOrientationPreference.THREE_AVERAGE),
 
-	GYNEPHILIC("gynephilic",Colour.FEMININE),
+	AMBIPHILIC("ambiphilic", Colour.ANDROGYNOUS, SexualOrientationPreference.THREE_AVERAGE);
 
-	AMBIPHILIC("ambiphilic", Colour.ANDROGYNOUS);
-	
 	private String name;
 	private Colour colour;
+	private SexualOrientationPreference orientationPreferenceDefault;
 
-	private SexualOrientation(String name, Colour colour) {
+	private SexualOrientation(String name, Colour colour, SexualOrientationPreference orientationPreferenceDefault) {
 		this.name = name;
 		this.colour = colour;
+		this.orientationPreferenceDefault = orientationPreferenceDefault;
 	}
 
 	public String getName() {
@@ -31,4 +32,7 @@ public enum SexualOrientation {
 		return colour;
 	}
 	
+	public SexualOrientationPreference getOrientationPreferenceDefault() {
+		return orientationPreferenceDefault;
+	}
 }

--- a/src/com/lilithsthrone/game/character/persona/SexualOrientationPreference.java
+++ b/src/com/lilithsthrone/game/character/persona/SexualOrientationPreference.java
@@ -1,0 +1,62 @@
+package com.lilithsthrone.game.character.persona;
+
+import com.lilithsthrone.main.Main;
+import com.lilithsthrone.utils.Util;
+
+public enum SexualOrientationPreference {
+
+	ZERO_NONE("off", 0),
+	ONE_MINIMAL("minimal", 1),
+	TWO_LOW("low", 5),
+	THREE_AVERAGE("average", 10),
+	FOUR_HIGH("high", 20),
+	FIVE_ABUNDANT("abundant", 40);
+
+	private String name;
+	private int value;
+	
+	private SexualOrientationPreference(String name, int value) {
+		this.name= name;
+		this.value=value;
+	}
+	
+	public static SexualOrientation getSexualOrientationFromUserPreferences(int gynephilicWeight, int ambiphilicWeight, int androphilicWeight) {
+		int gyne = Main.getProperties().orientationPreferencesMap.get(SexualOrientation.GYNEPHILIC) * gynephilicWeight;
+		int ambi = Main.getProperties().orientationPreferencesMap.get(SexualOrientation.AMBIPHILIC) * ambiphilicWeight;
+		int andro = Main.getProperties().orientationPreferencesMap.get(SexualOrientation.ANDROPHILIC) * androphilicWeight;
+		int total = gyne + ambi + andro;
+
+		if(total == 0) {
+			return SexualOrientation.AMBIPHILIC;
+		}
+		
+		int random = Util.random.nextInt(total)+1;
+		
+		int newTotal = 0;
+		
+		newTotal += gyne;
+		if(random <= newTotal) {
+			return SexualOrientation.GYNEPHILIC;
+		}
+
+		newTotal += ambi;
+		if(random <= newTotal) {
+			return SexualOrientation.AMBIPHILIC;
+		}
+
+		newTotal += andro;
+		if(random <= newTotal) {
+			return SexualOrientation.ANDROPHILIC;
+		}
+
+		return SexualOrientation.AMBIPHILIC;
+	}
+	
+	public int getValue() {
+		return value;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/src/com/lilithsthrone/game/character/race/RacialBody.java
+++ b/src/com/lilithsthrone/game/character/race/RacialBody.java
@@ -51,6 +51,7 @@ import com.lilithsthrone.game.character.gender.Gender;
 import com.lilithsthrone.game.character.persona.PersonalityTrait;
 import com.lilithsthrone.game.character.persona.PersonalityWeight;
 import com.lilithsthrone.game.character.persona.SexualOrientation;
+import com.lilithsthrone.game.character.persona.SexualOrientationPreference;
 import com.lilithsthrone.main.Main;
 import com.lilithsthrone.utils.Util;
 import com.lilithsthrone.utils.Util.Value;
@@ -130,7 +131,7 @@ public enum RacialBody {
 		
 		@Override
 		public SexualOrientation getSexualOrientation(Gender gender) {
-			return SexualOrientation.AMBIPHILIC;
+			return SexualOrientationPreference.getSexualOrientationFromUserPreferences(0, 1, 0);
 		}
 	},
 
@@ -175,7 +176,7 @@ public enum RacialBody {
 		
 		@Override
 		public SexualOrientation getSexualOrientation(Gender gender) {
-			return SexualOrientation.AMBIPHILIC;
+			return SexualOrientationPreference.getSexualOrientationFromUserPreferences(0, 1, 0);
 		}
 	},
 	
@@ -219,7 +220,7 @@ public enum RacialBody {
 		
 		@Override
 		public SexualOrientation getSexualOrientation(Gender gender) {
-			return SexualOrientation.AMBIPHILIC;
+			return SexualOrientationPreference.getSexualOrientationFromUserPreferences(0, 1, 0);
 		}
 	},
 
@@ -623,13 +624,7 @@ public enum RacialBody {
 		
 		@Override
 		public SexualOrientation getSexualOrientation(Gender gender) {
-			double chance = Math.random();
-			
-			if(chance<0.95f) {
-				return SexualOrientation.GYNEPHILIC;
-			} else {
-				return SexualOrientation.AMBIPHILIC;
-			}
+			return SexualOrientationPreference.getSexualOrientationFromUserPreferences(95, 5, 0);
 		}
 	};
 
@@ -890,25 +885,10 @@ public enum RacialBody {
 	}
 	
 	public SexualOrientation getSexualOrientation(Gender gender) {
-		double chance = Math.random();
-		
 		if(gender.isFeminine()) {
-			if(chance<0.15f) {
-				return SexualOrientation.GYNEPHILIC;
-			} else if (chance<0.5f) {
-				return SexualOrientation.ANDROPHILIC;
-			} else {
-				return SexualOrientation.AMBIPHILIC;
-			}
-			
+			return SexualOrientationPreference.getSexualOrientationFromUserPreferences(15, 50, 35);
 		} else {
-			if(chance<0.10f) {
-				return SexualOrientation.ANDROPHILIC;
-			} else if (chance<0.5f) {
-				return SexualOrientation.GYNEPHILIC;
-			} else {
-				return SexualOrientation.AMBIPHILIC;
-			}
+			return SexualOrientationPreference.getSexualOrientationFromUserPreferences(40, 50, 10);
 		}
 	}
 	

--- a/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
@@ -19,6 +19,8 @@ import com.lilithsthrone.game.character.gender.GenderPreference;
 import com.lilithsthrone.game.character.gender.GenderPronoun;
 import com.lilithsthrone.game.character.gender.PronounType;
 import com.lilithsthrone.game.character.npc.NPC;
+import com.lilithsthrone.game.character.persona.SexualOrientation;
+import com.lilithsthrone.game.character.persona.SexualOrientationPreference;
 import com.lilithsthrone.game.character.race.FurryPreference;
 import com.lilithsthrone.game.character.race.Subspecies;
 import com.lilithsthrone.game.combat.Combat;
@@ -682,6 +684,9 @@ public class OptionsDialogue {
 				return new Response("Gender preferences", "Set your preferred gender encounter rates.", GENDER_PREFERENCE);
 			
 			} else if (index == 9) {
+				return new Response("Orientation preferences", "Set your preferred sexual orientation encounter rates.", ORIENTATION_PREFERENCE);
+
+			} else if (index == 10) {
 				return new Response("Furry preferences", "Set your preferred transformation encounter rates.", FURRY_PREFERENCE);
 			
 			} else if (index == 0) {
@@ -1112,9 +1117,9 @@ public class OptionsDialogue {
 					+ "A character is considered to have breasts if they are at least an AA-cup."
 					+ "</div>");
 			
-			UtilText.nodeContentSB.append(getGenerPreferencesPanel(PronounType.MASCULINE));
-			UtilText.nodeContentSB.append(getGenerPreferencesPanel(PronounType.NEUTRAL));
-			UtilText.nodeContentSB.append(getGenerPreferencesPanel(PronounType.FEMININE));
+			UtilText.nodeContentSB.append(getGenderPreferencesPanel(PronounType.MASCULINE));
+			UtilText.nodeContentSB.append(getGenderPreferencesPanel(PronounType.NEUTRAL));
+			UtilText.nodeContentSB.append(getGenderPreferencesPanel(PronounType.FEMININE));
 			
 			
 			return UtilText.nodeContentSB.toString();
@@ -1141,7 +1146,7 @@ public class OptionsDialogue {
 		}
 	};
 	
-	private static String getGenerPreferencesPanel(PronounType type) {
+	private static String getGenderPreferencesPanel(PronounType type) {
 		int count = 0;
 		Colour colour = Colour.MASCULINE;
 		switch(type) {
@@ -1188,6 +1193,98 @@ public class OptionsDialogue {
 		sb.append(
 				getGenderRepresentation()
 				+"</div>");
+		
+		return sb.toString();
+	}
+
+	private static String getOrientationRepresentation() {
+		float total=0;
+		for(SexualOrientation o : SexualOrientation.values()) {
+			total+=Main.getProperties().orientationPreferencesMap.get(o);
+		}
+		
+		StringBuilder sb = new StringBuilder();
+		
+		if(total==0) {
+			sb.append("<div style='width:100%;height:12px;background:"+Colour.ANDROGYNOUS.toWebHexString()+";float:left;margin:4vw 0 0 0;border-radius: 2px;'>");
+			
+		} else {
+			sb.append("<div style='width:100%;height:12px;background:#222;float:left;margin:4vw 0 0 0;border-radius: 2px;'>");
+			
+			for(SexualOrientation o : SexualOrientation.values()) {
+				sb.append("<div style='width:" + (Main.getProperties().orientationPreferencesMap.get(o)/total) * (100) + "%; height:12px; background:"
+						+ o.getColour().toWebHexString() + "; float:left; border-radius: 2;'></div>");
+			}
+		}
+		
+		sb.append("</div>");
+		
+		return sb.toString();
+	}
+	
+	public static final DialogueNodeOld ORIENTATION_PREFERENCE = new DialogueNodeOld("Orientation preferences", "", true) {
+		private static final long serialVersionUID = 1L;
+		
+		@Override
+		public String getHeaderContent(){
+			UtilText.nodeContentSB.setLength(0);
+			
+			UtilText.nodeContentSB.append(
+					"<div class='container-full-width'>"
+					+ "These options will determine the sexual orientation encounter rates of random NPCs."
+					+ " Note that the race and femininity of NPCs can have an influence on their orientation, but your preferences will be taken into account wherever possible.</br>"
+					+ "<b>A visual representation of the encounter chances can be seen in the bars at the bottom.</b>"
+					+ " (The different shades of each orientation are solely for recognition in the bars, and don't mean anything other than that.)"
+					+ "</div>"
+		
+					+ "<div class='container-full-width' style='text-align:center;'>");
+			
+			UtilText.nodeContentSB.append(getOrientationPreferencesPanel(SexualOrientation.ANDROPHILIC));
+			UtilText.nodeContentSB.append(getOrientationPreferencesPanel(SexualOrientation.AMBIPHILIC));
+			UtilText.nodeContentSB.append(getOrientationPreferencesPanel(SexualOrientation.GYNEPHILIC));
+
+			UtilText.nodeContentSB.append(getOrientationRepresentation() + "</div>");
+			
+			return UtilText.nodeContentSB.toString();
+		}
+		
+		@Override
+		public String getContent(){
+			return "";
+		}
+		
+		@Override
+		public Response getResponse(int responseTab, int index) {
+			 if (index == 0) {
+				return new Response("Back", "Go back to the options menu.", OPTIONS);
+				
+			}else {
+				return null;
+			}
+		}
+
+		@Override
+		public DialogueNodeType getDialogueNodeType() {
+			return DialogueNodeType.OPTIONS;
+		}
+	};
+
+	private static String getOrientationPreferencesPanel(SexualOrientation orient) {
+		Colour colour = orient.getColour();
+		
+		StringBuilder sb = new StringBuilder();
+		
+		sb.append("<div style='display:inline-block; margin:4px auto;width:100%;'>"
+				+ "<div style='display:inline-block; margin:0 auto;'>"
+					+ "<div style='width:140px; float:left;'><b style='color:"+colour.toWebHexString()+";'>" +Util.capitaliseSentence(orient.getName())+"</b></div>");
+		
+		for(SexualOrientationPreference preference : SexualOrientationPreference.values()) {
+			sb.append("<div id='"+preference+"_"+orient+"' class='preference-button"+(Main.getProperties().orientationPreferencesMap.get(orient)==preference.getValue()?" selected":"")+"'>"+Util.capitaliseSentence(preference.getName())+"</div>");
+		}
+						
+		sb.append("</div>"
+				+ "</div>"
+				+ "<hr></hr>");
 		
 		return sb.toString();
 	}


### PR DESCRIPTION
This change adds an option for players to set the encounter rates for the sexual orientation of random NPCs, in the same way as gender encounter rates.

The generation function uses both the generic player-defined rates and call-specific rates when computing the final orientation. The specific rates can be used for race/feminity-dependent rates. For example, harpies were previously hardcoded as being almost always gynephilic, and now use the generation function with unbalanced specific rates.

-----

- No new graphical assets are required.
- This change has been tested on version 0.2.6.5.
- I am Otter#4718 on discord.