### PR TITLE
Clothing Enchantments alter Vaginal Urethra stats

### DIFF
--- a/src/com/lilithsthrone/game/inventory/enchanting/AbstractItemEffectType.java
+++ b/src/com/lilithsthrone/game/inventory/enchanting/AbstractItemEffectType.java
@@ -214,6 +214,9 @@ public abstract class AbstractItemEffectType {
 						);
 
 				if(Main.getProperties().hasValue(PropertyValue.urethralContent)) {
+					mods.add(TFModifier.TF_MOD_CAPACITY_2);
+					mods.add(TFModifier.TF_MOD_ELASTICITY_2);
+					mods.add(TFModifier.TF_MOD_PLASTICITY_2);
 					mods.add(TFModifier.TF_MOD_ORIFICE_PUFFY_2);
 					mods.add(TFModifier.TF_MOD_ORIFICE_RIBBED_2);
 					mods.add(TFModifier.TF_MOD_ORIFICE_MUSCLED_2);
@@ -234,6 +237,12 @@ public abstract class AbstractItemEffectType {
 			case TF_MOD_ELASTICITY:
 				return OrificeElasticity.SEVEN_ELASTIC.getValue();
 			case TF_MOD_PLASTICITY:
+				return OrificePlasticity.SEVEN_MOULDABLE.getValue();
+			case TF_MOD_CAPACITY_2:
+				return Capacity.SEVEN_GAPING.getMaximumValue();
+			case TF_MOD_ELASTICITY_2:
+				return OrificeElasticity.SEVEN_ELASTIC.getValue();
+			case TF_MOD_PLASTICITY_2:
 				return OrificePlasticity.SEVEN_MOULDABLE.getValue();
 			case TF_MOD_WETNESS:
 				if(primaryModifier!=TFModifier.TF_PENIS
@@ -359,6 +368,15 @@ public abstract class AbstractItemEffectType {
 				break;
 			case TF_MOD_PLASTICITY:
 				descriptions.add(getClothingTFChangeDescriptionEntry(potency, orificeName+" plasticity", OrificePlasticity.getElasticityFromInt(limit).getDescriptor()));
+				break;
+			case TF_MOD_CAPACITY_2:
+				descriptions.add(getClothingTFChangeDescriptionEntry(potency, orificeName+"l urethra capacity", limit+" inches"));
+				break;
+			case TF_MOD_ELASTICITY_2:
+				descriptions.add(getClothingTFChangeDescriptionEntry(potency, orificeName+"l urethra elasticity", OrificeElasticity.getElasticityFromInt(limit).getDescriptor()));
+				break;
+			case TF_MOD_PLASTICITY_2:
+				descriptions.add(getClothingTFChangeDescriptionEntry(potency, orificeName+"l urethra plasticity", OrificePlasticity.getElasticityFromInt(limit).getDescriptor()));
 				break;
 			case TF_MOD_WETNESS:
 				if(primaryModifier!=TFModifier.TF_PENIS
@@ -1136,6 +1154,27 @@ public abstract class AbstractItemEffectType {
 								if(target.hasVaginaOrificeModifier(OrificeModifier.TENTACLED)) {
 									sb.append(target.removeVaginaOrificeModifier(OrificeModifier.TENTACLED));
 								}
+							}
+							break;
+						case TF_MOD_CAPACITY_2:
+							if(isWithinLimits(capacityIncrement, target.getVaginaUrethraRawCapacityValue(), limit)) {
+								sb.append(target.incrementVaginaUrethraCapacity(capacityIncrement, true));
+							} else if(isSetToLimit(capacityIncrement, target.getVaginaUrethraRawCapacityValue(), limit)) {
+								sb.append(target.setVaginaUrethraCapacity(limit, true));
+							}
+							break;
+						case TF_MOD_ELASTICITY_2:
+							if(isWithinLimits(elasticityIncrement, target.getVaginaUrethraElasticity().getValue(), limit)) {
+								sb.append(target.incrementVaginaUrethraElasticity(elasticityIncrement));
+							} else if(isSetToLimit(elasticityIncrement, target.getVaginaUrethraElasticity().getValue(), limit)) {
+								sb.append(target.setVaginaUrethraElasticity(limit));
+							}
+							break;
+						case TF_MOD_PLASTICITY_2:
+							if(isWithinLimits(plasticityIncrement, target.getVaginaUrethraPlasticity().getValue(), limit)) {
+								sb.append(target.incrementVaginaUrethraPlasticity(plasticityIncrement));
+							} else if(isSetToLimit(plasticityIncrement, target.getVaginaUrethraPlasticity().getValue(), limit)) {
+								sb.append(target.setVaginaUrethraPlasticity(limit));
 							}
 							break;
 						case TF_MOD_ORIFICE_PUFFY_2:


### PR DESCRIPTION
Clothing enchantments can't currently alter vaginal urethral stats; there's no way in the UI to do so, and even 'cheated' in via save editing, they don't show up in the items and are removed if put in. With these changes to AbstractItemEffectTypes, they can be enchanted in clothing, they show up in UI and they function.

I've tested this in build 0.2.7 on the PC, and on several Enslaved NPCs, and it works; it allows altering the urethral stats via clothing enchanted by the PC.

@Innoxia this is obviously just how I assume that the game should work from the rest of the available enchantments; if the current paradigm is intentional it'd be nice to know.