### PR TITLE
Fix for imageEquippedName

### DIFF
--- a/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
+++ b/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
@@ -397,7 +397,8 @@ public abstract class AbstractClothingType extends AbstractCoreType {
 
 			this.pathNameEquipped = coreAttributes.getOptionalFirstOf("imageEquippedName")
 				.filter(filterEmptyElements)
-				.map(Element::getTextContent)
+				.map(e -> clothingXMLFile.getParentFile().getAbsolutePath() + "/" + e.getTextContent())
+				.filter(s -> !s.equals(this.pathName)) // if imageEquippedName is the same as imageName, we don't need to load it twice
 				.orElse(null);
 
 			Function< Element, List<Colour> > getColoursFromElement = (colorsElement) -> { //Helper function to get the colors depending on if it's a specified group or a list of individual colors


### PR DESCRIPTION
The path portion of imageEquippedName was left out. Also, don't
have two separate image entries if imageName and imageEquippedName
are the same.

As mentioned by Kobolds here: https://discordapp.com/channels/302617912949211136/446038411791433729/521647452139290624

Tested on version: 0.2.12.96
Discord handle: CognitiveMist|Phlarx