### PR TITLE
Combat rework

### DIFF
--- a/src/com/lilithsthrone/controller/MainControllerInitMethod.java
+++ b/src/com/lilithsthrone/controller/MainControllerInitMethod.java
@@ -23,10 +23,7 @@ import com.lilithsthrone.game.character.npc.NPC;
 import com.lilithsthrone.game.character.persona.*;
 import com.lilithsthrone.game.character.race.FurryPreference;
 import com.lilithsthrone.game.character.race.Subspecies;
-import com.lilithsthrone.game.combat.DamageType;
-import com.lilithsthrone.game.combat.Spell;
-import com.lilithsthrone.game.combat.SpellSchool;
-import com.lilithsthrone.game.combat.SpellUpgrade;
+import com.lilithsthrone.game.combat.*;
 import com.lilithsthrone.game.dialogue.*;
 import com.lilithsthrone.game.dialogue.places.dominion.lilayashome.LilayaHomeGeneric;
 import com.lilithsthrone.game.dialogue.places.dominion.shoppingArcade.SuccubisSecrets;
@@ -4198,6 +4195,31 @@ public class MainControllerInitMethod {
 							Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
 						}, false);
 					}
+				}
+			}
+
+
+			for(CombatMove move : CombatMove.allCombatMoves) {
+
+				GameCharacter character = CombatMovesSetup.getTarget();
+
+				id = "MOVE_"+move.getIdentifier();
+				if (((EventTarget) MainController.document.getElementById(id)) != null) {
+					MainController.addEventListener(MainController.document, id, "mousemove", MainController.moveTooltipListener, false);
+					MainController.addEventListener(MainController.document, id, "mouseleave", MainController.hideTooltipListener, false);
+					MainController.addEventListener(MainController.document, id, "mouseenter", new TooltipInformationEventListener().setCombatMove(move, character), false);
+
+					((EventTarget) MainController.document.getElementById(id)).addEventListener("click", event -> {
+						if(character.getEquippedMoves().contains(move))
+						{
+							character.unequipMove(move.getIdentifier());
+						}
+						else if(character.getEquippedMoves().size() < GameCharacter.MAX_COMBAT_MOVES)
+						{
+							character.equipMove(move.getIdentifier());
+						}
+						Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+					}, false);
 				}
 			}
 			

