### PR TITLE
minor bugfix

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/places/dominion/CityPlaces.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/CityPlaces.java
@@ -823,8 +823,8 @@ public class CityPlaces {
 						+ "<b style='color:"+Colour.RACE_HARPY.toWebHexString()+";'>Harpy Nests:</b><br/>"
 						+ "The wooden platforms and bridges of the rooftop Harpy Nests cast a shadow over these streets."
 						+ " Looking up, you see the occasional flash of brightly-coloured feathers as harpies swoop this way and that."
-					+ "</p>"
-					+ getExtraStreetFeatures();
+					+ "</p>";
+					//+ getExtraStreetFeatures();		//unneeded - this gets called in STREET.getContent()
 		}
 
 		@Override


### PR DESCRIPTION
Bugfix for
https://github.com/Innoxia/liliths-throne-public/issues/932
Character text no longer called twice for Harpy Nests.

tested with 1 npc in the harpy nests, 1 npc outside of harpy nests. Doesn't seem to break anything.