### PR TITLE
nightclubNPCs now always use their own location

### DIFF
--- a/src/com/lilithsthrone/game/character/PlayerCharacter.java
+++ b/src/com/lilithsthrone/game/character/PlayerCharacter.java
@@ -390,16 +390,12 @@ public class PlayerCharacter extends GameCharacter implements XMLSaving {
 		if(this.getWorldLocation()==WorldType.NIGHTLIFE_CLUB) {
 			List<GameCharacter> clubbers = new ArrayList<>(Main.game.getNonCompanionCharactersPresent());
 			clubbers.removeIf((npc) -> !(npc instanceof DominionClubNPC));
-			
-			WorldType worldLocationInitial = this.getWorldLocation();
-			Vector2i locationInitial = this.getLocation();
+
 			
 			super.setLocation(worldLocation, location, setAsHomeLocation);
 			
 			for(GameCharacter clubber : clubbers) {
 				clubber.setLocation(this, false);
-				// TODO Why is this needed? I can't figure out why IDs are not being removed without this line:
-				Main.game.getWorlds().get(worldLocationInitial).getCell(locationInitial).removeCharacterPresentId(clubber.getId());
 			}
 			
 		} else {

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionClubNPC.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionClubNPC.java
@@ -124,10 +124,6 @@ public class DominionClubNPC extends NPC {
 	
 	@Override
 	public Vector2i getLocation() {
-		if(this.getWorldLocation()==WorldType.NIGHTLIFE_CLUB
-				&& Main.game.getPlayer().getWorldLocation()==WorldType.NIGHTLIFE_CLUB) {
-			return Main.game.getPlayer().getLocation();
-		}
 		return location;
 	}
 	


### PR DESCRIPTION
### Things to include in a large Pull Request:

- What is the purpose of the pull request?

Fix two bugs involving the generic nightclub NPCs:
  1.Dom NPCs causing "IndexOutOfBounds" exceptions
  2.Sub NPCs not leaving their current cell when moving to a new cell

- Give a brief description of what you changed or added.

In the current version(0.2.12.96) dom NPCs will crash the game and sub NPCs don't remove their ID from their current cell when moving to a new one, this is technically already fixed in the current version however that fix is also the cause for bug # 1 above. This PR fixes both bugs. 
- Are any new graphical assets required?
No
- Has this change been tested? If so, mention the version number that the test was based on.
tested on 0.2.12.96 master branch 
- So we have a better idea of who you are, what is your Discord Handle?
Alaco on Discord
- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