--- a/src/com/lilithsthrone/controller/eventListeners/TooltipInformationEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/TooltipInformationEventListener.java
@@ -266,7 +266,10 @@ public class TooltipInformationEventListener implements EventListener {
 			tooltipSB.append("<div class='picture'>" + move.getSVGString() + "</div>");
 
 			// Description:
-			tooltipSB.append("<div class='subTitle-picture'>" + move.getDescription() + "</div>");
+			tooltipSB.append("<div class='subTitle-picture'>" + owner.getMoveAvailableReason(move.getIdentifier()) + "</div>");
+
+			// Description:
+			tooltipSB.append("<div class='description'>" + move.getDescription() + "</div>");
 
 			if(owner.getEquippedMoves().contains(move)) {
 				tooltipSB.append("<div class='subTitle' style='color:"+Colour.GENERIC_MINOR_BAD.toWebHexString()+";'>Click to unequip move.</div>");

--- a/src/com/lilithsthrone/controller/eventListeners/TooltipInformationEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/TooltipInformationEventListener.java
@@ -274,7 +274,7 @@ public class TooltipInformationEventListener implements EventListener {
 			if(owner.getEquippedMoves().contains(move)) {
 				tooltipSB.append("<div class='subTitle' style='color:"+Colour.GENERIC_MINOR_BAD.toWebHexString()+";'>Click to unequip move.</div>");
 			} else {
-				if(owner.getEquippedMoves().size()>=GameCharacter.MAX_TRAITS) {
+				if(owner.getEquippedMoves().size()>=GameCharacter.MAX_COMBAT_MOVES) {
 					tooltipSB.append("<div class='subTitle' style='color:"+Colour.GENERIC_BAD.toWebHexString()+";'>Maximum moves activated.</div>");
 				} else {
 					tooltipSB.append("<div class='subTitle' style='color:"+Colour.TRAIT.toWebHexString()+";'>Click to equip move.</div>");

--- a/src/com/lilithsthrone/controller/eventListeners/TooltipInformationEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/TooltipInformationEventListener.java
@@ -6,6 +6,7 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import com.lilithsthrone.game.PropertyValue;
+import com.lilithsthrone.game.combat.*;
 import com.lilithsthrone.rendering.CachedImage;
 import com.lilithsthrone.rendering.ImageCache;
 import org.w3c.dom.events.Event;
@@ -35,11 +36,6 @@ import com.lilithsthrone.game.character.fetishes.Fetish;
 import com.lilithsthrone.game.character.fetishes.FetishDesire;
 import com.lilithsthrone.game.character.fetishes.FetishLevel;
 import com.lilithsthrone.game.character.race.Race;
-import com.lilithsthrone.game.combat.Attack;
-import com.lilithsthrone.game.combat.Combat;
-import com.lilithsthrone.game.combat.SpecialAttack;
-import com.lilithsthrone.game.combat.Spell;
-import com.lilithsthrone.game.combat.SpellUpgrade;
 import com.lilithsthrone.game.dialogue.utils.UtilText;
 import com.lilithsthrone.game.inventory.InventorySlot;
 import com.lilithsthrone.game.inventory.clothing.AbstractClothing;
@@ -71,6 +67,7 @@ public class TooltipInformationEventListener implements EventListener {
 	private Attribute attribute;
 	private InventorySlot concealedSlot;
 	private LoadedEnchantment loadedEnchantment;
+	private CombatMove move;
 	private static StringBuilder tooltipSB  = new StringBuilder();
 	
 	
@@ -253,6 +250,34 @@ public class TooltipInformationEventListener implements EventListener {
 				}
 			}
 			
+			Main.mainController.setTooltipContent(UtilText.parse(tooltipSB.toString()));
+
+		} else if (move != null) {
+
+			Main.mainController.setTooltipSize(360, 352);
+
+			// Title:
+			tooltipSB.setLength(0);
+			tooltipSB.append("<div class='title'>" + Util.capitaliseSentence(move.getName()) + "</div>");
+
+			tooltipSB.append("<div class='subTitle' style='color:"+move.getType().getColour().toWebHexString()+";'>"+move.getType().getName()+"</div>");
+
+			// Picture:
+			tooltipSB.append("<div class='picture'>" + move.getSVGString() + "</div>");
+
+			// Description:
+			tooltipSB.append("<div class='subTitle-picture'>" + move.getDescription() + "</div>");
+
+			if(owner.getEquippedMoves().contains(move)) {
+				tooltipSB.append("<div class='subTitle' style='color:"+Colour.GENERIC_MINOR_BAD.toWebHexString()+";'>Click to unequip move.</div>");
+			} else {
+				if(owner.getEquippedMoves().size()>=GameCharacter.MAX_TRAITS) {
+					tooltipSB.append("<div class='subTitle' style='color:"+Colour.GENERIC_BAD.toWebHexString()+";'>Maximum moves activated.</div>");
+				} else {
+					tooltipSB.append("<div class='subTitle' style='color:"+Colour.TRAIT.toWebHexString()+";'>Click to equip move.</div>");
+				}
+			}
+
 			Main.mainController.setTooltipContent(UtilText.parse(tooltipSB.toString()));
 
 		} else if (desire != null) { // Desire:
@@ -1114,6 +1139,15 @@ public class TooltipInformationEventListener implements EventListener {
 
 		return this;
 	}
+
+	public TooltipInformationEventListener setCombatMove(CombatMove move, GameCharacter owner)
+	{
+		resetFields();
+		this.owner = owner;
+		this.move = move;
+
+		return this;
+	}
 	
 	private void resetFields() {
 		extraAttributes = false;
@@ -1135,5 +1169,6 @@ public class TooltipInformationEventListener implements EventListener {
 		copyInformation=false;
 		concealedSlot=null;
 		loadedEnchantment=null;
+		move=null;
 	}
 }

--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -79,8 +79,10 @@ public class Properties implements Serializable {
 	public int pregnancyLactationLimit = 1000;
 	
 	public Set<PropertyValue> values;
-	
+
+	// Difficulty settings
 	public DifficultyLevel difficultyLevel = DifficultyLevel.NORMAL;
+	public float AIblunderRate = 0.0f; /// The amount of times the AI will use random weight selection for an action instead of the proper one. 1.0 means every time, 0.0 means never.
 	
 	public AndrogynousIdentification androgynousIdentification = AndrogynousIdentification.CLOTHING_FEMININE;
 
@@ -224,6 +226,7 @@ public class Properties implements Serializable {
 			createXMLElementWithValue(doc, settings, "forcedFetishPercentage", String.valueOf(forcedFetishPercentage));
 
 			createXMLElementWithValue(doc, settings, "difficultyLevel", difficultyLevel.toString());
+			createXMLElementWithValue(doc, settings, "AIblunderRate", String.valueOf(AIblunderRate));
 			
 			
 			
@@ -557,6 +560,10 @@ public class Properties implements Serializable {
 				
 				if(element.getElementsByTagName("difficultyLevel").item(0)!=null) {
 					difficultyLevel = DifficultyLevel.valueOf(((Element)element.getElementsByTagName("difficultyLevel").item(0)).getAttribute("value"));
+				}
+
+				if(element.getElementsByTagName("AIblunderRate").item(0)!=null) {
+					AIblunderRate = Float.valueOf(((Element)element.getElementsByTagName("AIblunderRate").item(0)).getAttribute("value"));
 				}
 				
 				if(element.getElementsByTagName("androgynousIdentification").item(0)!=null) {

--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -11373,6 +11373,13 @@ public abstract class GameCharacter implements XMLSaving {
 		knownMoves.clear();
 	}
 
+	public void resetSelectedMoves()
+	{
+		selectedMoves.clear();
+		selectedMovesDisruption.clear();
+		selectedMoveTargets.clear();
+	}
+
 	public void resetMoveCooldowns()
 	{
 		this.moveTypeDisruptionMap.clear();

--- a/src/com/lilithsthrone/game/character/effects/Perk.java
+++ b/src/com/lilithsthrone/game/character/effects/Perk.java
@@ -936,6 +936,25 @@ public enum Perk {
 				return UtilText.parse(owner, "[npc.Name] is the " + (owner.isFeminine() ? "queen" : "king") + " of cardio, possessing a seemingly endless reserve of energy.");
 		}
 	},
+	UNARMED_TRAINING(20,
+			true,
+			"unarmed training",
+			PerkCategory.PHYSICAL,
+			"perks/fitness_runner_2",
+			Colour.ATTRIBUTE_PHYSIQUE,
+			Util.newHashMapOfValues(),
+			Util.newArrayListOfValues("<span style='color:"+ Colour.ATTRIBUTE_PHYSIQUE.toWebHexString()+ ";'>Base unarmed damage value is 8.</span>")) {
+		@Override
+		public String getName(GameCharacter character) {
+			return "Unarmed Training";
+		}
+
+		@Override
+		public String getDescription(GameCharacter owner)
+		{
+			return "You have a formal knowledge of the unarmed combat and know how to do a good hit with just your body even if you aren't the strongest fighter in the world.";
+		}
+	},
 	FEMALE_ATTRACTION(60,
 			true,
 			"ladykiller",

--- a/src/com/lilithsthrone/game/character/effects/PerkManager.java
+++ b/src/com/lilithsthrone/game/character/effects/PerkManager.java
@@ -66,7 +66,7 @@ public enum PerkManager {
 		physical2 = addPerkEntry(perkTree, PerkCategory.PHYSICAL, 2, Perk.PHYSIQUE_5, physical1);
 		addPerkEntry(perkTree, PerkCategory.PHYSICAL, 2, Perk.OBSERVANT, physical1);
 		
-		physical1 = addPerkEntry(perkTree, PerkCategory.PHYSICAL, 3, Perk.BRAWLER, physical2);
+		physical1 = addPerkEntry(perkTree, PerkCategory.PHYSICAL, 3, Perk.UNARMED_TRAINING, physical2);
 		physical3 = addPerkEntry(perkTree, PerkCategory.PHYSICAL, 3, Perk.RUNNER, physical2);
 		physical4 = addPerkEntry(perkTree, PerkCategory.PHYSICAL, 3, Perk.PHYSIQUE_1, physical3);
 		addPerkEntry(perkTree, PerkCategory.PHYSICAL, 3, Perk.RUNNER_2, physical4);
@@ -172,7 +172,7 @@ public enum PerkManager {
 		physical2 = addPerkEntry(NPCPerkTree, PerkCategory.PHYSICAL, 2, Perk.PHYSIQUE_5, physical1);
 		addPerkEntry(NPCPerkTree, PerkCategory.PHYSICAL, 2, Perk.OBSERVANT, physical1);
 		
-		physical1 = addPerkEntry(NPCPerkTree, PerkCategory.PHYSICAL, 3, Perk.BRAWLER, physical2);
+		physical1 = addPerkEntry(NPCPerkTree, PerkCategory.PHYSICAL, 3, Perk.UNARMED_TRAINING, physical2);
 		physical3 = addPerkEntry(NPCPerkTree, PerkCategory.PHYSICAL, 3, Perk.RUNNER, physical2);
 		physical4 = addPerkEntry(NPCPerkTree, PerkCategory.PHYSICAL, 3, Perk.PHYSIQUE_1, physical3);
 		addPerkEntry(NPCPerkTree, PerkCategory.PHYSICAL, 3, Perk.RUNNER_2, physical4);

--- a/src/com/lilithsthrone/game/character/effects/StatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/StatusEffect.java
@@ -7430,32 +7430,34 @@ public enum StatusEffect {
 			return true;
 		}
 	},
-	
+
 	CLOAK_OF_FLAMES(10,
 			"Cloak of Flames",
 			null,
 			Colour.DAMAGE_TYPE_FIRE,
 			true,
-			Util.newHashMapOfValues(
-					new Value<Attribute, Float>(Attribute.RESISTANCE_FIRE, 10f),
-					new Value<Attribute, Float>(Attribute.RESISTANCE_ICE, 50f)),
-			null) {
-		
+			Util.newHashMapOfValues(),
+			Util.newArrayListOfValues(
+					"Unarmed attacks deal 50% more damage!",
+					"Unarmed attacks have [style.boldFire(Fire Damage) type!",
+					"Unarmed attacks cause [style.boldBad(25% of their normal damage to burn) user's aura.")) {
+
+
 		@Override
 		public String getDescription(GameCharacter target) {
 			if (target.isPlayer()) {
-				return "You have been shrouded in a cloak of arcane flames, granting you significant bonuses to your ice and fire resistances.";
+				return "You have been shrouded in a cloak of arcane flames that improve your unarmed attacks at a cost of burning your aura proportionally.";
 			} else {
 				return UtilText.parse(target,
-						"[npc.Name] has been shrouded in a cloak of arcane flames, granting [npc.herHim] significant bonuses to [npc.her] ice and fire resistances.");
+						"[npc.Name] has been shrouded in a cloak of arcane flames that improve [npc.her] unarmed attacks at a cost of burning [npc.her] aura proportionally.");
 			}
 		}
-		
+
 		@Override
 		public String getSVGString(GameCharacter owner) {
-			return Spell.CLOAK_OF_FLAMES.getSVGString();
+			return SpellUpgrade.CLOAK_OF_FLAMES_1.getSVGString();
 		}
-		
+
 		@Override
 		public boolean isCombatEffect() {
 			return true;
@@ -7467,18 +7469,20 @@ public enum StatusEffect {
 			null,
 			Colour.DAMAGE_TYPE_FIRE,
 			true,
-			Util.newHashMapOfValues(
-					new Value<Attribute, Float>(Attribute.RESISTANCE_FIRE, 10f),
-					new Value<Attribute, Float>(Attribute.RESISTANCE_ICE, 50f)),
-			Util.newArrayListOfValues("Attacks deal <b>5</b> [style.boldFire(Fire Damage)]")) {
+			Util.newHashMapOfValues(),
+			Util.newArrayListOfValues(
+					"Unarmed attacks deal 50% more damage!",
+					"Unarmed attacks have [style.boldFire(Fire Damage) type!",
+					"Unarmed attacks cause [style.boldBad(25% of their normal damage to burn) user's aura.")) {
+
 		
 		@Override
 		public String getDescription(GameCharacter target) {
 			if (target.isPlayer()) {
-				return "You have been shrouded in a cloak of arcane flames, granting you significant bonuses to your ice and fire resistances. You are also dealing extra fire damage each time you attack.";
+				return "You have been shrouded in a cloak of arcane flames that improve your unarmed attacks at a cost of burning your aura proportionally.";
 			} else {
 				return UtilText.parse(target,
-						"[npc.Name] has been shrouded in a cloak of arcane flames, granting [npc.herHim] significant bonuses to [npc.her] ice and fire resistances. [npc.She] is also dealing extra fire damage each time [npc.she] attacks.");
+						"[npc.Name] has been shrouded in a cloak of arcane flames that improve [npc.her] unarmed attacks at a cost of burning [npc.her] aura proportionally.");
 			}
 		}
 		

--- a/src/com/lilithsthrone/game/character/effects/StatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/StatusEffect.java
@@ -184,8 +184,7 @@ public enum StatusEffect {
 			true,
 			Util.newHashMapOfValues(
 					new Value<Attribute, Float>(Attribute.DAMAGE_PHYSICAL, 10f),
-					new Value<Attribute, Float>(Attribute.CRITICAL_DAMAGE, 20f),
-					new Value<Attribute, Float>(Attribute.HEALTH_MAXIMUM, 10f)),
+					new Value<Attribute, Float>(Attribute.CRITICAL_DAMAGE, 20f)),
 			null) {
 		
 		@Override
@@ -219,8 +218,7 @@ public enum StatusEffect {
 			true,
 			Util.newHashMapOfValues(
 					new Value<Attribute, Float>(Attribute.DAMAGE_PHYSICAL, 15f),
-					new Value<Attribute, Float>(Attribute.CRITICAL_DAMAGE, 30f),
-					new Value<Attribute, Float>(Attribute.HEALTH_MAXIMUM, 25f)),
+					new Value<Attribute, Float>(Attribute.CRITICAL_DAMAGE, 30f)),
 			null) {
 		
 		@Override
@@ -254,8 +252,7 @@ public enum StatusEffect {
 			true,
 			Util.newHashMapOfValues(
 					new Value<Attribute, Float>(Attribute.DAMAGE_PHYSICAL, 20f),
-					new Value<Attribute, Float>(Attribute.CRITICAL_DAMAGE, 50f),
-					new Value<Attribute, Float>(Attribute.HEALTH_MAXIMUM, 50f)),
+					new Value<Attribute, Float>(Attribute.CRITICAL_DAMAGE, 50f)),
 			null) {
 		
 		@Override
@@ -423,8 +420,7 @@ public enum StatusEffect {
 					new Value<Attribute, Float>(Attribute.SPELL_COST_MODIFIER, 10f),
 					new Value<Attribute, Float>(Attribute.DAMAGE_FIRE, 5f),
 					new Value<Attribute, Float>(Attribute.DAMAGE_ICE, 5f),
-					new Value<Attribute, Float>(Attribute.DAMAGE_POISON, 5f),
-					new Value<Attribute, Float>(Attribute.MANA_MAXIMUM, 10f)),
+					new Value<Attribute, Float>(Attribute.DAMAGE_POISON, 5f)),
 			null) {
 		
 		@Override
@@ -462,8 +458,7 @@ public enum StatusEffect {
 					new Value<Attribute, Float>(Attribute.SPELL_COST_MODIFIER, 15f),
 					new Value<Attribute, Float>(Attribute.DAMAGE_FIRE, 10f),
 					new Value<Attribute, Float>(Attribute.DAMAGE_ICE, 10f),
-					new Value<Attribute, Float>(Attribute.DAMAGE_POISON, 10f),
-					new Value<Attribute, Float>(Attribute.MANA_MAXIMUM, 25f)),
+					new Value<Attribute, Float>(Attribute.DAMAGE_POISON, 10f)),
 			null) {
 		
 		@Override
@@ -502,8 +497,7 @@ public enum StatusEffect {
 					new Value<Attribute, Float>(Attribute.SPELL_COST_MODIFIER, 20f),
 					new Value<Attribute, Float>(Attribute.DAMAGE_FIRE, 15f),
 					new Value<Attribute, Float>(Attribute.DAMAGE_ICE, 15f),
-					new Value<Attribute, Float>(Attribute.DAMAGE_POISON, 15f),
-					new Value<Attribute, Float>(Attribute.MANA_MAXIMUM, 50f)),
+					new Value<Attribute, Float>(Attribute.DAMAGE_POISON, 15f)),
 			null) {
 		
 		@Override

--- a/src/com/lilithsthrone/game/combat/Combat.java
+++ b/src/com/lilithsthrone/game/combat/Combat.java
@@ -179,10 +179,12 @@ public enum Combat {
 			}
 		}
 
+		Main.game.getPlayer().resetSelectedMoves();
 		Main.game.getPlayer().resetMoveCooldowns();
 		Main.game.getPlayer().setRemainingAP(Main.game.getPlayer().getMaxAP(), null, null);
 		for(NPC npc : allCombatants)
 		{
+			npc.resetSelectedMoves();
 			npc.resetDefaultMoves(); // Resetting in case the save file was too old and NPC has no moves selected for them.
 			npc.resetMoveCooldowns();
 			npc.setRemainingAP(npc.getMaxAP(), null, null);
@@ -759,6 +761,10 @@ public enum Combat {
 					}
 					@Override
 					public Colour getHighlightColour() {
+						if(Main.game.getPlayer().getEquippedMoves().get(moveIndex).getAssociatedSpell() != null)
+						{
+							return Main.game.getPlayer().getEquippedMoves().get(moveIndex).getAssociatedSpell().getSpellSchool().getColour();
+						}
 						return Main.game.getPlayer().getEquippedMoves().get(moveIndex).getType().getColour();
 					}
 				};
@@ -1606,14 +1612,14 @@ public enum Combat {
 			List<GameCharacter> npcEnemies;
 			if(allies.contains(npc))
 			{
-				predictionStringBuilder.append("<span style='color:"+Colour.GENERIC_GOOD.toWebHexString()+";'>"+npc.getName("The")+"</span> is planning:</br></br>");
+				predictionStringBuilder.append("<p><span style='color:"+Colour.GENERIC_GOOD.toWebHexString()+";'>"+npc.getName("The")+"</span> is planning:</br></br>");
 				npcAllies = new ArrayList<>(allies);
 				npcAllies.add(Main.game.getPlayer());
 				npcEnemies = new ArrayList<>(enemies);
 			}
 			else
 			{
-				predictionStringBuilder.append("<span style='color:"+Colour.GENERIC_BAD.toWebHexString()+";'>"+npc.getName("The")+"</span> is planning:</br></br>");
+				predictionStringBuilder.append("<p><span style='color:"+Colour.GENERIC_BAD.toWebHexString()+";'>"+npc.getName("The")+"</span> is planning:</br></br>");
 				npcEnemies = new ArrayList<>(allies);
 				npcEnemies.add(Main.game.getPlayer());
 				npcAllies = new ArrayList<>(enemies);
@@ -1624,6 +1630,7 @@ public enum Combat {
 			// Figures out the new ones
 			npc.selectMoves(npcEnemies, npcAllies);
 			predictionStringBuilder.append(UtilText.parse(npc, npc.getMovesPredictionString(npcEnemies, npcAllies)));
+			predictionStringBuilder.append("</p>");
 
 			// Legacy code below
 			// Calculate what attack to use based on NPC preference:

--- a/src/com/lilithsthrone/game/combat/Combat.java
+++ b/src/com/lilithsthrone/game/combat/Combat.java
@@ -183,6 +183,7 @@ public enum Combat {
 		Main.game.getPlayer().setRemainingAP(Main.game.getPlayer().getMaxAP());
 		for(NPC npc : allCombatants)
 		{
+			npc.resetDefaultMoves(); // Resetting in case the save file was too old and NPC has no moves selected for them.
 			npc.resetMoveCooldowns();
 			npc.setRemainingAP(npc.getMaxAP());
 			// Sets up NPC ally/enemy lists that include player
@@ -734,7 +735,7 @@ public enum Combat {
 				
 			}
 
-			List<GameCharacter> pcEnemies = new ArrayList<>(allies);
+			List<GameCharacter> pcEnemies = new ArrayList<>(enemies);
 			List<GameCharacter> pcAllies = new ArrayList<>(allies);
 			pcAllies.add(Main.game.getPlayer());
 			int moveIndex = index==0?14:(index<15?index-1:index);
@@ -762,7 +763,7 @@ public enum Combat {
 
 			} else if(index == 0) {
 				return new Response("End Turn",
-						Main.game.getPlayer().getRemainingAP()>0?"Ends your current turn":"Ends your current turn. You still have unspent AP!",
+						Main.game.getPlayer().getRemainingAP()<=0?"Ends your current turn":"Ends your current turn. You still have unspent AP!",
 						ENEMY_ATTACK){
 					@Override
 					public void effects() {
@@ -771,7 +772,7 @@ public enum Combat {
 					}
 					@Override
 					public Colour getHighlightColour() {
-						if(Main.game.getPlayer().getRemainingAP() > 0)
+						if(Main.game.getPlayer().getRemainingAP() <= 0)
 						{
 							return Colour.GENERIC_BAD;
 						}
@@ -1309,7 +1310,7 @@ public enum Combat {
 		// Calculate hit + damage
 		attackStringBuilder = new StringBuilder("");
 		
-		attackStringBuilder.append(attacker.getSeductionDescription());
+		attackStringBuilder.append(attacker.getSeductionDescription(null));
 		
 		boolean critical = false;//Attack.rollForCritical(attacker);
 	
@@ -1603,14 +1604,14 @@ public enum Combat {
 			List<GameCharacter> npcEnemies;
 			if(allies.contains(npc))
 			{
-				predictionStringBuilder.append("<span style='color:"+Colour.GENERIC_GOOD.toWebHexString()+";'>"+npc.getName()+"</span> is planning:</br></br>");
+				predictionStringBuilder.append("<span style='color:"+Colour.GENERIC_GOOD.toWebHexString()+";'>"+npc.getName("The")+"</span> is planning:</br></br>");
 				npcAllies = new ArrayList<>(allies);
 				npcAllies.add(Main.game.getPlayer());
 				npcEnemies = new ArrayList<>(enemies);
 			}
 			else
 			{
-				predictionStringBuilder.append("<span style='color:"+Colour.GENERIC_BAD.toWebHexString()+";'>"+npc.getName()+"</span> is planning:</br></br>");
+				predictionStringBuilder.append("<span style='color:"+Colour.GENERIC_BAD.toWebHexString()+";'>"+npc.getName("The")+"</span> is planning:</br></br>");
 				npcEnemies = new ArrayList<>(allies);
 				npcEnemies.add(Main.game.getPlayer());
 				npcAllies = new ArrayList<>(enemies);
@@ -1743,14 +1744,22 @@ public enum Combat {
 
 	private static String getAPString()
 	{
+		List<GameCharacter> pcEnemies = new ArrayList<>(enemies);
+		List<GameCharacter> pcAllies = new ArrayList<>(allies);
+		pcAllies.add(Main.game.getPlayer());
+
 		Colour APColour = Colour.GENERIC_MINOR_BAD;
 		if(Main.game.getPlayer().getRemainingAP() > 0)
 		{
 			APColour = Colour.GENERIC_MINOR_GOOD;
 		}
-		String returnable = "<div class='container-quarter-width'style='width: calc(20% - 16px); style='text-align:center; box-sizing: border-box; border:6px solid "+APColour.getShades()[0]+"; border-radius:5px;'>"+
-				"<div class='container-quarter-width'style='width: calc(20% - 16px);'>" +
-				"<b style='color: " + APColour.toWebHexString() + "'> AP: "+String.valueOf(Main.game.getPlayer().getRemainingAP())+"</b></div></div>";
+
+		String returnable = "<div class='container-full-width' style='text-align:center; box-sizing: border-box; border:6px solid "+APColour.getShades()[0]+"; border-radius:5px;'>"
+				+ "<div class='container-quarter-width'style='width: calc(20% - 16px);'>"
+				+ "<b style='color: " + APColour.toWebHexString() + "'> AP: "+String.valueOf(Main.game.getPlayer().getRemainingAP())+"</b></div>"
+				+ "<div class='container-half-width' style='width: calc(80% - 16px);'>"
+				+ "<span style='color:"+Colour.GENERIC_GOOD.toWebHexString()+";'>You</span> are planning:</br></br>"
+				+ Main.game.getPlayer().getMovesPredictionString(pcEnemies, pcAllies)+"</div></div>";
 		return returnable;
 	}
 	

--- a/src/com/lilithsthrone/game/combat/CombatMove.java
+++ b/src/com/lilithsthrone/game/combat/CombatMove.java
@@ -4,8 +4,10 @@ import com.lilithsthrone.game.character.GameCharacter;
 import com.lilithsthrone.game.character.attributes.Attribute;
 import com.lilithsthrone.game.character.attributes.CorruptionLevel;
 import com.lilithsthrone.game.character.attributes.LustLevel;
+import com.lilithsthrone.game.character.body.types.FootType;
 import com.lilithsthrone.game.inventory.weapon.AbstractWeapon;
 import com.lilithsthrone.main.Main;
+import com.lilithsthrone.utils.Colour;
 import com.lilithsthrone.utils.Util;
 
 import java.io.IOException;
@@ -40,6 +42,12 @@ public class CombatMove {
         // Escape: Attempts to escape
         // Tease: Deals 7 lust damage
 
+
+        /*=============================================
+         *
+         *              DEFAULT ACTIONS
+         *
+         =============================================*/
         /*=============================================
          *
          *
@@ -59,7 +67,7 @@ public class CombatMove {
             {
                 AbstractWeapon weapon = source.getMainWeapon();
                 if (weapon == null) {
-                    return 1 + (int)(source.getAttributeValue(Attribute.MAJOR_PHYSIQUE)/10);
+                    return source.getUnarmedDamage();
                 } else {
                     return weapon.getWeaponType().getDamage();
                 }
@@ -108,12 +116,131 @@ public class CombatMove {
                     damageType = source.getMainWeapon().getDamageType();
                 }
 
-                int dealtDamage = damageType.damageTarget(target, getDamage(source));
+                int dealtDamage = damageType.damageTarget(target, source, getDamage(source));
 
                 return source.getName("The")+" attacked " + target.getName() + ", dealing "
                         + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
                         + String.valueOf(dealtDamage) + "</span> "
                         + damageType.getName() + " damage to them.";
+            }
+        };
+        allCombatMoves.add(newCombatMove);
+
+        /*=============================================
+         *
+         *
+         *
+         */
+        newCombatMove = new CombatMove("twin-strike",
+                "twin strike",
+                0,
+                1,
+                CombatMoveType.ATTACK,
+                "moves/twin-strike",
+                false,
+                true,
+                false){
+
+            private int getDamageMain(GameCharacter source)
+            {
+                AbstractWeapon weapon = source.getMainWeapon();
+                int totalDamage;
+                if (weapon == null) {
+                    totalDamage = source.getUnarmedDamage();
+                } else {
+                    totalDamage = weapon.getWeaponType().getDamage();
+                }
+                return (int)(totalDamage * 0.6);
+            }
+
+            private int getDamageOffhand(GameCharacter source)
+            {
+                AbstractWeapon weapon = source.getOffhandWeapon();
+                int totalDamage;
+                if (weapon == null) {
+                    totalDamage = source.getUnarmedDamage();
+                } else {
+                    totalDamage = weapon.getWeaponType().getDamage();
+                }
+                return (int)(totalDamage * 0.3);
+            }
+
+            @Override
+            public String isAvailableFromSpecialCase(GameCharacter source)
+            {
+                return "This move is a starter move, available to everyone from the beginning.";
+            }
+
+            @Override
+            public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageTypeMain = DamageType.PHYSICAL;
+                if(source.getMainWeapon() != null)
+                {
+                    damageTypeMain = source.getMainWeapon().getDamageType();
+                }
+                DamageType damageTypeOffhand = DamageType.PHYSICAL;
+                if(source.getOffhandWeapon() != null)
+                {
+                    damageTypeOffhand = source.getOffhandWeapon().getDamageType();
+                }
+                return "Attack " + target.getName() + ", dealing "
+                        + "<span style='color:" + damageTypeMain.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamageMain(source)) + " " + damageTypeMain.getName() + "</span>"
+                        + " and "
+                        + "<span style='color:" + damageTypeOffhand.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamageOffhand(source)) + " " + damageTypeOffhand.getName() + "</span>"
+                        + " damage.";
+            }
+
+            @Override
+            public String getDescription()
+            {
+                DamageType damageTypeMain = DamageType.PHYSICAL;
+                if(Main.game.getPlayer().getMainWeapon() != null)
+                {
+                    damageTypeMain = Main.game.getPlayer().getMainWeapon().getDamageType();
+                }
+                DamageType damageTypeOffhand = DamageType.PHYSICAL;
+                if(Main.game.getPlayer().getOffhandWeapon() != null)
+                {
+                    damageTypeOffhand = Main.game.getPlayer().getOffhandWeapon().getDamageType();
+                }
+                return "Attack your enemy, dealing 60% ("
+                        + "<span style='color:" + damageTypeMain.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamageMain(Main.game.getPlayer())) + "</span>"
+                        + ") of your main weapon's damage and 30% ("
+                        + "<span style='color:" + damageTypeOffhand.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamageOffhand(Main.game.getPlayer())) + "</span>"
+                        + ") of your offhand weapon's damage to them.";
+            }
+
+            @Override
+            public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageTypeMain = DamageType.PHYSICAL;
+                if(source.getMainWeapon() != null)
+                {
+                    damageTypeMain = source.getMainWeapon().getDamageType();
+                }
+                DamageType damageTypeOffhand = DamageType.PHYSICAL;
+                if(source.getOffhandWeapon() != null)
+                {
+                    damageTypeOffhand = source.getOffhandWeapon().getDamageType();
+                }
+
+                int dealtDamageMain = damageTypeMain.damageTarget(target, source, getDamageMain(source));
+                int dealtDamageOffhand = damageTypeOffhand.damageTarget(target, source, getDamageOffhand(source));
+
+                return source.getName("The")+" attacked " + target.getName() + ", dealing "
+                        + "<span style='color:" + damageTypeMain.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(dealtDamageMain) + " </span> "
+                        + damageTypeMain.getName()
+                        + "and"
+                        + "<span style='color:" + damageTypeOffhand.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(dealtDamageOffhand) + " </span> "
+                        + damageTypeOffhand.getName()
+                        + " damage to them.";
             }
         };
         allCombatMoves.add(newCombatMove);
@@ -166,11 +293,17 @@ public class CombatMove {
             public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
             {
                 DamageType damageType = DamageType.ENERGY;
-                target.setShields(damageType, target.getShields(damageType) + getBlock());
                 return source.getName("The")+" defended this turn, gaining protection from "
                         + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
                         + String.valueOf(getBlock()) + "</span>"
                         + " of the incoming " + damageType.getName() + " damage for this turn.";
+            }
+
+            @Override
+            public void performOnSelection(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.ENERGY;
+                target.setShields(damageType, target.getShields(damageType) + getBlock());
             }
         };
         allCombatMoves.add(newCombatMove);
@@ -227,7 +360,7 @@ public class CombatMove {
             {
                 DamageType damageType = DamageType.LUST;
 
-                int dealtDamage = damageType.damageTarget(target, getDamage(source));
+                int dealtDamage = damageType.damageTarget(target, source, getDamage(source));
 
                 return source.getSeductionDescription(target) + "<br/>"
                         + "As a result, " + source.getName("the")+" teased " + target.getName() + ", dealing "
@@ -295,6 +428,13 @@ public class CombatMove {
             }
 
             @Override
+            public void performOnSelection(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.LUST;
+                target.setShields(damageType, target.getShields(damageType) + getBlock());
+            }
+
+            @Override
             public float getWeight(GameCharacter source, List<GameCharacter> enemies, List<GameCharacter> allies)
             {
                 if(shouldBlunder())
@@ -309,6 +449,194 @@ public class CombatMove {
             }
         };
         allCombatMoves.add(newCombatMove);
+
+
+
+
+        /*=============================================
+         *
+         *                   RACIAL
+         *
+         =============================================*/
+        /*=============================================
+         *
+         *
+         *
+         */newCombatMove = new CombatMove("hoof-kick",
+                "hoof kick",
+                0,
+                2,
+                CombatMoveType.ATTACK,
+                "moves/hoof-kick",
+                false,
+                true,
+                false){
+
+            private int getDamage(GameCharacter source)
+            {
+                return source.getUnarmedDamage()*2;
+            }
+
+            @Override
+            public String isAvailableFromSpecialCase(GameCharacter source)
+            {
+                if(source.getLegType().getFootType() == FootType.HOOFS)
+                {
+                    return "This move is a move available to anyone with hooves.";
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            @Override
+            public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.UNARMED.getSuperDamage(target, source);
+                return "Attack " + target.getName() + ", dealing "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamage(source)) + " " + damageType.getName() + "</span>"
+                        + " damage. "
+                        + "<span style='color:" + Colour.GENERIC_GOOD + ";'>"
+                        + "Crit if this move breaks block; if crits, do a second kick." + "</span>";
+            }
+
+            @Override
+            public String getDescription()
+            {
+                DamageType damageType = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
+                return "Attack your enemy, dealing 100% ("
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamage(Main.game.getPlayer())) + "</span>"
+                        + ") unarmed damage to them. "
+                        + "<span style='color:" + Colour.GENERIC_GOOD + ";'>"
+                        + "Will crit if this move breaks block; if it crits, will do a second kick." + "</span>";
+            }
+
+            @Override
+            public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.UNARMED.getSuperDamage(target, source);
+
+                int dealtDamage = damageType.damageTarget(target, source, getDamage(source));
+
+                String report = source.getName("The")+" kicked " + target.getName() + ", dealing "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(dealtDamage) + "</span> "
+                        + damageType.getName() + " damage to them.<br/>";
+                if(canCrit(source, target, enemies, allies))
+                {
+                    dealtDamage = damageType.damageTarget(target, source, getDamage(source)); // Second kick damage from the crit.
+                    report += "The attack broke through the block, staggering the target, letting " + source.getName("the")
+                        + "<span style='color:" + Colour.GENERIC_GOOD + ";'>"
+                        + "to critically hit" + "</span>" + target.getName("the") + ", throwing in a second kick for "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(dealtDamage) + "</span> "
+                        + damageType.getName() + " additional damage!";
+                }
+                return report;
+            }
+
+            @Override
+            public boolean canCrit(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                int potentialDamage = DamageType.UNARMED.shieldCheckNoDamage(source, target, getDamage(source));
+                if(potentialDamage > 0 && potentialDamage != getDamage(source))
+                {
+                    return true;
+                }
+                return false;
+            }
+        };
+        allCombatMoves.add(newCombatMove);
+
+
+
+
+        /*=============================================
+         *
+         *                   SPELLS
+         *
+         =============================================*/
+        // Automatically generates respective moves based on the Spell class.
+        for(Spell spell : Spell.values())
+        {
+            newCombatMove = new CombatMove(
+                    spell.name(),
+                    spell.getName(),
+                    spell.getCooldown(),
+                    spell.getAPCost(),
+                    CombatMoveType.SPELL,
+                    spell.getSVGString(),
+                    spell.isCanTargetAllies(),
+                    spell.isCanTargetEnemies(),
+                    spell.isCanTargetSelf()) {
+
+                private Spell associatedSpell = spell;
+
+                @Override
+                public String isAvailableFromSpecialCase(GameCharacter source)
+                {
+                    if(source.hasSpell(this.associatedSpell))
+                    {
+                        return "This is a spell and it is available to casters that learned it.";
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                }
+
+                @Override
+                public float getWeight(GameCharacter source, List<GameCharacter> enemies, List<GameCharacter> allies)
+                {
+                    return associatedSpell.getWeight(source, enemies, allies);
+                }
+
+                @Override
+                public GameCharacter getPreferredTarget(GameCharacter  source, List<GameCharacter> enemies, List<GameCharacter> allies)
+                {
+                    return associatedSpell.getPreferredTarget(source, enemies, allies);
+                }
+
+                @Override
+                public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+                {
+                    return associatedSpell.getPrediction(source, target, enemies, allies);
+                }
+
+                @Override
+                public void applyDisruption(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+                {
+                    associatedSpell.applyDisruption(source, target, enemies, allies);
+                }
+
+                @Override
+                public String getDescription()
+                {
+                    return associatedSpell.getDescription();
+                }
+
+                @Override
+                public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+                {
+                    return associatedSpell.perform(source, target, enemies, allies);
+                }
+
+                @Override
+                public void performOnSelection(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+                {
+                    associatedSpell.performOnSelection(source, target, enemies, allies);
+                }
+
+                @Override
+                public boolean canCrit(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+                {
+                    return associatedSpell.canCrit(source, target, enemies, allies);
+                }
+            };
+        }
     }
 
     /**
@@ -500,6 +828,42 @@ public class CombatMove {
     }
 
     /**
+     * Performs the action itself. Override to get actual abilities there. This is performed during selection of the action and not during the turn. Use for blocks, AP damage/gains or disrupts.
+     * @param source Character that uses the action.
+     * @param source Target for the action.
+     * @param enemies Enemies of the character
+     * @param allies Allies of the character
+     * @return The string that describes the action that has been performed.
+     */
+    public void performOnSelection(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+    {
+        // Nothing. Override it.
+    }
+
+
+    /**
+     * Cancel out the action's effects if it's disrupted or cancelled via AP loss. Is called for every action in the queue for every disruption caused; non disrupted actions get reapplied.
+     * @param source Character that uses the action.
+     * @param source Target for the action.
+     * @param enemies Enemies of the character
+     * @param allies Allies of the character
+     * @return The string that describes the action that has been performed.
+     */
+    public void applyDisruption(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+    {
+        source.setRemainingAP(source.getRemainingAP() + this.getAPcost() * -1, enemies, allies); // Normally this is the only thing that gets adjusted on selection.
+    }
+
+    /**
+     * Checks the source character to see if they will have to use the action already with a disruption.
+     * @param source
+     */
+    public boolean isAlreadyDisrupted(GameCharacter source)
+    {
+        return source.disruptionByTypeCheck(this.getType());
+    }
+
+    /**
      * Returns a string if the character has the move available to select even if they don't "own" it; for example, purity based moves are available to Pure Virgin fetishists without even unlocking them.
      *
      * String contains the reason for why the move is available to them. Otherwise returns null.
@@ -597,6 +961,24 @@ public class CombatMove {
 
     public String getSVGString() {
         return SVGString;
+    }
+
+    public boolean canCrit(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+    {
+        // Normally moves crit on three hits in a row.
+        int thisMoveSelected = 0;
+        for(CombatMove move : source.getSelectedMoves())
+        {
+            if(move.getIdentifier() == this.getIdentifier())
+            {
+                thisMoveSelected++;
+            }
+        }
+        if(thisMoveSelected >= 3)
+        {
+            return true;
+        }
+        return false;
     }
 
 }

--- a/src/com/lilithsthrone/game/combat/CombatMove.java
+++ b/src/com/lilithsthrone/game/combat/CombatMove.java
@@ -1,0 +1,359 @@
+package com.lilithsthrone.game.combat;
+
+import com.lilithsthrone.game.character.GameCharacter;
+import com.lilithsthrone.game.character.attributes.Attribute;
+import com.lilithsthrone.game.inventory.weapon.AbstractWeapon;
+import com.lilithsthrone.main.Main;
+import com.lilithsthrone.utils.Util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A class containing logic for Combat Moves. Additionally contains all the registered combat moves in the game.
+ */
+public class CombatMove {
+    public static List<CombatMove> allCombatMoves = new ArrayList<>();
+
+    private String identifier;
+    private String name;
+    private int cooldown;
+    private int APcost;
+    private CombatMoveType type;
+    private boolean canTargetEnemies;
+    private boolean canTargetAllies;
+    private boolean canTargetSelf;
+    private String SVGString;
+
+    static {
+        // Initializing default actions
+        // TODO
+        // Strike: Main weapon deals 100% damage
+        // Battle Dance: Deal 60% damage with main weapon and 30% with offhand weapon.
+        // Flash kick: Deal 100% unarmed damage
+        // Protect: Block 25 physical damage
+        // Calm Down: Block 25 lust damage
+        // Escape: Attempts to escape
+        // Tease: Deals 7 lust damage
+
+        CombatMove newCombatMove = new CombatMove("strike",
+                "strike",
+                0,
+                1,
+                CombatMoveType.ATTACK,
+                "moves/strike",
+                false,
+                true,
+                false){
+
+            private int getDamage(GameCharacter source)
+            {
+                AbstractWeapon weapon = source.getMainWeapon();
+                if (weapon == null) {
+                    return 1 + (int)(source.getAttributeValue(Attribute.MAJOR_PHYSIQUE)/10);
+                } else {
+                    return weapon.getWeaponType().getDamage();
+                }
+            }
+
+            @Override
+            public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.PHYSICAL;
+                if(source.getMainWeapon() != null)
+                {
+                    damageType = source.getMainWeapon().getDamageType();
+                }
+                return "Attack " + target.getName() + ", dealing 100% ("
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamage(source)) + "</span>"
+                        + ") of their weapon's damage to them.";
+            }
+
+            @Override
+            public String getDescription()
+            {
+                DamageType damageType = DamageType.PHYSICAL;
+                if(Main.game.getPlayer().getMainWeapon() != null)
+                {
+                    damageType = Main.game.getPlayer().getMainWeapon().getDamageType();
+                }
+                return "Attack your enemy, dealing 100% ("
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamage(Main.game.getPlayer())) + "</span>"
+                        + ") of your main weapon's damage to them.";
+            }
+
+            @Override
+            public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.PHYSICAL;
+                if(source.getMainWeapon() != null)
+                {
+                    damageType = source.getMainWeapon().getDamageType();
+                }
+
+                int dealtDamage = damageType.damageTarget(target, getDamage(source));
+
+                return source.getName("The")+" attacked " + target.getName() + ", dealing "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(dealtDamage) + "</span> "
+                        + damageType.getName() + " damage to them.";
+            }
+        };
+        allCombatMoves.add(newCombatMove);
+
+        newCombatMove = new CombatMove("block",
+                "block",
+                0,
+                1,
+                CombatMoveType.DEFEND,
+                "moves/block",
+                false,
+                false,
+                true){
+            private int getBlock() {
+                return 7;
+            }
+
+            @Override
+            public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.ENERGY;
+                return "Defend for "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getBlock()) + "</span>"
+                        + " of the incoming " + damageType.getName() + " damage for the next turn.";
+            }
+
+            @Override
+            public String getDescription()
+            {
+                DamageType damageType = DamageType.ENERGY;
+                return "Defend, blocking for "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getBlock()) + "</span>"
+                        + " of the incoming " + damageType.getName() + " damage for this turn.";
+            }
+
+            @Override
+            public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.ENERGY;
+                target.setShields(damageType, target.getShields(damageType) + getBlock());
+                return source.getName("The")+" defended this turn, gaining protection from "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getBlock()) + "</span>"
+                        + " of the incoming " + damageType.getName() + " damage for this turn.";
+            }
+        };
+        allCombatMoves.add(newCombatMove);
+    }
+
+    /**
+     * Default constructor
+     * @param identifier = Internal name that the game will refer to when looking up the item. Must be unique for proper searching.
+     * @param name = Human friendly name of the action
+     * @param cooldown = Amount of turns this action takes to become available. 0 means it's available always, 1 means it is available only once per turn.
+     * @param APcost = Cost in action points to perform this action.
+     * @param type = Combat action type. Used for various interactions.
+     */
+    public CombatMove(String identifier, String name, int cooldown, int APcost, CombatMoveType type, String pathName, boolean canTargetAllies, boolean canTargetEnemies, boolean canTargetSelf)
+    {
+        this.identifier = identifier;
+        this.name = name;
+        this.cooldown = cooldown;
+        this.APcost = APcost;
+        this.type = type;
+        this.canTargetEnemies = canTargetEnemies;
+        this.canTargetAllies = canTargetAllies;
+        this.canTargetSelf = canTargetSelf;
+
+        try {
+            InputStream is = this.getClass().getResourceAsStream("/com/lilithsthrone/res/" + pathName + ".svg");
+            if(is==null) {
+                System.err.println("Error! Perk icon file does not exist (Trying to read from '"+pathName+"')!");
+            }
+            SVGString = Util.inputStreamToString(is);
+
+            SVGString = SVGString.replaceAll("#ff2a2a", this.type.getColour().getShades()[0]);
+            SVGString = SVGString.replaceAll("#ff5555", this.type.getColour().getShades()[1]);
+            SVGString = SVGString.replaceAll("#ff8080", this.type.getColour().getShades()[2]);
+            SVGString = SVGString.replaceAll("#ffaaaa", this.type.getColour().getShades()[3]);
+            SVGString = SVGString.replaceAll("#ffd5d5", this.type.getColour().getShades()[4]);
+
+            is.close();
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Returns weight of the action. Used in calculations for AI to pick certain actions. For every unspent AP, AI will try to select an action out of the available ones. The AI will then pick the action with highest weight. Randomness of action selection should be in the weight values itself!
+     * @param source Character that uses the weight function.
+     * @param enemies Enemies of the character
+     * @param allies Allies of the character
+     * @return Weight of the action. 1.0 is the expected normal weight; weigh the actions accordingly.
+     */
+    public float getWeight(GameCharacter source, List<GameCharacter> enemies, List<GameCharacter> allies)
+    {
+        if(canTargetAllies && allies.isEmpty())
+        {
+            return 0.0f;
+        }
+        return (float)(Math.random());
+    }
+
+    /**
+     * Returns the preferred target for the action. By default prefers a random enemy or ally if it can't target enemies but can target allies and has one, otherwise targets self.
+     * @param source Character that uses the target function.
+     * @param enemies Enemies of the character
+     * @param allies Allies of the character
+     * @return Character to target with this action.
+     */
+    public GameCharacter getPreferredTarget(GameCharacter source, List<GameCharacter> enemies, List<GameCharacter> allies)
+    {
+        if(canTargetEnemies)
+        {
+            return enemies.get(Util.random.nextInt(enemies.size()));
+        }
+        if(canTargetAllies && !allies.isEmpty())
+        {
+            return allies.get(Util.random.nextInt(allies.size()));
+        }
+        return source;
+    }
+
+    /**
+     * @param identifier Identifier of the move to find.
+     * @return Returns the move if it can find one or null if it can't
+     */
+    public static CombatMove getMove(String identifier)
+    {
+        for (CombatMove move: allCombatMoves) {
+            if(move.getIdentifier().equals(identifier)) {
+                return move;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets a prediction that specifies what kind of action will be performed for the player (i.e "The catgirl will attack you for 10 damage" or "The horseboy is planning to buff his ally")
+     * @param source Character that uses the action.
+     * @param source Target for the action.
+     * @param enemies Enemies of the character
+     * @param allies Allies of the character
+     * @return The string that describes the intent of the NPC that uses this action.
+     */
+    public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+    {
+        return "There's a plan for you. More pain.";
+    }
+
+    /**
+     * Performs the action itself. Override to get actual abilities there.
+     * @param source Character that uses the action.
+     * @param source Target for the action.
+     * @param enemies Enemies of the character
+     * @param allies Allies of the character
+     * @return The string that describes the action that has been performed.
+     */
+    public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+    {
+        return "The action has been performed.";
+    }
+
+    /**
+     * Returns true if the character has the move available to select even if they don't "own" it; for example, purity based moves are available to Pure Virgin fetishists without even unlocking them.
+     */
+    public boolean isAvailableFromSpecialCase(GameCharacter source)
+    {
+        return false;
+    }
+
+    /**
+     * Returns a string if action can't be used either due to special constraints or because of AP/cooldowns on a specified target; string specifies rejection reason. Returns null if action can be used without an issue.
+     * @param source Character that uses the action.
+     * @param source Target for the action. Can be null.
+     * @param enemies Enemies of the character
+     * @param allies Allies of the character
+     */
+    public String isUseable(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+    {
+        if(target != null)
+        {
+            // TODO: Figure out if target is an enemy
+            if(!canTargetSelf && source == target)
+            {
+                return "This action can't be used on yourself!";
+            }
+
+            if(!canTargetAllies && allies.contains(target) && source != target)
+            {
+                return "This action can't be used on your allies!";
+            }
+
+            if(!canTargetEnemies && enemies.contains(target))
+            {
+                return "This action can't be used on your enemies!";
+            }
+        }
+
+        if(source.getMoveCooldown(this.getIdentifier()) > 0)
+        {
+            return "This action can't be used since it is still on cooldown! "+String.valueOf(source.getMoveCooldown(this.getIdentifier()))+" turns remaining.";
+        }
+
+        if(source.getRemainingAP() < this.getAPcost())
+        {
+            return "This action can't be used since you don't have enough AP!";
+        }
+
+        return null;
+    }
+
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public int getCooldown() {
+        return cooldown;
+    }
+
+    public CombatMoveType getType() {
+        return type;
+    }
+
+    public boolean isCanTargetEnemies() {
+        return canTargetEnemies;
+    }
+
+    public boolean isCanTargetAllies() {
+        return canTargetAllies;
+    }
+
+    public boolean isCanTargetSelf() {
+        return canTargetSelf;
+    }
+
+    public int getAPcost() {
+        return APcost;
+    }
+
+    public String getDescription() {
+        return "This action does nothing.";
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getSVGString() {
+        return SVGString;
+    }
+
+}

--- a/src/com/lilithsthrone/game/combat/CombatMove.java
+++ b/src/com/lilithsthrone/game/combat/CombatMove.java
@@ -568,7 +568,7 @@ public class CombatMove {
                     spell.getCooldown(),
                     spell.getAPCost(),
                     CombatMoveType.SPELL,
-                    "moves/"+spell.getPathName(),
+                    "combat/spell/"+spell.getPathName(),
                     spell.isCanTargetAllies(),
                     spell.isCanTargetEnemies(),
                     spell.isCanTargetSelf()) {

--- a/src/com/lilithsthrone/game/combat/CombatMove.java
+++ b/src/com/lilithsthrone/game/combat/CombatMove.java
@@ -2,6 +2,8 @@ package com.lilithsthrone.game.combat;
 
 import com.lilithsthrone.game.character.GameCharacter;
 import com.lilithsthrone.game.character.attributes.Attribute;
+import com.lilithsthrone.game.character.attributes.CorruptionLevel;
+import com.lilithsthrone.game.character.attributes.LustLevel;
 import com.lilithsthrone.game.inventory.weapon.AbstractWeapon;
 import com.lilithsthrone.main.Main;
 import com.lilithsthrone.utils.Util;
@@ -38,6 +40,11 @@ public class CombatMove {
         // Escape: Attempts to escape
         // Tease: Deals 7 lust damage
 
+        /*=============================================
+         *
+         *
+         *
+         */
         CombatMove newCombatMove = new CombatMove("strike",
                 "strike",
                 0,
@@ -59,6 +66,12 @@ public class CombatMove {
             }
 
             @Override
+            public String isAvailableFromSpecialCase(GameCharacter source)
+            {
+                return "This move is a starter move, available to everyone from the beginning.";
+            }
+
+            @Override
             public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
             {
                 DamageType damageType = DamageType.PHYSICAL;
@@ -66,10 +79,10 @@ public class CombatMove {
                 {
                     damageType = source.getMainWeapon().getDamageType();
                 }
-                return "Attack " + target.getName() + ", dealing 100% ("
+                return "Attack " + target.getName() + ", dealing "
                         + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
-                        + String.valueOf(getDamage(source)) + "</span>"
-                        + ") of their weapon's damage to them.";
+                        + String.valueOf(getDamage(source)) + " " + damageType.getName() + "</span>"
+                        + " damage.";
             }
 
             @Override
@@ -105,6 +118,11 @@ public class CombatMove {
         };
         allCombatMoves.add(newCombatMove);
 
+        /*=============================================
+         *
+         *
+         *
+         */
         newCombatMove = new CombatMove("block",
                 "block",
                 0,
@@ -119,13 +137,19 @@ public class CombatMove {
             }
 
             @Override
+            public String isAvailableFromSpecialCase(GameCharacter source)
+            {
+                return "This move is a starter move, available to everyone from the beginning.";
+            }
+
+            @Override
             public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
             {
                 DamageType damageType = DamageType.ENERGY;
                 return "Defend for "
                         + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
-                        + String.valueOf(getBlock()) + "</span>"
-                        + " of the incoming " + damageType.getName() + " damage for the next turn.";
+                        + String.valueOf(getBlock())+ " " + damageType.getName() + " </span>"
+                        + " damage for the next turn.";
             }
 
             @Override
@@ -147,6 +171,141 @@ public class CombatMove {
                         + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
                         + String.valueOf(getBlock()) + "</span>"
                         + " of the incoming " + damageType.getName() + " damage for this turn.";
+            }
+        };
+        allCombatMoves.add(newCombatMove);
+
+
+        /*=============================================
+         *
+         *
+         *
+         */
+        newCombatMove = new CombatMove("tease",
+                "tease",
+                0,
+                1,
+                CombatMoveType.TEASE,
+                "moves/tease",
+                false,
+                true,
+                false){
+
+            private int getDamage(GameCharacter source)
+            {
+                return 7;
+            }
+
+            @Override
+            public String isAvailableFromSpecialCase(GameCharacter source)
+            {
+                return "This move is a starter move, available to everyone from the beginning.";
+            }
+
+            @Override
+            public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.LUST;
+                return "Tease " + target.getName() + ", dealing "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamage(source)) + " " + damageType.getName() + "</span>"
+                        + " damage.";
+            }
+
+            @Override
+            public String getDescription()
+            {
+                DamageType damageType = DamageType.LUST;
+                return "Tease your enemy, dealing "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamage(Main.game.getPlayer())) + "</span>"
+                        + " lust damage to them.";
+            }
+
+            @Override
+            public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.LUST;
+
+                int dealtDamage = damageType.damageTarget(target, getDamage(source));
+
+                return source.getSeductionDescription(target) + "<br/>"
+                        + "As a result, " + source.getName("the")+" teased " + target.getName() + ", dealing "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(dealtDamage) + "</span> "
+                        + damageType.getName() + " damage to them.";
+            }
+        };
+        allCombatMoves.add(newCombatMove);
+
+
+        /*=============================================
+         *
+         *
+         *
+         */
+        newCombatMove = new CombatMove("avert",
+                "avert",
+                0,
+                1,
+                CombatMoveType.DEFEND,
+                "moves/avert",
+                false,
+                false,
+                true){
+            private int getBlock() {
+                return 7;
+            }
+
+            @Override
+            public String isAvailableFromSpecialCase(GameCharacter source)
+            {
+                return "This move is a starter move, available to everyone from the beginning.";
+            }
+
+            @Override
+            public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.LUST;
+                return "Defend for "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getBlock())+ " " + damageType.getName() + " </span>"
+                        + " damage for the next turn.";
+            }
+
+            @Override
+            public String getDescription()
+            {
+                DamageType damageType = DamageType.LUST;
+                return "Avert your gase, blocking for "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getBlock()) + "</span>"
+                        + " of the incoming " + damageType.getName() + " damage for this turn.";
+            }
+
+            @Override
+            public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.LUST;
+                target.setShields(damageType, target.getShields(damageType) + getBlock());
+                return source.getName("The")+" averted their gase this turn, gaining protection from "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getBlock()) + "</span>"
+                        + " of the incoming " + damageType.getName() + " damage for this turn.";
+            }
+
+            @Override
+            public float getWeight(GameCharacter source, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                if(shouldBlunder())
+                {
+                    return (float)(Math.random()) - 0.2f * source.getSelectedMovesByType(this.getType());
+                }
+                if(source.getLustLevel() == LustLevel.FOUR_IMPASSIONED || source.getLustLevel() == LustLevel.FIVE_BURNING)
+                {
+                    return 1.0f + 0.2f * (float)(Math.random()) - 0.2f * source.getSelectedMovesByType(this.getType());
+                }
+                return 0.8f + 0.2f * (float)(Math.random()) - 0.2f * source.getSelectedMovesByType(this.getType());
             }
         };
         allCombatMoves.add(newCombatMove);
@@ -204,11 +363,50 @@ public class CombatMove {
         {
             return 0.0f;
         }
-        return (float)(Math.random());
+        if(shouldBlunder())
+        {
+            return (float)(Math.random()) - 0.2f * source.getSelectedMovesByType(type);
+        }
+        // Trying to figure out best use cases
+        switch(type)
+        {
+            default:
+                return (float)(Math.random()) - 0.2f * source.getSelectedMovesByType(type); // Other types are too nuanced in themselves to have a broad weight generation apply to them
+            case ATTACK:
+                for(GameCharacter character : enemies)
+                {
+                    if(character.getHealthPercentage() < 0.2)
+                    {
+                        return 1.1f + 0.2f*(float)(Math.random()) - 0.2f * source.getSelectedMovesByType(type); // If the enemy is low on health, chances to attack increase
+                    }
+                }
+                return 0.8f + 0.2f*(float)(Math.random()) - 0.2f * source.getSelectedMovesByType(type); // Attacks aren't sophisticated
+            case DEFEND:
+                if(source.getHealthPercentage() < 0.2)
+                {
+                    return 1.0f + 0.5f*(float)(Math.random()) - 0.2f * source.getSelectedMovesByType(type);
+                }
+                return 0.25f + 0.75f*(float)(Math.random()) - 0.2f * source.getSelectedMovesByType(type);
+            case TEASE:
+                float weight = 0.8f + 0.2f*(float)(Math.random()) - 0.2f * source.getSelectedMovesByType(type);
+                for(GameCharacter character : enemies)
+                {
+                    if(character.getLustLevel() == LustLevel.FOUR_IMPASSIONED || character.getLustLevel() == LustLevel.FIVE_BURNING)
+                    {
+                        weight += 0.2f;
+                        break;
+                    }
+                }
+                if(source.getCorruptionLevel() == CorruptionLevel.FOUR_LUSTFUL || source.getCorruptionLevel() == CorruptionLevel.FIVE_CORRUPT)
+                {
+                    weight += 0.4f;
+                }
+                return weight; // Attacks aren't sophisticated
+        }
     }
 
     /**
-     * Returns the preferred target for the action. By default prefers a random enemy or ally if it can't target enemies but can target allies and has one, otherwise targets self.
+     * Returns the preferred target for the action. Prefers to aim at targets with lowest HP values if not forced to select at random. Override for custom behavior
      * @param source Character that uses the target function.
      * @param enemies Enemies of the character
      * @param allies Allies of the character
@@ -218,11 +416,45 @@ public class CombatMove {
     {
         if(canTargetEnemies)
         {
-            return enemies.get(Util.random.nextInt(enemies.size()));
+            if(shouldBlunder())
+            {
+                return enemies.get(Util.random.nextInt(enemies.size()));
+            }
+            else
+            {
+                float lowestHP = -1;
+                GameCharacter potentialCharacter = null;
+                for(GameCharacter character : enemies)
+                {
+                    if(lowestHP == -1 || character.getHealth() < lowestHP)
+                    {
+                        potentialCharacter = character;
+                        lowestHP = character.getHealth();
+                    }
+                }
+                return potentialCharacter;
+            }
         }
         if(canTargetAllies && !allies.isEmpty())
         {
-            return allies.get(Util.random.nextInt(allies.size()));
+            if(shouldBlunder())
+            {
+                return allies.get(Util.random.nextInt(allies.size()));
+            }
+            else
+            {
+                float lowestHP = -1;
+                GameCharacter potentialCharacter = null;
+                for(GameCharacter character : allies)
+                {
+                    if(lowestHP == -1 || character.getHealth() < lowestHP)
+                    {
+                        potentialCharacter = character;
+                        lowestHP = character.getHealth();
+                    }
+                }
+                return potentialCharacter;
+            }
         }
         return source;
     }
@@ -268,11 +500,13 @@ public class CombatMove {
     }
 
     /**
-     * Returns true if the character has the move available to select even if they don't "own" it; for example, purity based moves are available to Pure Virgin fetishists without even unlocking them.
+     * Returns a string if the character has the move available to select even if they don't "own" it; for example, purity based moves are available to Pure Virgin fetishists without even unlocking them.
+     *
+     * String contains the reason for why the move is available to them. Otherwise returns null.
      */
-    public boolean isAvailableFromSpecialCase(GameCharacter source)
+    public String isAvailableFromSpecialCase(GameCharacter source)
     {
-        return false;
+        return null;
     }
 
     /**
@@ -314,6 +548,15 @@ public class CombatMove {
         }
 
         return null;
+    }
+
+    /**
+     * Returns true based on user settings on how often should the AI make "mistakes" and select actions irrationally.
+     * @return
+     */
+    static boolean shouldBlunder()
+    {
+        return Math.random() <= Main.getProperties().AIblunderRate;
     }
 
     public String getIdentifier() {

--- a/src/com/lilithsthrone/game/combat/CombatMove.java
+++ b/src/com/lilithsthrone/game/combat/CombatMove.java
@@ -31,6 +31,8 @@ public class CombatMove {
     private boolean canTargetSelf;
     private String SVGString;
 
+    private Spell associatedSpell;
+
     static {
         // Initializing default actions
         // TODO
@@ -82,7 +84,7 @@ public class CombatMove {
             @Override
             public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
             {
-                DamageType damageType = DamageType.PHYSICAL;
+                DamageType damageType = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
                 if(source.getMainWeapon() != null)
                 {
                     damageType = source.getMainWeapon().getDamageType();
@@ -96,7 +98,7 @@ public class CombatMove {
             @Override
             public String getDescription()
             {
-                DamageType damageType = DamageType.PHYSICAL;
+                DamageType damageType = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
                 if(Main.game.getPlayer().getMainWeapon() != null)
                 {
                     damageType = Main.game.getPlayer().getMainWeapon().getDamageType();
@@ -110,7 +112,7 @@ public class CombatMove {
             @Override
             public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
             {
-                DamageType damageType = DamageType.PHYSICAL;
+                DamageType damageType = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
                 if(source.getMainWeapon() != null)
                 {
                     damageType = source.getMainWeapon().getDamageType();
@@ -174,12 +176,12 @@ public class CombatMove {
             @Override
             public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
             {
-                DamageType damageTypeMain = DamageType.PHYSICAL;
+                DamageType damageTypeMain = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
                 if(source.getMainWeapon() != null)
                 {
                     damageTypeMain = source.getMainWeapon().getDamageType();
                 }
-                DamageType damageTypeOffhand = DamageType.PHYSICAL;
+                DamageType damageTypeOffhand = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
                 if(source.getOffhandWeapon() != null)
                 {
                     damageTypeOffhand = source.getOffhandWeapon().getDamageType();
@@ -196,12 +198,12 @@ public class CombatMove {
             @Override
             public String getDescription()
             {
-                DamageType damageTypeMain = DamageType.PHYSICAL;
+                DamageType damageTypeMain = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
                 if(Main.game.getPlayer().getMainWeapon() != null)
                 {
                     damageTypeMain = Main.game.getPlayer().getMainWeapon().getDamageType();
                 }
-                DamageType damageTypeOffhand = DamageType.PHYSICAL;
+                DamageType damageTypeOffhand = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
                 if(Main.game.getPlayer().getOffhandWeapon() != null)
                 {
                     damageTypeOffhand = Main.game.getPlayer().getOffhandWeapon().getDamageType();
@@ -218,12 +220,12 @@ public class CombatMove {
             @Override
             public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
             {
-                DamageType damageTypeMain = DamageType.PHYSICAL;
+                DamageType damageTypeMain = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
                 if(source.getMainWeapon() != null)
                 {
                     damageTypeMain = source.getMainWeapon().getDamageType();
                 }
-                DamageType damageTypeOffhand = DamageType.PHYSICAL;
+                DamageType damageTypeOffhand = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
                 if(source.getOffhandWeapon() != null)
                 {
                     damageTypeOffhand = source.getOffhandWeapon().getDamageType();
@@ -498,7 +500,7 @@ public class CombatMove {
                         + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
                         + String.valueOf(getDamage(source)) + " " + damageType.getName() + "</span>"
                         + " damage. "
-                        + "<span style='color:" + Colour.GENERIC_GOOD + ";'>"
+                        + "<span style='color:" + Colour.CRIT.toWebHexString() + ";'>"
                         + "Crit if this move breaks block; if crits, do a second kick." + "</span>";
             }
 
@@ -510,7 +512,7 @@ public class CombatMove {
                         + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
                         + String.valueOf(getDamage(Main.game.getPlayer())) + "</span>"
                         + ") unarmed damage to them. "
-                        + "<span style='color:" + Colour.GENERIC_GOOD + ";'>"
+                        + "<span style='color:" + Colour.CRIT.toWebHexString() + ";'>"
                         + "Will crit if this move breaks block; if it crits, will do a second kick." + "</span>";
             }
 
@@ -529,7 +531,7 @@ public class CombatMove {
                 {
                     dealtDamage = damageType.damageTarget(target, source, getDamage(source)); // Second kick damage from the crit.
                     report += "The attack broke through the block, staggering the target, letting " + source.getName("the")
-                        + "<span style='color:" + Colour.GENERIC_GOOD + ";'>"
+                        + "<span style='color:" + Colour.CRIT.toWebHexString() + ";'>"
                         + "to critically hit" + "</span>" + target.getName("the") + ", throwing in a second kick for "
                         + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
                         + String.valueOf(dealtDamage) + "</span> "
@@ -573,14 +575,16 @@ public class CombatMove {
                     spell.isCanTargetEnemies(),
                     spell.isCanTargetSelf()) {
 
-                private Spell associatedSpell = spell;
-
                 @Override
                 public String isAvailableFromSpecialCase(GameCharacter source)
                 {
-                    if(source.hasSpell(this.associatedSpell))
+                    if(source.hasSpell(this.getAssociatedSpell()))
                     {
                         return "This is a spell and it is available to casters that learned it.";
+                    }
+                    else if(source.getExtraSpells().contains(this.getAssociatedSpell()))
+                    {
+                        return "This is a spell and it is available to you because of your equipped weapon.";
                     }
                     else
                     {
@@ -591,52 +595,203 @@ public class CombatMove {
                 @Override
                 public float getWeight(GameCharacter source, List<GameCharacter> enemies, List<GameCharacter> allies)
                 {
-                    return associatedSpell.getWeight(source, enemies, allies);
+                    return getAssociatedSpell().getWeight(source, enemies, allies);
                 }
 
                 @Override
                 public GameCharacter getPreferredTarget(GameCharacter  source, List<GameCharacter> enemies, List<GameCharacter> allies)
                 {
-                    return associatedSpell.getPreferredTarget(source, enemies, allies);
+                    return getAssociatedSpell().getPreferredTarget(source, enemies, allies);
                 }
 
                 @Override
                 public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
                 {
-                    return associatedSpell.getPrediction(source, target, enemies, allies);
+                    return getAssociatedSpell().getPrediction(source, target, enemies, allies);
                 }
 
                 @Override
                 public void applyDisruption(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
                 {
-                    associatedSpell.applyDisruption(source, target, enemies, allies);
+                    getAssociatedSpell().applyDisruption(source, target, enemies, allies);
                 }
 
                 @Override
                 public String getDescription()
                 {
-                    return associatedSpell.getDescription();
+                    return getAssociatedSpell().getDescription();
                 }
 
                 @Override
                 public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
                 {
-                    return associatedSpell.perform(source, target, enemies, allies);
+                    return getAssociatedSpell().perform(source, target, enemies, allies);
                 }
 
                 @Override
                 public void performOnSelection(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
                 {
-                    associatedSpell.performOnSelection(source, target, enemies, allies);
+                    getAssociatedSpell().performOnSelection(source, target, enemies, allies);
                 }
 
                 @Override
                 public boolean canCrit(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
                 {
-                    return associatedSpell.canCrit(source, target, enemies, allies);
+                    return getAssociatedSpell().canCrit(source, target, enemies, allies);
+                }
+
+                @Override
+                public String isUseable(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+                {
+                    String reason = super.isUseable(source, target, enemies, allies);
+                    if(reason == null)
+                    {
+                        if(getAssociatedSpell().getSpellSchool() != SpellSchool.FIRE && getAssociatedSpell().getModifiedCost(source) < source.getMana())
+                        {
+                            reason = "Not enough aura to cast this spell!";
+                        }
+                    }
+                    return reason;
                 }
             };
+            newCombatMove.setAssociatedSpell(spell);
+            allCombatMoves.add(newCombatMove);
         }
+
+        // Note: Not a spell per se, but recovers mana and is only available to spell casters.
+        /*=============================================
+         *
+         *
+         *
+         */
+        newCombatMove = new CombatMove("arcane-strike",
+                "arcane strike",
+                0,
+                1,
+                CombatMoveType.ATTACK,
+                "moves/arcane-strike",
+                false,
+                true,
+                false){
+
+            private int getDamage(GameCharacter source)
+            {
+                AbstractWeapon weapon = source.getMainWeapon();
+                int totalDamage;
+                if (weapon == null) {
+                    totalDamage = source.getUnarmedDamage();
+                } else {
+                    totalDamage = weapon.getWeaponType().getDamage();
+                }
+                return (int)(totalDamage * 0.33);
+            }
+
+            private int getManaGain(GameCharacter source)
+            {
+                return 15;
+            }
+
+            @Override
+            public String isAvailableFromSpecialCase(GameCharacter source)
+            {
+                if(source.getSpells().size() > 0)
+                {
+                    return "This is a very simple move that requires a knowledge of at least 1 spell.";
+                }
+                return null;
+            }
+
+            @Override
+            public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
+                if(source.getMainWeapon() != null)
+                {
+                    damageType = source.getMainWeapon().getDamageType();
+                }
+                return "Attack " + target.getName() + ", dealing "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamage(source)) + " " + damageType.getName() + "</span>"
+                        + " damage and recover "
+                        + "<span style='color:" + Colour.ATTRIBUTE_MANA.toWebHexString() + ";'>"
+                        + String.valueOf(getManaGain(source)) + "</span> "
+                        + " arcane. "
+                        + "<span style='color:" + Colour.CRIT.toWebHexString() + ";'>"
+                        + "Crit if won't cast spells this turn; if crits, double aura gain and damage dealt." + "</span>";
+            }
+
+            @Override
+            public String getDescription()
+            {
+                DamageType damageType = DamageType.PHYSICAL;
+                if(Main.game.getPlayer().getMainWeapon() != null)
+                {
+                    damageType = Main.game.getPlayer().getMainWeapon().getDamageType();
+                }
+                return "Attack your enemy, dealing 33% ("
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(getDamage(Main.game.getPlayer())) + "</span>"
+                        + ") of your main weapon's damage to them and recover "
+                        + "<span style='color:" + Colour.ATTRIBUTE_MANA.toWebHexString() + ";'>"
+                        + String.valueOf(getManaGain(Main.game.getPlayer())) + "</span> "
+                        + " arcane. "
+                        + "<span style='color:" + Colour.CRIT.toWebHexString() + ";'>"
+                        + "Crits if you don't cast any spells this turn; if crits, double aura gain and damage dealt." + "</span>";
+            }
+
+            @Override
+            public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                DamageType damageType = DamageType.UNARMED.getSuperDamage(null, Main.game.getPlayer());
+                if(source.getMainWeapon() != null)
+                {
+                    damageType = source.getMainWeapon().getDamageType();
+                }
+
+                int dealtDamage;
+                int manaGain;
+                boolean didCrit;
+                if(canCrit(source, target, enemies, allies))
+                {
+                    didCrit = true;
+                    dealtDamage = damageType.damageTarget(target, source, getDamage(source) * 2);
+                    manaGain = getManaGain(source) * 2;
+                }
+                else
+                {
+                    didCrit = false;
+                    dealtDamage = damageType.damageTarget(target, source, getDamage(source));
+                    manaGain = getManaGain(source);
+                }
+
+                source.incrementMana(manaGain);
+
+                String report = source.getName("The")+" attacked " + target.getName() + ", dealing "
+                        + "<span style='color:" + damageType.getMultiplierAttribute().getColour().toWebHexString() + ";'>"
+                        + String.valueOf(dealtDamage) + "</span> "
+                        + damageType.getName() + " damage to them and recovers "
+                        + "<span style='color:" + Colour.ATTRIBUTE_MANA.toWebHexString() + ";'>"
+                        + String.valueOf(manaGain) + "</span> "
+                        + " arcane. ";
+                if(didCrit)
+                {
+                    report += "Since " + source.getName("The")+ " didn't use a spell this turn,"
+                            + "<span style='color:" + Colour.CRIT.toWebHexString() + ";'>" + " the attack crits, doubling aura gain and damage dealt!" + "</span>";
+                }
+                return report;
+            }
+
+            @Override
+            public boolean canCrit(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+            {
+                if(source.getSelectedMovesByType(CombatMoveType.SPELL) == 0) // Crits if no spells are cast this turn.
+                {
+                    return true;
+                }
+                return false;
+            }
+        };
+        allCombatMoves.add(newCombatMove);
     }
 
     /**
@@ -649,6 +804,8 @@ public class CombatMove {
      */
     public CombatMove(String identifier, String name, int cooldown, int APcost, CombatMoveType type, String pathName, boolean canTargetAllies, boolean canTargetEnemies, boolean canTargetSelf)
     {
+        this.associatedSpell = null;
+
         this.identifier = identifier;
         this.name = name;
         this.cooldown = cooldown;
@@ -884,7 +1041,6 @@ public class CombatMove {
     {
         if(target != null)
         {
-            // TODO: Figure out if target is an enemy
             if(!canTargetSelf && source == target)
             {
                 return "This action can't be used on yourself!";
@@ -933,6 +1089,14 @@ public class CombatMove {
 
     public CombatMoveType getType() {
         return type;
+    }
+
+    public Spell getAssociatedSpell() {
+        return associatedSpell;
+    }
+
+    public void setAssociatedSpell(Spell associatedSpell) {
+        this.associatedSpell = associatedSpell;
     }
 
     public boolean isCanTargetEnemies() {

--- a/src/com/lilithsthrone/game/combat/CombatMove.java
+++ b/src/com/lilithsthrone/game/combat/CombatMove.java
@@ -568,7 +568,7 @@ public class CombatMove {
                     spell.getCooldown(),
                     spell.getAPCost(),
                     CombatMoveType.SPELL,
-                    spell.getSVGString(),
+                    "moves/"+spell.getPathName(),
                     spell.isCanTargetAllies(),
                     spell.isCanTargetEnemies(),
                     spell.isCanTargetSelf()) {

--- a/src/com/lilithsthrone/game/combat/CombatMoveType.java
+++ b/src/com/lilithsthrone/game/combat/CombatMoveType.java
@@ -1,0 +1,65 @@
+package com.lilithsthrone.game.combat;
+
+import com.lilithsthrone.utils.Colour;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Move type used in combat. Determines certain interactions, but doesn't have inherent power to itself.
+ */
+public enum CombatMoveType {
+
+    ATTACK("Attack", Colour.DAMAGE_TYPE_PHYSICAL),
+    DEFEND("Defend", Colour.SPELL_SCHOOL_WATER),
+    TEASE("Tease", Colour.ATTRIBUTE_CORRUPTION),
+    SPELL("Spell", Colour.GENERIC_ARCANE),
+    SKILL("Skill", Colour.GENERIC_GOOD),
+    ATTACK_DEFEND("Defensive Attack", Colour.SPELL_SCHOOL_WATER, new ArrayList<>(Arrays.asList(CombatMoveType.ATTACK, CombatMoveType.DEFEND)));
+
+    private String name;
+    private List<CombatMoveType> countsAsList;
+    private Colour colour;
+
+    CombatMoveType(String name, Colour colour)
+    {
+        this.name = name;
+        this.colour = colour;
+    }
+
+    CombatMoveType(String name, Colour colour, List<CombatMoveType> countsAsList)
+    {
+        this.name = name;
+        this.colour = colour;
+        this.countsAsList = countsAsList;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public Colour getColour() {
+        return colour;
+    }
+
+    /**
+     * Returns true if the type can count as a different type. Use it for multitypes.
+     * @param moveTypeCompared Type to compare against
+     * @return
+     */
+    public boolean countsAs(CombatMoveType moveTypeCompared)
+    {
+        if(this == moveTypeCompared)
+        {
+            return true;
+        }
+        for (CombatMoveType moveType: countsAsList) {
+            if(moveTypeCompared == moveType) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/com/lilithsthrone/game/combat/CombatMoveType.java
+++ b/src/com/lilithsthrone/game/combat/CombatMoveType.java
@@ -26,6 +26,7 @@ public enum CombatMoveType {
     {
         this.name = name;
         this.colour = colour;
+        countsAsList = new ArrayList<>();
     }
 
     CombatMoveType(String name, Colour colour, List<CombatMoveType> countsAsList)

--- a/src/com/lilithsthrone/game/combat/CombatMoveType.java
+++ b/src/com/lilithsthrone/game/combat/CombatMoveType.java
@@ -27,6 +27,7 @@ public enum CombatMoveType {
         this.name = name;
         this.colour = colour;
         countsAsList = new ArrayList<>();
+        countsAsList.add(this);
     }
 
     CombatMoveType(String name, Colour colour, List<CombatMoveType> countsAsList)
@@ -44,6 +45,8 @@ public enum CombatMoveType {
     public Colour getColour() {
         return colour;
     }
+
+    public List<CombatMoveType> getCountsAsList() { return countsAsList; }
 
     /**
      * Returns true if the type can count as a different type. Use it for multitypes.

--- a/src/com/lilithsthrone/game/combat/DamageType.java
+++ b/src/com/lilithsthrone/game/combat/DamageType.java
@@ -65,7 +65,7 @@ public enum DamageType {
 			damageAmount = shieldCheck(target, damageAmount);
 			if(damageAmount > 0)
 			{
-				target.setLust(target.getLust()-damageAmount);
+				target.setLust(target.getLust()+damageAmount);
 			}
 			return damageAmount;
 

--- a/src/com/lilithsthrone/game/combat/DamageType.java
+++ b/src/com/lilithsthrone/game/combat/DamageType.java
@@ -1,5 +1,6 @@
 package com.lilithsthrone.game.combat;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import com.lilithsthrone.game.character.attributes.Attribute;
 import com.lilithsthrone.utils.Colour;
 
@@ -10,47 +11,75 @@ import com.lilithsthrone.utils.Colour;
  */
 public enum DamageType {
 
+
+	ENERGY("energy",
+			Colour.DAMAGE_TYPE_PHYSICAL,
+			"energy damaging",
+			Attribute.RESISTANCE_PHYSICAL,
+			Attribute.DAMAGE_PHYSICAL,
+			SpellSchool.EARTH,
+			null),
+
 	PHYSICAL("physical",
 			Colour.DAMAGE_TYPE_PHYSICAL,
 			"forceful",
 			Attribute.RESISTANCE_PHYSICAL,
 			Attribute.DAMAGE_PHYSICAL,
-			SpellSchool.EARTH),
+			SpellSchool.EARTH,
+			DamageType.ENERGY),
 	
 	ICE("ice",
 			Colour.DAMAGE_TYPE_COLD,
 			"freezing",
 			Attribute.RESISTANCE_ICE,
 			Attribute.DAMAGE_ICE,
-			SpellSchool.WATER),
+			SpellSchool.WATER,
+			DamageType.ENERGY),
 	
 	FIRE("fire",
 			Colour.DAMAGE_TYPE_FIRE,
 			"burning",
 			Attribute.RESISTANCE_FIRE,
 			Attribute.DAMAGE_FIRE,
-			SpellSchool.FIRE),
+			SpellSchool.FIRE,
+			DamageType.ENERGY),
 	
 	POISON("poison",
 			Colour.DAMAGE_TYPE_POISON,
 			"poisoned",
 			Attribute.RESISTANCE_POISON,
 			Attribute.DAMAGE_POISON,
-			SpellSchool.AIR),
+			SpellSchool.AIR,
+			DamageType.ENERGY),
 
 	LUST("lust",
 			Colour.DAMAGE_TYPE_LUST,
 			"arousing",
 			Attribute.RESISTANCE_LUST,
 			Attribute.DAMAGE_LUST,
-			SpellSchool.ARCANE),
+			SpellSchool.ARCANE,
+			null) {
+		@Override
+		public int damageTarget(GameCharacter target, int damageAmount)
+		{
+			damageAmount = shieldCheck(target, damageAmount);
+			if(damageAmount > 0)
+			{
+				target.setLust(target.getLust()-damageAmount);
+			}
+			return damageAmount;
+
+			// TODO: DAMAGE OVERFLOW
+		}
+	},
 	
 	MISC("generic",
 			Colour.DAMAGE_TYPE_PHYSICAL,
 			"standard",
 			Attribute.RESISTANCE_PHYSICAL,
 			Attribute.DAMAGE_PHYSICAL,
-			SpellSchool.ARCANE);
+			SpellSchool.ARCANE,
+			DamageType.ENERGY);
 
 	private String name;
 	private Colour colour;
@@ -58,14 +87,16 @@ public enum DamageType {
 	private Attribute resistAttribute;
 	private Attribute multiplierAttribute;
 	private SpellSchool spellSchool;
+	private DamageType superDamage;
 
-	private DamageType(String name, Colour colour, String weaponDescriptor, Attribute resistAttribute, Attribute multiplierAttribute, SpellSchool spellSchool) {
+	private DamageType(String name, Colour colour, String weaponDescriptor, Attribute resistAttribute, Attribute multiplierAttribute, SpellSchool spellSchool, DamageType superDamage) {
 		this.name = name;
 		this.colour = colour;
 		this.weaponDescriptor = weaponDescriptor;
 		this.resistAttribute = resistAttribute;
 		this.multiplierAttribute = multiplierAttribute;
 		this.spellSchool = spellSchool;
+		this.superDamage = superDamage; // The umbrella damage type  that covers all of the other damage types in it. Usually doesn't show up for weapons.
 	}
 
 	public String getName() {
@@ -90,6 +121,49 @@ public enum DamageType {
 
 	public SpellSchool getSpellSchool() {
 		return spellSchool;
+	}
+
+	/**
+	 * Deals damage to the target, checking against their shielding against the attack type. Override this if the attack
+	 * @param target
+	 * @param damageAmount
+	 * @return
+	 */
+	public int damageTarget(GameCharacter target, int damageAmount) {
+		damageAmount = shieldCheck(target, damageAmount);
+		if(damageAmount > 0)
+		{
+			target.setHealth(target.getHealth()-damageAmount);
+		}
+		return damageAmount;
+	}
+
+	public int shieldCheck(GameCharacter target, int damageAmount)
+	{
+		if(this.superDamage != null)
+		{
+			if(target.getShields(this.superDamage) > 0)
+			{
+				int oldShields = target.getShields(this.superDamage);
+				target.setShields(this.superDamage, target.getShields(this.superDamage) - damageAmount);
+				damageAmount -= oldShields;
+				if(damageAmount < 0)
+				{
+					damageAmount = 0;
+				}
+			}
+		}
+		if(target.getShields(this) > 0)
+		{
+			int oldShields = target.getShields(this);
+			target.setShields(this, target.getShields(this) - damageAmount);
+			damageAmount -= oldShields;
+			if(damageAmount < 0)
+			{
+				damageAmount = 0;
+			}
+		}
+		return damageAmount;
 	}
 	
 }

--- a/src/com/lilithsthrone/game/combat/Spell.java
+++ b/src/com/lilithsthrone/game/combat/Spell.java
@@ -10,6 +10,8 @@ import java.util.Map.Entry;
 
 import com.lilithsthrone.game.character.GameCharacter;
 import com.lilithsthrone.game.character.attributes.Attribute;
+import com.lilithsthrone.game.character.attributes.CorruptionLevel;
+import com.lilithsthrone.game.character.attributes.LustLevel;
 import com.lilithsthrone.game.character.effects.Perk;
 import com.lilithsthrone.game.character.effects.StatusEffect;
 import com.lilithsthrone.game.character.effects.TreeEntry;
@@ -69,7 +71,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 			
 			float damage = Attack.calculateSpellDamage(caster, target, damageType, this.getDamage(caster), damageVariance, isCritical);
 			float cost = getModifiedCost(caster);
@@ -173,7 +175,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 			
 			float cost = getModifiedCost(caster);
 			
@@ -271,7 +273,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -325,7 +327,7 @@ public enum Spell {
 			null, Util.newArrayListOfValues("Summons [style.colourArcane(Elemental)] in form of [style.colourSchoolFire(Fire)]")) {
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -409,7 +411,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float damage = Attack.calculateSpellDamage(caster, target, damageType, this.getDamage(caster), damageVariance, isCritical);
 			float cost = getModifiedCost(caster);
@@ -497,7 +499,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -553,7 +555,7 @@ public enum Spell {
 			null, Util.newArrayListOfValues("[style.boldGood(Restores)] 20% [style.boldHealth(energy)]")) {
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -683,7 +685,7 @@ public enum Spell {
 			null, Util.newArrayListOfValues("Summons [style.colourArcane(Elemental)] in form of [style.colourSchoolWater(Water)]")) {
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -772,7 +774,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -847,7 +849,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float damage = Attack.calculateSpellDamage(caster, target, damageType, this.getDamage(caster), damageVariance, isCritical);
 			float cost = getModifiedCost(caster);
@@ -925,7 +927,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 			float cost = getModifiedCost(caster);
 			
 			descriptionSB.setLength(0);
@@ -979,7 +981,7 @@ public enum Spell {
 			null, Util.newArrayListOfValues("Summons [style.colourArcane(Elemental)] in form of [style.colourSchoolAir(Air)]")) {
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -1060,7 +1062,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float damage = Attack.calculateSpellDamage(caster, target, damageType, this.getDamage(caster), damageVariance, isCritical);
 			float cost = getModifiedCost(caster);
@@ -1161,7 +1163,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -1235,7 +1237,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -1290,7 +1292,7 @@ public enum Spell {
 			null, Util.newArrayListOfValues("Summons [style.colourArcane(Elemental)] in form of [style.colourSchoolEarth(Earth)]")) {
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -1379,7 +1381,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float damage = Attack.calculateSpellDamage(caster, target, damageType, this.getDamage(caster), damageVariance, isCritical);
 			float cost = getModifiedCost(caster);
@@ -1459,7 +1461,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 			float cost = getModifiedCost(caster);
 			
 			descriptionSB.setLength(0);
@@ -1532,7 +1534,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -1628,7 +1630,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 			float cost = getModifiedCost(caster);
 			
 			descriptionSB.setLength(0);
@@ -1704,7 +1706,7 @@ public enum Spell {
 			null, Util.newArrayListOfValues("[style.colourExcellent(Steals)] a random item from the target's inventory")) {
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -1925,7 +1927,7 @@ public enum Spell {
 		}
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 			float cost = getModifiedCost(caster);
 			
 			descriptionSB.setLength(0);
@@ -1992,7 +1994,7 @@ public enum Spell {
 			null, Util.newArrayListOfValues("[style.colourGood(25%)] chance for target to [style.colourExcellent(instantly submit)]")) {
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 			float cost = getModifiedCost(caster);
 			
 			descriptionSB.setLength(0);
@@ -2081,7 +2083,7 @@ public enum Spell {
 			null, Util.newArrayListOfValues("Summons [style.colourArcane(Elemental)] in form of [style.colourArcane(Arcane)]")) {
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			float cost = getModifiedCost(caster);
 			
@@ -2149,7 +2151,7 @@ public enum Spell {
 					"Lasts for [style.colourGood(3 turns)]")) {
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			descriptionSB.setLength(0);
 			
@@ -2195,7 +2197,7 @@ public enum Spell {
 					new Value<Attribute, Integer>(Attribute.DAMAGE_LUST, 25)), Util.newArrayListOfValues("Lasts for [style.colourGood(5 turns)]")) {
 		
 		@Override
-		public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical) {
+		public String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical) {
 
 			descriptionSB.setLength(0);
 			
@@ -2281,7 +2283,8 @@ public enum Spell {
 	private HashMap<Attribute, Integer> attributeModifiers;
 	private List<String> extraEffects;
 	private List<String> modifiersList;
-	
+
+	private String pathName;
 	private String SVGString;
 
 	private Spell(boolean forbiddenSpell,
@@ -2340,6 +2343,7 @@ public enum Spell {
 		
 		
 		// SVG:
+		this.pathName = pathName;
 		try {
 			InputStream is = this.getClass().getResourceAsStream("/com/lilithsthrone/res/combat/spell/" + pathName + ".svg");
 			if(is==null) {
@@ -2377,7 +2381,12 @@ public enum Spell {
 		}
 	}
 
-	public abstract String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical);
+	public String applyEffect(GameCharacter caster, GameCharacter target, boolean isHit, boolean isCritical)
+	{
+		return applyEffect(caster, target, null, null, isHit, isCritical);
+	}
+
+	public abstract String applyEffect(GameCharacter caster, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies, boolean isHit, boolean isCritical);
 
 	public List<String> getModifiersAsStringList() {
 		return modifiersList;
@@ -2457,6 +2466,10 @@ public enum Spell {
 	
 	public String getSVGString() {
 		return SVGString;
+	}
+
+	public String getPathName() {
+		return pathName;
 	}
 	
 	protected void applyStatusEffects(GameCharacter caster, GameCharacter target, boolean isCritical) {
@@ -2854,5 +2867,119 @@ public enum Spell {
 				:siblingAvailable
 					?Colour.BASE_GREY
 					:Colour.TEXT_GREY_DARK;
+	}
+
+	// Combat maneuver compatibility
+	// These functions are almost identical to the ones in CombatMove class,  with modifications to fit spells as necessary. Refer to CombatMove class for information.
+
+	public int getAPCost()
+	{
+		return 1; // Normally just 1 AP.
+	}
+
+	public int getCooldown()
+	{
+		return 0; // Normally no CD.
+	}
+
+	public boolean isCanTargetEnemies()
+	{
+		return true;
+	}
+
+	public boolean isCanTargetAllies()
+	{
+		return true;
+	}
+
+	public boolean isCanTargetSelf()
+	{
+		return true;
+	}
+
+	public float getWeight(GameCharacter source, List<GameCharacter> enemies, List<GameCharacter> allies)
+	{
+		if(isCanTargetAllies() && allies.isEmpty())
+		{
+			return 0.0f;
+		}
+		return (float)(Math.random()) - 0.2f * source.getSelectedMovesByType(CombatMoveType.SPELL);
+	}
+
+	public GameCharacter getPreferredTarget(GameCharacter source, List<GameCharacter> enemies, List<GameCharacter> allies)
+	{
+		if(isCanTargetEnemies())
+		{
+			if(CombatMove.shouldBlunder())
+			{
+				return enemies.get(Util.random.nextInt(enemies.size()));
+			}
+			else
+			{
+				float lowestHP = -1;
+				GameCharacter potentialCharacter = null;
+				for(GameCharacter character : enemies)
+				{
+					if(lowestHP == -1 || character.getHealth() < lowestHP)
+					{
+						potentialCharacter = character;
+						lowestHP = character.getHealth();
+					}
+				}
+				return potentialCharacter;
+			}
+		}
+		if(isCanTargetAllies() && !allies.isEmpty())
+		{
+			if(CombatMove.shouldBlunder())
+			{
+				return allies.get(Util.random.nextInt(allies.size()));
+			}
+			else
+			{
+				float lowestHP = -1;
+				GameCharacter potentialCharacter = null;
+				for(GameCharacter character : allies)
+				{
+					if(lowestHP == -1 || character.getHealth() < lowestHP)
+					{
+						potentialCharacter = character;
+						lowestHP = character.getHealth();
+					}
+				}
+				return potentialCharacter;
+			}
+		}
+		return source;
+	}
+
+	public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+	{
+		return "An unknown spell!";
+	}
+
+	public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+	{
+		return this.applyEffect(source, target, enemies, allies, true, canCrit(source, target, enemies, allies));
+	}
+
+	public void performOnSelection(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+	{
+		// Nothing. Override it.
+	}
+
+	public void applyDisruption(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+	{
+		// Nothing. Override it.
+	}
+
+	//Differs from normal version; spells have special crit requirements.
+	public boolean canCrit(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
+	{
+		if(this.getSpellSchool() == SpellSchool.FIRE && source.getHealth() == 1) // Fire school spells crit on 1 health.
+		{
+			return true;
+		}
+		return false;
 	}
 }

--- a/src/com/lilithsthrone/game/combat/Spell.java
+++ b/src/com/lilithsthrone/game/combat/Spell.java
@@ -45,7 +45,7 @@ public enum Spell {
 			"Summons a ball of arcane flames that can be launched at a target.",
 			15,
 			DamageVariance.LOW,
-			50,
+			75,
 			null,
 			Util.newArrayListOfValues(
 					SpellUpgrade.FIREBALL_1,
@@ -132,8 +132,6 @@ public enum Spell {
 			
 			descriptionSB.append(getCostDescription(caster, cost));
 			
-			caster.incrementMana(-cost);
-			
 			return descriptionSB.toString();
 		}
 	},
@@ -148,7 +146,7 @@ public enum Spell {
 			"Crates a blinding flash of light that stuns the target.",
 			0,
 			DamageVariance.LOW,
-			60,
+			75,
 			Util.newHashMapOfValues(new Value<StatusEffect, Integer>(StatusEffect.FLASH, 1)),
 			Util.newArrayListOfValues(
 					SpellUpgrade.FLASH_1,
@@ -230,7 +228,6 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
 			
 			return descriptionSB.toString();
 		}
@@ -246,7 +243,7 @@ public enum Spell {
 			"Shrouds the target in a protective cloak of arcane flames, granting them improved fire and ice resistance.",
 			0,
 			DamageVariance.LOW,
-			40,
+			50,
 			Util.newHashMapOfValues(new Value<StatusEffect, Integer>(StatusEffect.CLOAK_OF_FLAMES, 3)),
 			Util.newArrayListOfValues(
 					SpellUpgrade.CLOAK_OF_FLAMES_1,
@@ -301,8 +298,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -370,7 +366,6 @@ public enum Spell {
 			
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
 			
 			return descriptionSB.toString();
 		}
@@ -388,7 +383,7 @@ public enum Spell {
 			"Summons a shard of ice that can be launched at a target.",
 			15,
 			DamageVariance.LOW,
-			50,
+			33,
 			null, Util.newArrayListOfValues(
 							SpellUpgrade.ICE_SHARD_1,
 							SpellUpgrade.ICE_SHARD_2,
@@ -454,8 +449,7 @@ public enum Spell {
 			
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -470,7 +464,7 @@ public enum Spell {
 			"Summons a small cloud of arcane-enchanted rain above the target's head, which saps their ability to cast spells.",
 			0,
 			DamageVariance.LOW,
-			30,
+			33,
 			null,
 			Util.newArrayListOfValues(
 					SpellUpgrade.RAIN_CLOUD_1,
@@ -530,8 +524,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -576,8 +569,7 @@ public enum Spell {
 			descriptionSB.append("</p>");
 			
 			
-			caster.incrementMana(-cost);
-			
+
 			// If attack hits, apply damage and effects:
 			if (isHit) {
 				if(caster.hasSpellUpgrade(SpellUpgrade.SOOTHING_WATERS_3)) {
@@ -728,8 +720,7 @@ public enum Spell {
 			
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -804,8 +795,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -881,8 +871,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -955,8 +944,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -1023,8 +1011,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -1119,8 +1106,7 @@ public enum Spell {
 			
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -1192,8 +1178,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -1266,8 +1251,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -1334,8 +1318,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -1416,8 +1399,7 @@ public enum Spell {
 			
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -1489,8 +1471,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -1563,8 +1544,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -1680,8 +1660,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -1876,8 +1855,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 		
@@ -1969,8 +1947,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -2057,8 +2034,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -2125,8 +2101,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -2174,8 +2149,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	},
@@ -2220,8 +2194,7 @@ public enum Spell {
 			}
 			
 			descriptionSB.append(getCostDescription(caster, cost));
-			caster.incrementMana(-cost);
-			
+
 			return descriptionSB.toString();
 		}
 	};
@@ -2955,7 +2928,9 @@ public enum Spell {
 
 	public String getPrediction(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
 	{
-		return "An unknown spell!";
+		return "Cast "
+				+ "<span style='color:" + getSpellSchool().getColour().toWebHexString() + ";'>"
+				+ getName() + "</span>" + " spell.";
 	}
 
 	public String perform(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
@@ -2963,14 +2938,22 @@ public enum Spell {
 		return this.applyEffect(source, target, enemies, allies, true, canCrit(source, target, enemies, allies));
 	}
 
+	// Applies mana cost effects here. If overriden, don't forget to call it unless it's a free spell.
 	public void performOnSelection(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
 	{
-		// Nothing. Override it.
+		if(getSpellSchool() == SpellSchool.FIRE)
+		{
+			source.burnMana(getModifiedCost(source));
+		}
+		else
+		{
+			source.incrementMana(-getModifiedCost(source));
+		}
 	}
 
 	public void applyDisruption(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies)
 	{
-		// Nothing. Override it.
+		// Override. Note that disrupted spells don't disrupt their mana.
 	}
 
 	//Differs from normal version; spells have special crit requirements.

--- a/src/com/lilithsthrone/game/dialogue/utils/CombatMovesSetup.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/CombatMovesSetup.java
@@ -1,0 +1,99 @@
+package com.lilithsthrone.game.dialogue.utils;
+
+import com.lilithsthrone.game.PropertyValue;
+import com.lilithsthrone.game.character.GameCharacter;
+import com.lilithsthrone.game.character.effects.Perk;
+import com.lilithsthrone.game.character.effects.PerkManager;
+import com.lilithsthrone.game.combat.CombatMove;
+import com.lilithsthrone.game.dialogue.DialogueNodeOld;
+import com.lilithsthrone.game.dialogue.DialogueNodeType;
+import com.lilithsthrone.game.dialogue.responses.Response;
+import com.lilithsthrone.main.Main;
+import com.lilithsthrone.utils.Colour;
+
+public class CombatMovesSetup {
+
+    private static GameCharacter target;
+
+    public static GameCharacter getTarget() {
+        if(target==null) {
+            return Main.game.getPlayer();
+        }
+        return target;
+    }
+
+    public static void setTarget(GameCharacter target) {
+        CombatMovesSetup.target = target;
+    }
+
+    public static final DialogueNodeOld COMBAT_MOVES_CORE = new DialogueNodeOld("Combat Moves", "", true) {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String getHeaderContent() {
+            UtilText.nodeContentSB.setLength(0);
+
+            UtilText.nodeContentSB.append(
+                    "<div class='container-full-width' style='padding:8px;'>"
+                            + "Every character can have up to "+String.valueOf(GameCharacter.MAX_COMBAT_MOVES)+" combat moves available to them at a time in combat, but they may know an infinite amount themselves. <br/>"
+                            + "You can click on the active moves to remove them from your active move list and click on the known ones to add them."
+                            + "</div>"
+                            + "<div class='container-full-width' style='padding:8px; text-align:center;'>"
+                            + "<h6 style='text-align:center;'>Active Moves</h6>");
+
+            for(int i=0;i<GameCharacter.MAX_COMBAT_MOVES;i++) {
+                CombatMove mv = null;
+                if(i<Main.game.getPlayer().getEquippedMoves().size()) {
+                    mv = Main.game.getPlayer().getEquippedMoves().get(i);
+                }
+                if(mv!=null) {
+                    UtilText.nodeContentSB.append("<div id='MOVE_" + mv.getIdentifier() + "' class='square-button small' style='width:8%; display:inline-block; float:none; border:2px solid " + mv.getType().getColour().toWebHexString() + ";'>"
+                            + "<div class='square-button-content'>"+mv.getSVGString()+"</div>"
+                            + "</div>");
+
+                } else {
+                    UtilText.nodeContentSB.append("<div id='MOVE_" + i + "' class='square-button small' style='display:inline-block; float:none;'></div>");
+
+                }
+            }
+            UtilText.nodeContentSB.append("</div>");
+
+            UtilText.nodeContentSB.append(
+                            "<div class='container-full-width' style='padding:8px; text-align:center;'>"
+                            + "<h6 style='text-align:center;'>Known Moves</h6>");
+
+            for(int i=0;i<Main.game.getPlayer().getAvailableMoves().size();i++) {
+                CombatMove mv = Main.game.getPlayer().getAvailableMoves().get(i);
+                if(!Main.game.getPlayer().getEquippedMoves().contains(Main.game.getPlayer().getAvailableMoves().get(i))) {
+                    UtilText.nodeContentSB.append("<div id='MOVE_" + mv.getIdentifier() + "' class='square-button small' style='width:8%; display:inline-block; float:none; border:2px solid " + mv.getType().getColour().toWebHexString() + ";'>"
+                            + "<div class='square-button-content'>" + mv.getSVGString() + "</div>"
+                            + "</div>");
+                }
+            }
+            UtilText.nodeContentSB.append("</div>");
+
+            return UtilText.nodeContentSB.toString();
+        }
+
+        @Override
+        public String getContent(){
+            return "";
+        }
+
+        @Override
+        public Response getResponse(int responseTab, int index) {
+
+            if (index == 0) {
+                return new Response("Back", "Return to your phone's main menu.", PhoneDialogue.MENU);
+            } else {
+                return null;
+            }
+        }
+
+        @Override
+        public DialogueNodeType getDialogueNodeType() {
+            return DialogueNodeType.PHONE;
+        }
+    };
+}

--- a/src/com/lilithsthrone/game/dialogue/utils/PhoneDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/PhoneDialogue.java
@@ -160,6 +160,18 @@ public class PhoneDialogue {
 					return new Response("Transform", "Only demons and slimes can transform themselves!", null);
 				}
 				
+			} else if (index == 11) {
+				if(Main.game.isSavedDialogueNeutral()) {
+					return new Response("Combat Moves", "Adjust the moves you perform in combat.", CombatMovesSetup.COMBAT_MOVES_CORE) {
+						@Override
+						public void effects() {
+							CombatMovesSetup.setTarget(Main.game.getPlayer());
+						}
+					};
+				} else {
+					return new Response("Combat Moves", "You are too busy to change your combat moves.", null);
+				}
+
 			} else if (index == 0){
 				return new ResponseEffectsOnly("Back", "Put your phone away."){
 					@Override

--- a/src/com/lilithsthrone/res/moves/arcane-strike.svg
+++ b/src/com/lilithsthrone/res/moves/arcane-strike.svg
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 256 256"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="specialAttackIcon.svg">
+  <defs
+     id="defs4">
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4154"
+       is_visible="true"
+       offset_points="0,0.5"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4150"
+       is_visible="true"
+       offset_points="0,0.5"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-7"
+       is_visible="true"
+       offset_points="0.34983355,5.1754019"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1"
+       is_visible="true"
+       offset_points="0.25601354,12.9606"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-0"
+       is_visible="true"
+       offset_points="0.25601354,12.9606"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-1"
+       is_visible="true"
+       offset_points="0.24778369,16.361328"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="263.54314"
+     inkscape:cy="169.39131"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1388"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:inline">
+    <path
+       style="display:inline;fill:#ff2a2a;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 188.21379,247.4435 C 183.23693,222.74935 174.07911,198.24912 162.26517,174.63396 138.38691,145.46916 110.44566,120.38462 83.762253,100.59164 57.048227,80.775948 31.347003,66.080042 11.967981,57.939762 29.258084,69.858965 52.05642,87.884131 75.332657,110.46411 c 23.31169,22.61437 46.957893,49.6536 65.948683,79.41205 17.66036,16.93998 33.98525,36.21064 46.93245,57.56734 z"
+       id="path4144-8-3-0"
+       inkscape:path-effect="#path-effect4146-2-4-1"
+       inkscape:original-d="M 188.21379,247.4435 C 153.13141,157.50937 61.281354,84.919139 11.967981,57.939762"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;fill:#ff2a2a;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 250.16258,192.99562 c -2.7065,-27.77927 -10.64824,-53.93913 -22.2899,-78.47835 C 204.18606,83.939841 175.04398,60.20913 147.5037,42.24824 119.89187,24.240695 93.223236,11.601677 73.916774,3.4918772 91.333032,15.498047 115.33014,31.612287 139.77188,52.649144 c 24.47447,21.065038 48.64594,46.444747 66.78369,76.605246 17.1283,17.287 32.5739,38.29753 43.60701,63.74123 z"
+       id="path4144-8-3-0-6"
+       inkscape:path-effect="#path-effect4146-2-4-1-0"
+       inkscape:original-d="M 250.16258,192.99562 C 223.29449,89.132919 123.23015,30.471254 73.916774,3.4918772"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;fill:#ff2a2a;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 243.73401,248.7099 C 242.49907,223.14694 232.24494,194.45513 216.74611,165.37583 195.27703,140.50468 169.48437,116.64408 143.39902,95.384805 117.52401,74.296965 91.013751,55.485529 67.773582,40.728848 44.50132,25.951788 24.252765,15.073125 11.059632,9.920448 c 11.433383,8.31681 29.388588,22.071383 50.249196,39.57559 20.93022,17.56262 44.587932,38.725632 67.455472,61.979872 23.06059,23.45055 45.00453,48.71283 62.06743,73.84786 22.14054,19.91482 41.4126,41.51232 52.90228,63.38613 z"
+       id="path4144-8-3-0-7"
+       inkscape:path-effect="#path-effect4146-2-4-1-1"
+       inkscape:original-d="M 243.73401,248.7099 C 217.5802,152.70434 60.373009,36.899826 11.059632,9.920448"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/src/com/lilithsthrone/res/moves/avert.svg
+++ b/src/com/lilithsthrone/res/moves/avert.svg
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100%"
+   height="100%"
+   viewBox="0 0 64.000001 64.000001"
+   id="svg4311"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="attCorruption0.svg">
+  <defs
+     id="defs4313">
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4258"
+       is_visible="true"
+       offset_points="0.26733603,0.17738073"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <linearGradient
+       inkscape:collect="always"
+       id="angelWings0">
+      <stop
+         style="stop-color:#d5f6ff;stop-opacity:1"
+         offset="0"
+         id="stop4165" />
+      <stop
+         style="stop-color:#aaeeff;stop-opacity:1"
+         offset="1"
+         id="stop4167" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4349"
+       is_visible="true"
+       offset_points="0.75050302,0.34025633"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4349-3"
+       is_visible="true"
+       offset_points="0.66162266,0.24688345"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4349-7"
+       is_visible="true"
+       offset_points="0.75050302,0.34025633"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4349-3-9"
+       is_visible="true"
+       offset_points="0.66162266,0.24688345"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#angelWings0"
+       id="linearGradient4169-3"
+       x1="-101.61064"
+       y1="1012.6269"
+       x2="-97.934288"
+       y2="1010.9301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4774554,0,0,1.4774554,164.87381,-468.24663)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#angelWings0"
+       id="linearGradient4237"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.4774554,0,0,1.4774554,-100.64666,-468.28248)"
+       x1="-101.61064"
+       y1="1012.6269"
+       x2="-97.934288"
+       y2="1010.9301" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313708"
+     inkscape:cx="44.434761"
+     inkscape:cy="22.250148"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1388"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata4316">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-988.36216)"
+     style="display:inline">
+    <path
+       style="display:inline;fill:url(#linearGradient4169-3);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 31.486798,1030.5787 c 0.971162,0.078 -2.734665,6.7218 -5.021778,7.7816 -0.540716,0.2506 -0.338629,-0.9311 -0.244987,-3.3391 -1.76462,2.5048 -3.697438,4.6128 -5.160522,4.9933 -0.868653,0.2259 -0.07953,-3.1788 0.230749,-4.6995 -1.600839,1.6909 -4.452431,3.114 -6.429695,2.886 -0.970437,-0.1123 2.791812,-2.8361 3.360827,-4.9102 -2.057549,1.4562 -6.173577,1.9432 -8.021578,1.1454 -1.087437,-0.4694 2.849465,-1.572 4.365083,-3.0389 -3.871259,0.203 -6.8980919,-1.991 -7.7871064,-3.0181 -0.9187261,-1.0614 2.6624042,-0.8113 5.5670664,-2.0096 -3.4717539,-0.197 -6.3233315,-1.156 -8.7613988,-4.8233 -0.7847357,-1.1804 4.2061973,0.8878 7.2596248,-0.7268 -6.0599754,-1.5596 -8.9882477,-6.2298 -8.6701811,-7.0668 0.3301227,-0.8686 2.2507113,1.2764 7.2989843,1.8433 -7.2572905,-3.2264 -8.73224897,-11.4155 -6.4083889,-13.8541 0.7781757,-0.8166 3.6066164,9.9836 12.4481677,9.2834 7.243089,-0.5735 6.390083,2.2131 5.45212,4.8319 -4.250063,11.8659 4.642464,14.2515 10.523013,14.7215 z"
+       id="path4161-8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sscscscscscscscssss" />
+    <path
+       sodipodi:nodetypes="sscscscscscscscssss"
+       inkscape:connector-curvature="0"
+       id="path4235"
+       d="m 32.740362,1030.5428 c -0.971161,0.078 2.734667,6.7218 5.021783,7.7816 0.540719,0.2506 0.338618,-0.9311 0.244976,-3.3391 1.764629,2.5048 3.697451,4.6128 5.160531,4.9933 0.868655,0.2259 0.07949,-3.1788 -0.230749,-4.6995 1.600837,1.6909 4.45243,3.114 6.429692,2.886 0.970437,-0.1123 -2.791813,-2.8361 -3.360825,-4.9102 2.057547,1.4562 6.173575,1.9432 8.021576,1.1454 1.087437,-0.4694 -2.849465,-1.572 -4.365083,-3.0389 3.871258,0.203 6.898092,-1.991 7.787106,-3.0181 0.918726,-1.0614 -2.662404,-0.8113 -5.567066,-2.0096 3.471754,-0.197 6.323331,-1.156 8.761399,-4.8233 0.784735,-1.1804 -4.206198,0.8878 -7.259625,-0.7268 6.059975,-1.5596 8.988248,-6.2298 8.670181,-7.0668 -0.330123,-0.8686 -2.250711,1.2764 -7.298984,1.8433 7.25729,-3.2264 8.732249,-11.4153 6.408389,-13.854 -0.778176,-0.8167 -3.606617,9.9835 -12.448168,9.2833 -7.243091,-0.5735 -6.390082,2.2131 -5.452119,4.8319 4.250061,11.8659 -4.64246,14.2515 -10.523014,14.7215 z"
+       style="display:inline;fill:url(#linearGradient4237);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:#ffd42a;fill-opacity:1;stroke:#000000;stroke-width:0.25;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 32.214202,1016.106 a 7.4506458,3.4338133 0 0 0 -7.450762,3.4339 7.4506458,3.4338133 0 0 0 7.450762,3.4339 7.4506458,3.4338133 0 0 0 7.450762,-3.4339 7.4506458,3.4338133 0 0 0 -7.450762,-3.4339 z m -0.01152,1.0849 a 6.5067731,2.6483539 0 0 1 6.507152,2.649 6.5067731,2.6483539 0 0 1 -6.507152,2.6491 6.5067731,2.6483539 0 0 1 -6.507151,-2.6491 6.5067731,2.6483539 0 0 1 6.507151,-2.649 z"
+       id="path4239"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 39.266526,1019.0729 c -0.266839,-0.5619 -0.722066,-1.0475 -1.304939,-1.4617 -0.539172,-0.2974 -1.152492,-0.5281 -1.792365,-0.7063 -1.37407,-0.3828 -2.898004,-0.5311 -4.128444,-0.561 1.230387,0.1107 2.729015,0.3393 4.056916,0.7922 0.617443,0.2107 1.192471,0.468 1.683337,0.7805 0.600142,0.287 1.121206,0.6619 1.485495,1.1563 z"
+       id="path4256"
+       inkscape:path-effect="#path-effect4258"
+       inkscape:original-d="m 39.266526,1019.0729 c -1.181585,-1.9749 -4.764681,-2.5885 -7.225748,-2.729"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:type="star"
+       style="opacity:1;fill:#f9f9f9;fill-opacity:1;stroke:#808080;stroke-width:0.03384197;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="path4244"
+       sodipodi:sides="8"
+       sodipodi:cx="28.383711"
+       sodipodi:cy="1024.8624"
+       sodipodi:r1="1.8708614"
+       sodipodi:r2="0.29933783"
+       sodipodi:arg1="-0.84807746"
+       sodipodi:arg2="-0.45537838"
+       inkscape:flatsided="false"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="m 29.621148,1023.4593 -0.968603,1.2715 1.598353,0.014 -1.584003,0.2142 1.119981,1.1405 -1.271516,-0.9686 -0.01446,1.5983 -0.214191,-1.584 -1.140433,1.12 0.968603,-1.2715 -1.598354,-0.014 1.584004,-0.2142 -1.119981,-1.1404 1.271515,0.9686 0.01446,-1.5984 0.214192,1.584 z"
+       transform="matrix(1.3710615,0.5505133,-0.5505133,1.3710615,562.22959,-403.56449)" />
+  </g>
+</svg>

--- a/src/com/lilithsthrone/res/moves/block.svg
+++ b/src/com/lilithsthrone/res/moves/block.svg
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 256 256"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="protective_gusts.svg">
+  <defs
+     id="defs4">
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152"
+       effect="powerstroke" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4154"
+       is_visible="true"
+       offset_points="0,0.5"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4150"
+       is_visible="true"
+       offset_points="0,0.5"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-7"
+       is_visible="true"
+       offset_points="0.34983355,5.1754019"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-0"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-1"
+       is_visible="true"
+       offset_points="0.24778369,14.766099"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-3"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152-6"
+       effect="powerstroke" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-7"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152-9"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="156.90361"
+     inkscape:cy="126.3907"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1388"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:inline">
+    <path
+       style="display:inline;fill:#759fdf;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 71.822816,127.73471 c -41.401329,52.2808 84.889704,51.0925 106.129904,23.20508 C 144.2296,175.83035 44.502801,166.8755 71.822816,127.73471 Z"
+       id="path4239-5-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <g
+       id="g4167"
+       transform="matrix(0.88209,0,0,0.88209,14.296305,-32.279466)">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4141"
+         d="M 128.52731,218.53777 C 90.748011,182.60591 62.607307,135.94033 63.05821,77.513066 c 9.021735,-0.131244 41.3765,-15.701957 65.23787,-33.582981 25.31048,17.458335 55.8296,32.07682 64.36495,32.814922 0.11707,58.822423 -26.40068,103.210643 -64.13372,141.792763 z"
+         style="fill:#a0b9df;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.85311675px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4163-2-4"
+         d="m 130.96787,48.291502 c 27.39433,15.932802 32.42856,21.99499 59.47264,30.787925 C 164.00137,76.31761 149.74374,67.99718 130.96787,48.291502 Z"
+         style="display:inline;fill:#c0d0e9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path4163-2-4-1"
+         d="M 63.682486,78.242893 C 74.250031,75.536427 109.89898,57.312857 128.14065,44.560595 127.98727,75.237705 129.80869,161.01495 128.73348,219.46247 70.031687,157.87509 63.524303,108.32616 63.682486,78.242893 Z"
+         style="display:inline;fill:#759fdf;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <path
+       style="display:inline;fill:#a0b9df;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 183.89934,133.46713 c 49.62435,43.49491 -74.79308,66.50519 -100.433463,43.14272 37.407713,18.02496 133.970193,-9.8759 100.433463,-43.14272 z"
+       id="path4239-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;fill:#a0b9df;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 72.346564,179.54438 C 59.011295,211.09917 159.47115,211.47731 177.19515,192.07467 149.05473,209.39224 74.928208,200.75216 72.346564,179.54438 Z"
+       id="path4239-5-6-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;fill:#759fdf;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 181.03404,197.86389 c 11.85888,29.58106 -77.47887,29.93555 -93.240584,11.74652 25.024924,16.23436 90.944754,8.13472 93.240584,-11.74652 z"
+       id="path4239-5-6-3-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;fill:#a0b9df;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 88.710951,220.0309 c -7.964613,20.19586 52.035989,20.43787 62.621809,8.01968 -16.80713,11.08369 -61.079889,5.55384 -62.621809,-8.01968 z"
+       id="path4239-5-6-3-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;fill:#c0d0e9;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 153.62558,231.75583 c 7.08283,18.93262 -46.275,19.15949 -55.688817,7.51808 14.946367,10.3904 54.317617,5.20641 55.688817,-7.51808 z"
+       id="path4239-5-6-3-2-0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+  </g>
+</svg>

--- a/src/com/lilithsthrone/res/moves/hoof-kick.svg
+++ b/src/com/lilithsthrone/res/moves/hoof-kick.svg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 256 256"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="biteIcon.svg">
+  <defs
+     id="defs4">
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152"
+       effect="powerstroke" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4154"
+       is_visible="true"
+       offset_points="0,0.5"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4150"
+       is_visible="true"
+       offset_points="0,0.5"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-7"
+       is_visible="true"
+       offset_points="0.34983355,5.1754019"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-0"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-1"
+       is_visible="true"
+       offset_points="0.24778369,14.766099"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-3"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152-6"
+       effect="powerstroke" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-7"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152-9"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="143.48794"
+     inkscape:cy="108.1677"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1388"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:inline">
+    <g
+       id="g4440"
+       transform="matrix(1.157625,0,0,1.157625,-21.739236,-19.549663)"
+       style="fill:#f4eed7">
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223"
+         d="m 60.703775,45.288342 c -33.19872,1.087359 -14.36093,99.290618 -6.92096,99.270398 1.53071,-0.004 7.79794,-26.5825 13.68847,-49.341325 4.12026,-15.919165 9.69997,-30.375287 9.66106,-33.054073 -0.12193,-8.395163 -8.61805,-17.130818 -16.42857,-16.875 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225"
+         d="m 82.578775,45.556199 c -3.54633,1.98246 3.60864,31.630863 6.60714,31.607143 3.27599,-0.02591 9.50469,-8.864483 9.55357,-12.5 0.11214,-8.340918 -10.73547,-22.139949 -16.16071,-19.107143 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0"
+         d="m 106.31876,76.301922 c -3.79093,0.273113 -4.81548,-18.98031 3.11331,-19.448458 2.19463,-0.12958 5.03217,2.66642 4.80471,4.893446 -0.42582,4.169136 -3.63386,14.246366 -7.91802,14.555012 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3"
+         d="m 122.174,73.348679 c -3.77499,0.552924 -6.18204,-15.643724 1.7208,-16.712998 2.18744,-0.295967 5.22834,1.827789 5.16047,3.730621 -0.12708,3.562225 -2.61513,12.357516 -6.88127,12.982377 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223-4"
+         d="m 201.53644,45.302345 c 33.19872,1.087359 14.36093,99.290615 6.92096,99.270395 -1.53071,-0.004 -7.79794,-26.5825 -13.68847,-49.341322 -4.12026,-15.919165 -9.69997,-30.375287 -9.66106,-33.054073 0.12193,-8.395163 8.61805,-17.130818 16.42857,-16.875 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-7"
+         d="m 179.66144,45.570202 c 3.54633,1.98246 -3.60864,31.630863 -6.60714,31.607143 -3.27599,-0.02591 -9.50469,-8.864483 -9.55357,-12.5 -0.11214,-8.340918 10.73547,-22.139949 16.16071,-19.107143 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-0"
+         d="m 155.92146,76.315925 c 3.79093,0.273113 4.81548,-18.98031 -3.11331,-19.448458 -2.19463,-0.12958 -5.03217,2.66642 -4.80471,4.893446 0.42582,4.169136 3.63386,14.246366 7.91802,14.555012 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3-7"
+         d="m 140.06622,73.362682 c 3.77499,0.552924 6.18204,-15.643724 -1.7208,-16.712998 -2.18744,-0.295967 -5.22834,1.827789 -5.16047,3.730621 0.12708,3.562225 2.61513,12.357516 6.88127,12.982377 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223-4-8"
+         d="m 82.869865,216.08642 c -24.40411,-0.79931 -26.09231,-57.71987 -14.64111,-63.68714 0.99787,-0.51999 5.01793,12.39772 13.81229,27.87755 5.97091,10.50998 11.72859,22.23933 11.69998,24.20849 -0.0896,6.17121 -5.12971,11.78915 -10.87116,11.6011 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-7-4"
+         d="m 104.46612,185.88878 c 2.98633,0.0367 9.21085,25.98498 2.71194,27.42326 -2.35134,0.52038 -5.72273,-3.82089 -7.02959,-6.15228 -2.998275,-5.34888 -0.250895,-21.32707 4.31765,-21.27098 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-0-9"
+         d="m 115.0618,195.74395 c -2.16169,0.46888 -3.58447,14.93441 2.24392,15.27855 1.61325,0.0953 3.07291,-1.88219 2.81762,-3.50785 -0.31302,-1.99327 -1.97588,-12.44 -5.06154,-11.7707 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3-7-3"
+         d="m 125.15435,199.61129 c -2.77496,-0.40645 -4.54436,11.49957 1.26495,12.28559 1.60797,0.21756 2.95045,-1.38824 2.90056,-2.78699 -0.0934,-2.61857 -1.0295,-9.03927 -4.16551,-9.4986 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223-4-8-9"
+         d="m 179.79721,216.51119 c 24.40411,-0.79931 26.09231,-57.71987 14.64111,-63.68714 -0.99787,-0.51999 -5.01793,12.39772 -13.81229,27.87755 -5.97091,10.50998 -11.72859,22.23933 -11.69998,24.20849 0.0896,6.17121 5.12971,11.78915 10.87116,11.6011 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-7-4-4"
+         d="m 158.20096,186.31355 c -2.98633,0.0367 -9.21085,25.98498 -2.71194,27.42326 2.35134,0.52038 5.72273,-3.82089 7.02959,-6.15228 2.99827,-5.34888 0.25089,-21.32707 -4.31765,-21.27098 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-0-9-0"
+         d="m 147.60528,196.16872 c 2.16169,0.46888 3.58447,14.93441 -2.24392,15.27855 -1.61325,0.0953 -3.07291,-1.88219 -2.81762,-3.50785 0.31302,-1.99327 1.97588,-12.44 5.06154,-11.7707 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3-7-3-3"
+         d="m 137.51273,200.03606 c 2.77496,-0.40645 4.54436,11.49957 -1.26495,12.28559 -1.60797,0.21756 -2.95045,-1.38824 -2.90056,-2.78699 0.0934,-2.61857 1.0295,-9.03927 4.16551,-9.4986 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/com/lilithsthrone/res/moves/strike.svg
+++ b/src/com/lilithsthrone/res/moves/strike.svg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 256 256"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="biteIcon.svg">
+  <defs
+     id="defs4">
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152"
+       effect="powerstroke" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4154"
+       is_visible="true"
+       offset_points="0,0.5"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4150"
+       is_visible="true"
+       offset_points="0,0.5"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-7"
+       is_visible="true"
+       offset_points="0.34983355,5.1754019"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-0"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-1"
+       is_visible="true"
+       offset_points="0.24778369,14.766099"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-3"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152-6"
+       effect="powerstroke" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-7"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152-9"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="143.48794"
+     inkscape:cy="108.1677"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1388"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:inline">
+    <g
+       id="g4440"
+       transform="matrix(1.157625,0,0,1.157625,-21.739236,-19.549663)"
+       style="fill:#f4eed7">
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223"
+         d="m 60.703775,45.288342 c -33.19872,1.087359 -14.36093,99.290618 -6.92096,99.270398 1.53071,-0.004 7.79794,-26.5825 13.68847,-49.341325 4.12026,-15.919165 9.69997,-30.375287 9.66106,-33.054073 -0.12193,-8.395163 -8.61805,-17.130818 -16.42857,-16.875 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225"
+         d="m 82.578775,45.556199 c -3.54633,1.98246 3.60864,31.630863 6.60714,31.607143 3.27599,-0.02591 9.50469,-8.864483 9.55357,-12.5 0.11214,-8.340918 -10.73547,-22.139949 -16.16071,-19.107143 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0"
+         d="m 106.31876,76.301922 c -3.79093,0.273113 -4.81548,-18.98031 3.11331,-19.448458 2.19463,-0.12958 5.03217,2.66642 4.80471,4.893446 -0.42582,4.169136 -3.63386,14.246366 -7.91802,14.555012 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3"
+         d="m 122.174,73.348679 c -3.77499,0.552924 -6.18204,-15.643724 1.7208,-16.712998 2.18744,-0.295967 5.22834,1.827789 5.16047,3.730621 -0.12708,3.562225 -2.61513,12.357516 -6.88127,12.982377 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223-4"
+         d="m 201.53644,45.302345 c 33.19872,1.087359 14.36093,99.290615 6.92096,99.270395 -1.53071,-0.004 -7.79794,-26.5825 -13.68847,-49.341322 -4.12026,-15.919165 -9.69997,-30.375287 -9.66106,-33.054073 0.12193,-8.395163 8.61805,-17.130818 16.42857,-16.875 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-7"
+         d="m 179.66144,45.570202 c 3.54633,1.98246 -3.60864,31.630863 -6.60714,31.607143 -3.27599,-0.02591 -9.50469,-8.864483 -9.55357,-12.5 -0.11214,-8.340918 10.73547,-22.139949 16.16071,-19.107143 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-0"
+         d="m 155.92146,76.315925 c 3.79093,0.273113 4.81548,-18.98031 -3.11331,-19.448458 -2.19463,-0.12958 -5.03217,2.66642 -4.80471,4.893446 0.42582,4.169136 3.63386,14.246366 7.91802,14.555012 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3-7"
+         d="m 140.06622,73.362682 c 3.77499,0.552924 6.18204,-15.643724 -1.7208,-16.712998 -2.18744,-0.295967 -5.22834,1.827789 -5.16047,3.730621 0.12708,3.562225 2.61513,12.357516 6.88127,12.982377 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223-4-8"
+         d="m 82.869865,216.08642 c -24.40411,-0.79931 -26.09231,-57.71987 -14.64111,-63.68714 0.99787,-0.51999 5.01793,12.39772 13.81229,27.87755 5.97091,10.50998 11.72859,22.23933 11.69998,24.20849 -0.0896,6.17121 -5.12971,11.78915 -10.87116,11.6011 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-7-4"
+         d="m 104.46612,185.88878 c 2.98633,0.0367 9.21085,25.98498 2.71194,27.42326 -2.35134,0.52038 -5.72273,-3.82089 -7.02959,-6.15228 -2.998275,-5.34888 -0.250895,-21.32707 4.31765,-21.27098 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-0-9"
+         d="m 115.0618,195.74395 c -2.16169,0.46888 -3.58447,14.93441 2.24392,15.27855 1.61325,0.0953 3.07291,-1.88219 2.81762,-3.50785 -0.31302,-1.99327 -1.97588,-12.44 -5.06154,-11.7707 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3-7-3"
+         d="m 125.15435,199.61129 c -2.77496,-0.40645 -4.54436,11.49957 1.26495,12.28559 1.60797,0.21756 2.95045,-1.38824 2.90056,-2.78699 -0.0934,-2.61857 -1.0295,-9.03927 -4.16551,-9.4986 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223-4-8-9"
+         d="m 179.79721,216.51119 c 24.40411,-0.79931 26.09231,-57.71987 14.64111,-63.68714 -0.99787,-0.51999 -5.01793,12.39772 -13.81229,27.87755 -5.97091,10.50998 -11.72859,22.23933 -11.69998,24.20849 0.0896,6.17121 5.12971,11.78915 10.87116,11.6011 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-7-4-4"
+         d="m 158.20096,186.31355 c -2.98633,0.0367 -9.21085,25.98498 -2.71194,27.42326 2.35134,0.52038 5.72273,-3.82089 7.02959,-6.15228 2.99827,-5.34888 0.25089,-21.32707 -4.31765,-21.27098 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-0-9-0"
+         d="m 147.60528,196.16872 c 2.16169,0.46888 3.58447,14.93441 -2.24392,15.27855 -1.61325,0.0953 -3.07291,-1.88219 -2.81762,-3.50785 0.31302,-1.99327 1.97588,-12.44 5.06154,-11.7707 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3-7-3-3"
+         d="m 137.51273,200.03606 c 2.77496,-0.40645 4.54436,11.49957 -1.26495,12.28559 -1.60797,0.21756 -2.95045,-1.38824 -2.90056,-2.78699 0.0934,-2.61857 1.0295,-9.03927 4.16551,-9.4986 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/com/lilithsthrone/res/moves/tease.svg
+++ b/src/com/lilithsthrone/res/moves/tease.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="100%"
+   height="100%"
+   viewBox="0 0 64.000001 64.000001"
+   id="svg4311"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="attArousal2.svg">
+  <defs
+     id="defs4313">
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4154"
+       is_visible="true"
+       offset_points="0.54375131,-0.69077239"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4154-8"
+       is_visible="true"
+       offset_points="0.54375131,-0.3626555"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4154-8-7"
+       is_visible="true"
+       offset_points="0.54375131,-0.29835758"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9999996"
+     inkscape:cx="42.208745"
+     inkscape:cy="28.559993"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1388"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata4316">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-988.36216)"
+     style="display:inline">
+    <path
+       style="fill:#ff80e5;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 16.533895,1017.5855 c -0.01549,-9.4997 12.837476,-10.0685 15.730134,-4.4381 2.364678,-5.7382 15.764603,-5.8808 15.727417,4.55 -0.0267,7.4908 -13.006051,11.0306 -15.599133,17.1173 -2.952548,-6.1881 -15.845725,-9.4478 -15.858418,-17.2292 z"
+       id="path4859"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scscs" />
+    <path
+       style="fill:#ffffff;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 38.598437,1010.8406 c 2.090929,-0.7465 4.561138,-0.1726 6.481313,1.5717 1.282522,1.7373 1.9161,4.0006 1.632433,6.4235 -0.176623,-2.4444 -1.275147,-4.3298 -2.657206,-5.4891 -1.258216,-1.7031 -3.274367,-2.8004 -5.45654,-2.5061 z"
+       id="path4152"
+       inkscape:path-effect="#path-effect4154"
+       inkscape:original-d="m 38.598437,1010.8406 c 3.925585,-0.9544 8.232194,2.6628 8.113746,7.9952"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/src/com/lilithsthrone/res/moves/twin-strike.svg
+++ b/src/com/lilithsthrone/res/moves/twin-strike.svg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 256 256"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="biteIcon.svg">
+  <defs
+     id="defs4">
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152"
+       effect="powerstroke" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4154"
+       is_visible="true"
+       offset_points="0,0.5"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4150"
+       is_visible="true"
+       offset_points="0,0.5"
+       sort_points="true"
+       interpolator_type="CubicBezierJohan"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-7"
+       is_visible="true"
+       offset_points="0.34983355,5.1754019"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4"
+       is_visible="true"
+       offset_points="0.34598408,6.7401315"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-0"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-1"
+       is_visible="true"
+       offset_points="0.24778369,14.766099"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-3"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152-6"
+       effect="powerstroke" />
+    <inkscape:path-effect
+       effect="powerstroke"
+       id="path-effect4146-2-4-1-7"
+       is_visible="true"
+       offset_points="0.25601354,11.696941"
+       sort_points="true"
+       interpolator_type="Linear"
+       interpolator_beta="0.2"
+       start_linecap_type="zerowidth"
+       linejoin_type="round"
+       miter_limit="4"
+       end_linecap_type="zerowidth"
+       cusp_linecap_type="round" />
+    <inkscape:path-effect
+       cusp_linecap_type="round"
+       end_linecap_type="zerowidth"
+       miter_limit="4"
+       linejoin_type="round"
+       start_linecap_type="zerowidth"
+       interpolator_beta="0.2"
+       interpolator_type="Linear"
+       sort_points="true"
+       offset_points="0.25601354,8.1684104"
+       is_visible="true"
+       id="path-effect4152-9"
+       effect="powerstroke" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="143.48794"
+     inkscape:cy="108.1677"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1388"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer 2"
+     style="display:inline">
+    <g
+       id="g4440"
+       transform="matrix(1.157625,0,0,1.157625,-21.739236,-19.549663)"
+       style="fill:#f4eed7">
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223"
+         d="m 60.703775,45.288342 c -33.19872,1.087359 -14.36093,99.290618 -6.92096,99.270398 1.53071,-0.004 7.79794,-26.5825 13.68847,-49.341325 4.12026,-15.919165 9.69997,-30.375287 9.66106,-33.054073 -0.12193,-8.395163 -8.61805,-17.130818 -16.42857,-16.875 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225"
+         d="m 82.578775,45.556199 c -3.54633,1.98246 3.60864,31.630863 6.60714,31.607143 3.27599,-0.02591 9.50469,-8.864483 9.55357,-12.5 0.11214,-8.340918 -10.73547,-22.139949 -16.16071,-19.107143 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0"
+         d="m 106.31876,76.301922 c -3.79093,0.273113 -4.81548,-18.98031 3.11331,-19.448458 2.19463,-0.12958 5.03217,2.66642 4.80471,4.893446 -0.42582,4.169136 -3.63386,14.246366 -7.91802,14.555012 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3"
+         d="m 122.174,73.348679 c -3.77499,0.552924 -6.18204,-15.643724 1.7208,-16.712998 2.18744,-0.295967 5.22834,1.827789 5.16047,3.730621 -0.12708,3.562225 -2.61513,12.357516 -6.88127,12.982377 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223-4"
+         d="m 201.53644,45.302345 c 33.19872,1.087359 14.36093,99.290615 6.92096,99.270395 -1.53071,-0.004 -7.79794,-26.5825 -13.68847,-49.341322 -4.12026,-15.919165 -9.69997,-30.375287 -9.66106,-33.054073 0.12193,-8.395163 8.61805,-17.130818 16.42857,-16.875 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-7"
+         d="m 179.66144,45.570202 c 3.54633,1.98246 -3.60864,31.630863 -6.60714,31.607143 -3.27599,-0.02591 -9.50469,-8.864483 -9.55357,-12.5 -0.11214,-8.340918 10.73547,-22.139949 16.16071,-19.107143 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-0"
+         d="m 155.92146,76.315925 c 3.79093,0.273113 4.81548,-18.98031 -3.11331,-19.448458 -2.19463,-0.12958 -5.03217,2.66642 -4.80471,4.893446 0.42582,4.169136 3.63386,14.246366 7.91802,14.555012 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3-7"
+         d="m 140.06622,73.362682 c 3.77499,0.552924 6.18204,-15.643724 -1.7208,-16.712998 -2.18744,-0.295967 -5.22834,1.827789 -5.16047,3.730621 0.12708,3.562225 2.61513,12.357516 6.88127,12.982377 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223-4-8"
+         d="m 82.869865,216.08642 c -24.40411,-0.79931 -26.09231,-57.71987 -14.64111,-63.68714 0.99787,-0.51999 5.01793,12.39772 13.81229,27.87755 5.97091,10.50998 11.72859,22.23933 11.69998,24.20849 -0.0896,6.17121 -5.12971,11.78915 -10.87116,11.6011 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-7-4"
+         d="m 104.46612,185.88878 c 2.98633,0.0367 9.21085,25.98498 2.71194,27.42326 -2.35134,0.52038 -5.72273,-3.82089 -7.02959,-6.15228 -2.998275,-5.34888 -0.250895,-21.32707 4.31765,-21.27098 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-0-9"
+         d="m 115.0618,195.74395 c -2.16169,0.46888 -3.58447,14.93441 2.24392,15.27855 1.61325,0.0953 3.07291,-1.88219 2.81762,-3.50785 -0.31302,-1.99327 -1.97588,-12.44 -5.06154,-11.7707 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3-7-3"
+         d="m 125.15435,199.61129 c -2.77496,-0.40645 -4.54436,11.49957 1.26495,12.28559 1.60797,0.21756 2.95045,-1.38824 2.90056,-2.78699 -0.0934,-2.61857 -1.0295,-9.03927 -4.16551,-9.4986 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssss"
+         inkscape:connector-curvature="0"
+         id="path4223-4-8-9"
+         d="m 179.79721,216.51119 c 24.40411,-0.79931 26.09231,-57.71987 14.64111,-63.68714 -0.99787,-0.51999 -5.01793,12.39772 -13.81229,27.87755 -5.97091,10.50998 -11.72859,22.23933 -11.69998,24.20849 0.0896,6.17121 5.12971,11.78915 10.87116,11.6011 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-7-4-4"
+         d="m 158.20096,186.31355 c -2.98633,0.0367 -9.21085,25.98498 -2.71194,27.42326 2.35134,0.52038 5.72273,-3.82089 7.02959,-6.15228 2.99827,-5.34888 0.25089,-21.32707 -4.31765,-21.27098 z"
+         style="fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-0-9-0"
+         d="m 147.60528,196.16872 c 2.16169,0.46888 3.58447,14.93441 -2.24392,15.27855 -1.61325,0.0953 -3.07291,-1.88219 -2.81762,-3.50785 0.31302,-1.99327 1.97588,-12.44 5.06154,-11.7707 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ssss"
+         inkscape:connector-curvature="0"
+         id="path4225-0-3-7-3-3"
+         d="m 137.51273,200.03606 c 2.77496,-0.40645 4.54436,11.49957 -1.26495,12.28559 -1.60797,0.21756 -2.95045,-1.38824 -2.90056,-2.78699 0.0934,-2.61857 1.0295,-9.03927 4.16551,-9.4986 z"
+         style="display:inline;fill:#f4eed7;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/com/lilithsthrone/utils/Colour.java
+++ b/src/com/lilithsthrone/utils/Colour.java
@@ -86,6 +86,7 @@ public enum Colour {
 	GENERIC_ATTRIBUTE(false, BaseColour.MAGENTA, "magenta"),
 	GENERIC_EXPERIENCE(false, BaseColour.BLUE_LIGHT, "light blue", Util.newArrayListOfValues("experience", "xp")),
 	COOLDOWN(false, BaseColour.CRIMSON, "crimson", Util.newArrayListOfValues("cooldown")),
+	CRIT(false, BaseColour.GOLD, "gold", Util.newArrayListOfValues("crit")),
 
 	SCAR(false, BaseColour.TAN, "tan"),
 	TATTOO(false, BaseColour.GREY, "grey"),


### PR DESCRIPTION
Purpose:
* Implement the changes to combat outlined previously

Changes:
* Complete overhaul of combat loop
* Turn based system changed to AP based turn system
* Able to see intents of enemies in combat
* Abilities available to any character in combat are limited to maximum of 8 - respective menu added to phone to assign abilities
* Combat AI is a little smarter now, although improvements can be made
* As a result of the complete overhaul of the abilities, racial moves are not available in full yet.
* Spells are not balanced for this system  either.
* HP formula changed to avoid physique playing a major role in it. Might change the calculations again later, however.
* Mana formula changed to overally bring the amount of mana to 100-120 average values.
* A massive overhaul to unarmed weapons 
* Deprecated special tease attacks
* Deprecated percentage based protection - use blocks instead.
* Did not enable ranged/melee specific damage adjustments yet. Might deprecate.
* Added functionality to calculate damages and resistances to DamageType class to avoid it sitting in Attack class as Attack class will be deprecated soon.
* Added blocking system

Graphical Assets:
* Placeholder images can be replaced with better ones for the moves

Tested:
* 0.2.10.5
* While I tried to test the system, an overhaul of this scale can end up with issues.

Discord handle:
* Irbynx
