### PR TITLE
Fix for perk point weirdness

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -685,7 +685,7 @@ public abstract class GameCharacter implements XMLSaving {
 		
 
 		CharacterUtils.createXMLElementWithValue(doc, characterCoreInfo, "experience", String.valueOf(this.getExperience()));
-		CharacterUtils.createXMLElementWithValue(doc, characterCoreInfo, "perkPoints", String.valueOf(this.getPerkPoints()));
+		CharacterUtils.createXMLElementWithValue(doc, characterCoreInfo, "perkPoints", String.valueOf(this.getAdditionalPerkPoints()));
 
 		CharacterUtils.createXMLElementWithValue(doc, characterCoreInfo, "health", String.valueOf(this.getHealth()));
 		CharacterUtils.createXMLElementWithValue(doc, characterCoreInfo, "mana", String.valueOf(this.getMana()));
@@ -4478,11 +4478,6 @@ public abstract class GameCharacter implements XMLSaving {
 			experience -= getExperienceNeededForNextLevel();
 
 			level++;
-
-			incrementPerkPoints(1);
-			if(level%5==0) {
-				perkPoints+=2;
-			}
 		}
 		if (getLevel() == LEVEL_CAP) {
 			experience = 0;

--- a/src/com/lilithsthrone/main/Main.java
+++ b/src/com/lilithsthrone/main/Main.java
@@ -90,13 +90,13 @@ public class Main extends Application {
 			
 		+ "<p>"
 			+ "Once again I'm sorry for the delay on this; there was a significant amount of lore that I had to go over and check before adding Lyssieth's content, which I hadn't properly looked at since around v0.1."
-			+ " That took quite a lot of time, as did actually writing the Lyssieth quest resolution dialogue (sorry that it's a big info dump - I already cut it back once, and strugled to edit it any smaller)."
+			+ " That took quite a lot of time, as did actually writing the Lyssieth quest resolution dialogue (sorry that it's a big info dump - I already cut it back once, and struggled to edit it any smaller)."
 			+ " I also had to make quite a few changes to the code in order to get the demon subspecies working, so, in all, there was far more work to do than I originally planned for."
 		+ "</p>"
 			
 		+ "<p>"
 			+ "While there is a world map in this (which you see after completing Lyssieth's section of the main quest), you cna't travel to the fields just yet, as I simply ran out of time in which to add content for it."
-			+ " There are also some palceholders in Lyssieth's palace, and Lilaya's reactions to your demon transformation are missing."
+			+ " There are also some placeholders in Lyssieth's palace, and Lilaya's reactions to your demon transformation are missing."
 			+ " All of that will make it into v0.3.1, along with bug fixes and other things."
 		+ "</p>"
 			


### PR DESCRIPTION
No longer given additional perk points on level up, instead relying on the getPerkPointsAtLevel function added in 0.3. This means that gameCharacters should no longer receive double perk points on level up.

Now saving perk point value using getAdditionalPerkPoints instead of getPerkPoints, as this saves the value that the load function is expecting. This means that the perk point value will no longer change on save/load (this was causing negative perk points, but it could also cause absurdly inflated perk points)

Tested with a fresh character on version 0.3:
Perk points were at the value expected for each level, and we unaffected by saving or loading.