### PR TITLE
Fix parser where none of the capitalise commande would not be recongnized

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -680,7 +680,7 @@ public class UtilText {
 					}
 				}
 				
-				if (openBrackets>0 && ((target!=null && command!=null) || String.valueOf(c).matches(".") || c!=' ' || c!=Character.MIN_VALUE)) {
+				if (openBrackets>0 && (Character.isLetterOrDigit(c) || c=='+' || c=='.' || c=='[')) {
 					sb.append(c);
 				}
 				

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -652,7 +652,7 @@ public class UtilText {
 						
 						} else if (c == '(') {
 							if(command == null) {
-								command = sb.toString().substring(1); // Cut off the '.' at the start.
+								command = sb.toString().substring(1); // Cut off the '(' at the start.
 								sb.setLength(0);
 							}
 							
@@ -680,7 +680,7 @@ public class UtilText {
 					}
 				}
 				
-				if (openBrackets>0 && (Character.isLetterOrDigit(c) || c=='+' || c=='.' || c=='[')) {
+				if (openBrackets>0 && (Character.isLetterOrDigit(c) || c=='+' || c=='.' || c=='[' || c=='(')) {
 					sb.append(c);
 				}
 				

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -587,8 +587,8 @@ public class UtilText {
 			
 			int startedParsingSegmentAt = 0;
 			
-			for (int i = 0; i < input.length(); i++) {
-				char c = input.charAt(i);
+			for (int i = 0; i < input.length(); i++) {				
+				char c = input.charAt(i);				
 				
 				if (currentParseMode != ParseMode.REGULAR) {
 					if (c == 'F' && substringMatchesInReverseAtIndex(input, "#IF", i)) {
@@ -680,7 +680,7 @@ public class UtilText {
 					}
 				}
 				
-				if (openBrackets>0 && ((target!=null && command!=null) || String.valueOf(c).matches(".") || c!=' ')) {
+				if (openBrackets>0 && ((target!=null && command!=null) || String.valueOf(c).matches(".") || c!=' ' || c!=Character.MIN_VALUE)) {
 					sb.append(c);
 				}
 				
@@ -4825,14 +4825,10 @@ public class UtilText {
 			command = command.split("_")[1];
 			parseAddPronoun = true;
 		} 
-		for(int i=0; i<command.length(); i++){
-			if(Character.isLetter(command.charAt(i))){
-				if(Character.isUpperCase(command.charAt(i))) {
-					parseCapitalise = true;
-				}
-				break;
-			}
-		}
+		
+		if(Character.isUpperCase(command.charAt(0))) {
+			parseCapitalise = true;
+		}		
 		
 		ParserTarget parserTarget = findParserTargetWithTag(target.replaceAll("\u200b", ""));
 		if (parserTarget == null) {

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -4825,9 +4825,13 @@ public class UtilText {
 			command = command.split("_")[1];
 			parseAddPronoun = true;
 		} 
-			
-		if(Character.isUpperCase(command.charAt(0))) {
-			parseCapitalise = true;
+		for(int i=0; i<command.length(); i++){
+			if(Character.isLetter(command.charAt(i))){
+				if(Character.isUpperCase(command.charAt(i))) {
+					parseCapitalise = true;
+				}
+				break;
+			}
 		}
 		
 		ParserTarget parserTarget = findParserTargetWithTag(target.replaceAll("\u200b", ""));

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -587,8 +587,8 @@ public class UtilText {
 			
 			int startedParsingSegmentAt = 0;
 			
-			for (int i = 0; i < input.length(); i++) {				
-				char c = input.charAt(i);				
+			for (int i = 0; i < input.length(); i++) {
+				char c = input.charAt(i);
 				
 				if (currentParseMode != ParseMode.REGULAR) {
 					if (c == 'F' && substringMatchesInReverseAtIndex(input, "#IF", i)) {
@@ -4828,7 +4828,7 @@ public class UtilText {
 		
 		if(Character.isUpperCase(command.charAt(0))) {
 			parseCapitalise = true;
-		}		
+		}
 		
 		ParserTarget parserTarget = findParserTargetWithTag(target.replaceAll("\u200b", ""));
 		if (parserTarget == null) {

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -652,7 +652,7 @@ public class UtilText {
 						
 						} else if (c == '(') {
 							if(command == null) {
-								command = sb.toString().substring(1); // Cut off the '(' at the start.
+								command = sb.toString().substring(1); // Cut off the '.' at the start.
 								sb.setLength(0);
 							}
 							


### PR DESCRIPTION
I have found a bug in the parser where the capitalized technique of making the first letter capital would not work even for the given example in the help. It seems that when removing the name from the command it would leave some empty char
[brax.Height] -> 'n/a'n/a'n/a'n/a'H'e'i'g'h't'

~~Now it looks for the first letter~~

An `if` statement was always returning true. So I fix the `if` so that now it properly filter the letter and most importantly remove the character `\U200B` that would appear in the input.