### PR TITLE
Further implement the conceal system

### DIFF
--- a/src/com/lilithsthrone/game/character/npc/NPC.java
+++ b/src/com/lilithsthrone/game/character/npc/NPC.java
@@ -258,14 +258,23 @@ public abstract class NPC extends GameCharacter implements XMLSaving {
 	public String getPresentInTileDescription() {
 		StringBuilder tileSB = new StringBuilder();
 		
-		tileSB.append(
-				UtilText.parse(this,
-						"<p style='text-align:center;'>"
-						+ "<b style='color:"+Femininity.valueOf(this.getFemininityValue()).getColour().toWebHexString()+";'>[npc.A_femininity]</b>"
-						+ " <b style='color:"+this.getRaceStage().getColour().toWebHexString()+";'>[npc.raceStage]</b>"
-						+ " <b style='color:"+this.getRace().getColour().toWebHexString()+";'>[npc.race]</b> <b>is prowling this area!</b></p>"
+		if(!this.isRaceConcealed()) {		
+			tileSB.append(
+					UtilText.parse(this,
+							"<p style='text-align:center;'>"
+							+ "<b style='color:"+Femininity.valueOf(this.getFemininityValue()).getColour().toWebHexString()+";'>[npc.A_femininity]</b>"
+							+ " <b style='color:"+this.getRaceStage().getColour().toWebHexString()+";'>[npc.raceStage]</b>"
+							+ " <b style='color:"+this.getRace().getColour().toWebHexString()+";'>[npc.race]</b> <b>is prowling this area!</b></p>"
 						
-						+ "<p style='text-align:center;'>"));
+							+ "<p style='text-align:center;'>"));
+		} else {
+			tileSB.append(
+					UtilText.parse(this,
+							"<p style='text-align:center;'>"
+							+"<b>Someone or something is prowling this area!</b></p>"
+				
+							+ "<p style='text-align:center;'>"));
+		}
 				
 		// Combat:
 		if(this.getFoughtPlayerCount()>0) {

--- a/src/com/lilithsthrone/game/dialogue/utils/CharactersPresentDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/CharactersPresentDialogue.java
@@ -34,8 +34,13 @@ public class CharactersPresentDialogue {
 		} else {
 			CharactersPresentDialogue.characterViewed = characterViewed;
 		}
-		menuTitle = "Characters Present ("+Util.capitaliseSentence(CharactersPresentDialogue.characterViewed.getName())+")";
-		menuContent = ((NPC) CharactersPresentDialogue.characterViewed).getCharacterInformationScreen();
+		if((!((NPC)CharactersPresentDialogue.characterViewed).isRaceConcealed())) {
+			menuTitle = "Characters Present ("+Util.capitaliseSentence(CharactersPresentDialogue.characterViewed.getName())+")";
+			menuContent = ((NPC) CharactersPresentDialogue.characterViewed).getCharacterInformationScreen();
+		} else {
+			menuTitle = "Characters Present";
+			menuContent = "You have not yet seen the true nature of this person";
+		}
 	}
 	
 	public static final DialogueNodeOld MENU = new DialogueNodeOld("", "", true) {
@@ -95,8 +100,14 @@ public class CharactersPresentDialogue {
 					String description = "Take a detailed look at [npc.name].";
 					
 					if(charactersPresent.get(index - 1).equals(characterViewed)) {
-						title = "[style.colourDisabled([npc.Name])]";
-						description = "You are already looking at [npc.name]!";
+						if(!charactersPresent.get(index - 1).isRaceConcealed()) {
+							title = "[style.colourDisabled([npc.Name])]";
+							description = "You are already looking at [npc.name]!";
+						}else {
+							title = "[style.colourDisabled(Unknown person)]";
+							description = "You don't know what the person look's like";
+						}
+							
 						
 					} else if(Main.game.getPlayer().hasCompanion(charactersPresent.get(index - 1))) {
 						title = "[style.colourCompanion([npc.Name])]";
@@ -110,9 +121,13 @@ public class CharactersPresentDialogue {
 						@Override
 						public void effects() {
 							characterViewed = charactersPresent.get(index-1);
-							
+						if(!((NPC) charactersPresent.get(index - 1)).isRaceConcealed()) {	
 							menuTitle = "Characters Present ("+Util.capitaliseSentence(charactersPresent.get(index - 1).getName())+")";
 							menuContent = ((NPC) charactersPresent.get(index - 1)).getCharacterInformationScreen();
+						} else {
+							menuTitle = "Characters Present";
+							menuContent = "You have not yet seen the true nature of this person";
+						}
 						}
 					};
 					
@@ -195,6 +210,7 @@ public class CharactersPresentDialogue {
 									
 									Main.game.setResponseTab(0);
 									characterViewed = charactersPresent.get(0);
+									//no need for character conceal check since its for follower
 									menuTitle = "Characters Present ("+Util.capitaliseSentence(charactersPresent.get(0).getName())+")";
 									menuContent = ((NPC) charactersPresent.get(0)).getCharacterInformationScreen();
 								}

--- a/src/com/lilithsthrone/rendering/RenderingEngine.java
+++ b/src/com/lilithsthrone/rendering/RenderingEngine.java
@@ -1,5 +1,6 @@
 package com.lilithsthrone.rendering;
 
+import java.awt.Color;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1135,19 +1136,35 @@ public enum RenderingEngine {
 			} else {
 				int count = 0;
 				for(NPC character : charactersPresent) {
-					uiAttributeSB.append(
-							"<div class='event-log-entry' style='background:"+getEntryBackgroundColour(count%2==0)+";'>"
-								+ "<div class='icon' style='width:11%; left:0; top:0; margin:0 8px 0 0; padding:0;'>"
-									+ "<div class='icon-content'>"
-										+ (character.isRaceConcealed()?SVGImages.SVG_IMAGE_PROVIDER.getRaceUnknown():character.getMapIcon())
+					if(!character.isRaceConcealed()) {
+						uiAttributeSB.append(
+								"<div class='event-log-entry' style='background:"+getEntryBackgroundColour(count%2==0)+";'>"
+									+ "<div class='icon' style='width:11%; left:0; top:0; margin:0 8px 0 0; padding:0;'>"
+										+ "<div class='icon-content'>"
+											+ (character.isRaceConcealed()?SVGImages.SVG_IMAGE_PROVIDER.getRaceUnknown():character.getMapIcon())
+										+ "</div>"
 									+ "</div>"
-								+ "</div>"
-								+" <div style='color:"+character.getFemininity().getColour().toWebHexString()+";'>"
-									+(!character.getArtworkList().isEmpty() && Main.getProperties().hasValue(PropertyValue.artwork)?"&#128247; ":"")+character.getName("A")
-									+ "<div class='overlay-inventory' id='NPC_" + character.getId() + "_" + Attribute.EXPERIENCE.getName() + "' style='width:calc(11% + 8px);'></div>"
-									+ "<div class='overlay-inventory' id='NPC_"+character.getId()+"_ATTRIBUTES' style='width:calc(89% - 8px); left:calc(11% + 8px);'></div>"
-								+"</div>"
-							+ "</div>");
+									+" <div style='color:"+character.getFemininity().getColour().toWebHexString()+";'>"
+										+(!character.getArtworkList().isEmpty() && Main.getProperties().hasValue(PropertyValue.artwork)?"&#128247; ":"")+character.getName("A")
+										+ "<div class='overlay-inventory' id='NPC_" + character.getId() + "_" + Attribute.EXPERIENCE.getName() + "' style='width:calc(11% + 8px);'></div>"
+										+ "<div class='overlay-inventory' id='NPC_"+character.getId()+"_ATTRIBUTES' style='width:calc(89% - 8px); left:calc(11% + 8px);'></div>"
+									+"</div>"
+								+ "</div>");
+					} else {
+						uiAttributeSB.append(
+								"<div class='event-log-entry' style='background:"+getEntryBackgroundColour(count%2==0)+";'>"
+									+ "<div class='icon' style='width:11%; left:0; top:0; margin:0 8px 0 0; padding:0;'>"
+										+ "<div class='icon-content'>"
+											+ (character.isRaceConcealed()?SVGImages.SVG_IMAGE_PROVIDER.getRaceUnknown():character.getMapIcon())
+										+ "</div>"
+									+ "</div>"
+									+" <div style='color:"+Color.DARK_GRAY+";'>"
+										+(!character.getArtworkList().isEmpty() && Main.getProperties().hasValue(PropertyValue.artwork)?"&#128247; ":"")+ "Somebody is here" 
+										+ "<div class='overlay-inventory' id='NPC_" + character.getId() + "_" + Attribute.EXPERIENCE.getName() + "' style='width:calc(11% + 8px);'></div>"
+										+ /*"<div class='overlay-inventory' id='NPC_"+character.getId()+"_ATTRIBUTES' style='width:calc(89% - 8px); left:calc(11% + 8px);'>*/"</div>"
+									+"</div>"
+								+ "</div>");
+					}//The commented section remove the ability to click the character to see the character present dialogue and the overlay that contain the stats. Clicking on the icon will still bring you to the character present dialogue
 					count++;
 				}
 			}


### PR DESCRIPTION
When the race was concealed, the tile text would still display the race.

After the second commit
There was more to it then I thought. Now when the race is concealed:
-The character present window won't show stats
-The character present window won't show the race or the name of the person
-The icon shown is now a question mark(already implemented)
-The character present dialogue won't show the character detail

The only thing that I think is missing is the stats window in the character present dialogue
![2018-07-03 22_47_23-lilith s throne 0 2 7 8 alpha](https://user-images.githubusercontent.com/33431624/42254737-2769b9ea-7f16-11e8-9c5a-a91827b6e803.png)

I'm not sure of what direction to take with this window, remove it? Remove all the information from it?

PS. Right now no generated character or unique character return true at `isRaceConceal()` method you need to edit an npc to test the feature