### PR TITLE
fixed bug #152 (Hash Symbol in File Path prevents saving)

### DIFF
--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -290,7 +290,7 @@ public class Game implements Serializable, XMLSaving {
 				saveNumber++;
 				saveLocation = "data/characters/exported_"+character.getName()+"_day"+Main.game.getDayNumber()+"("+saveNumber+").xml";
 			}
-			StreamResult result = new StreamResult(new File(saveLocation));
+			StreamResult result = new StreamResult(saveLocation);
 			
 			transformer.transform(source, result);
 
@@ -495,7 +495,7 @@ public class Game implements Serializable, XMLSaving {
 				DOMSource source = new DOMSource(doc);
 				
 				String saveLocation = "data/saves/"+exportFileName+".xml";
-				StreamResult result = new StreamResult(new File(saveLocation));
+				StreamResult result = new StreamResult(saveLocation);
 				
 				transformer.transform(source, result);
 				

--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -433,7 +433,7 @@ public class Properties implements Serializable {
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 			DOMSource source = new DOMSource(doc);
-			StreamResult result = new StreamResult(new File("data/properties.xml"));
+			StreamResult result = new StreamResult("data/properties.xml");
 		
 			transformer.transform(source, result);
 		

--- a/src/com/lilithsthrone/game/character/CharacterUtils.java
+++ b/src/com/lilithsthrone/game/character/CharacterUtils.java
@@ -168,7 +168,7 @@ public class CharacterUtils {
 				saveLocation = "data/characters/"+character.getName()+"_day"+Main.game.getDayNumber()+"("+saveNumber+").xml";
 			}
 			
-			StreamResult result = new StreamResult(new File(saveLocation));
+			StreamResult result = new StreamResult(saveLocation);
 			
 			transformer.transform(source, result);
 		

--- a/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
@@ -889,7 +889,7 @@ public class EnchantmentDialogue {
 			DOMSource source = new DOMSource(doc);
 			
 			String saveLocation = "data/enchantments/"+name+".xml";
-			StreamResult result = new StreamResult(new File(saveLocation));
+			StreamResult result = new StreamResult(saveLocation);
 			
 			transformer.transform(source, result);
 			


### PR DESCRIPTION
This fixes bug #152 

changed all calls 
`StreamResult(File(String))` 
to 
`StreamResult(String)`

The solution might be the result of StreamResult corrupting Filepath by adding "file:%Filepath%" as pointed out here https://stackoverflow.com/questions/15324008/writing-xml-in-java-filenotfoundexception

tested with latest Version in Repo (v0.2.9.1)