### PR TITLE
Custom pregnancy duration

### DIFF
--- a/src/com/lilithsthrone/controller/MainControllerInitMethod.java
+++ b/src/com/lilithsthrone/controller/MainControllerInitMethod.java
@@ -18,6 +18,7 @@ import com.lilithsthrone.game.Game;
 import com.lilithsthrone.game.PropertyValue;
 import com.lilithsthrone.game.character.FluidStored;
 import com.lilithsthrone.game.character.GameCharacter;
+import com.lilithsthrone.game.character.PregnancyPossibility;
 import com.lilithsthrone.game.character.body.Arm;
 import com.lilithsthrone.game.character.body.Breast;
 import com.lilithsthrone.game.character.body.CoverableArea;
@@ -4971,6 +4972,39 @@ public class MainControllerInitMethod {
 			if (((EventTarget) MainController.document.getElementById(id)) != null) {
 				((EventTarget) MainController.document.getElementById(id)).addEventListener("click", e -> {
 					Main.getProperties().pregnancyLactationLimit = Math.max(0, Main.getProperties().pregnancyLactationLimit-250);
+					Main.saveProperties();
+					Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+				}, false);
+			}
+			
+			id = "PREGNANCY_TIME_ON_HUNDRED";
+			if (((EventTarget) MainController.document.getElementById(id)) != null) {
+				((EventTarget) MainController.document.getElementById(id)).addEventListener("click", e -> {
+					Main.getProperties().pregnancyTimeHours = Math.min(PregnancyPossibility.PREGNANCY_TIME_HOURS_MAX, Main.getProperties().pregnancyTimeHours + 100);
+					Main.saveProperties();
+					Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+				}, false);
+			}
+			id = "PREGNANCY_TIME_ON";
+			if (((EventTarget) MainController.document.getElementById(id)) != null) {
+				((EventTarget) MainController.document.getElementById(id)).addEventListener("click", e -> {
+					Main.getProperties().pregnancyTimeHours = Math.min(PregnancyPossibility.PREGNANCY_TIME_HOURS_MAX, Main.getProperties().pregnancyTimeHours + 10);
+					Main.saveProperties();
+					Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+				}, false);
+			}
+			id = "PREGNANCY_TIME_OFF";
+			if (((EventTarget) MainController.document.getElementById(id)) != null) {
+				((EventTarget) MainController.document.getElementById(id)).addEventListener("click", e -> {
+					Main.getProperties().pregnancyTimeHours = Math.max(PregnancyPossibility.PREGNANCY_TIME_HOURS_MIN, Main.getProperties().pregnancyTimeHours - 10);
+					Main.saveProperties();
+					Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+				}, false);
+			}
+			id = "PREGNANCY_TIME_OFF_HUNDRED";
+			if (((EventTarget) MainController.document.getElementById(id)) != null) {
+				((EventTarget) MainController.document.getElementById(id)).addEventListener("click", e -> {
+					Main.getProperties().pregnancyTimeHours = Math.max(PregnancyPossibility.PREGNANCY_TIME_HOURS_MIN, Main.getProperties().pregnancyTimeHours - 100);
 					Main.saveProperties();
 					Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
 				}, false);

--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -23,6 +23,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import com.lilithsthrone.game.character.CharacterUtils;
+import com.lilithsthrone.game.character.PregnancyPossibility;
 import com.lilithsthrone.game.character.body.valueEnums.AgeCategory;
 import com.lilithsthrone.game.character.body.valueEnums.CupSize;
 import com.lilithsthrone.game.character.gender.AndrogynousIdentification;
@@ -79,6 +80,7 @@ public class Properties {
 	public int pregnancyLactationIncreaseVariance = 100;
 	public int pregnancyLactationIncrease = 250;
 	public int pregnancyLactationLimit = 1000;
+	public int pregnancyTimeHours = PregnancyPossibility.PREGNANCY_TIME_HOURS_DEFAULT;
 	
 	public Set<PropertyValue> values;
 	
@@ -242,6 +244,7 @@ public class Properties {
 			createXMLElementWithValue(doc, settings, "pregnancyLactationIncreaseVariance", String.valueOf(pregnancyLactationIncreaseVariance));
 			createXMLElementWithValue(doc, settings, "pregnancyLactationIncrease", String.valueOf(pregnancyLactationIncrease));
 			createXMLElementWithValue(doc, settings, "pregnancyLactationLimit", String.valueOf(pregnancyLactationLimit));
+			createXMLElementWithValue(doc, settings, "pregnancyTimeHours", String.valueOf(pregnancyTimeHours));
 			
 			createXMLElementWithValue(doc, settings, "forcedFetishPercentage", String.valueOf(forcedFetishPercentage));
 
@@ -676,6 +679,8 @@ public class Properties {
 					pregnancyLactationIncreaseVariance = Integer.valueOf(((Element)element.getElementsByTagName("pregnancyLactationIncreaseVariance").item(0)).getAttribute("value"));
 					pregnancyLactationIncrease = Integer.valueOf(((Element)element.getElementsByTagName("pregnancyLactationIncrease").item(0)).getAttribute("value"));
 					pregnancyLactationLimit = Integer.valueOf(((Element)element.getElementsByTagName("pregnancyLactationLimit").item(0)).getAttribute("value"));
+					pregnancyTimeHours = Integer.valueOf(((Element)element.getElementsByTagName("pregnancyTimeHours").item(0)).getAttribute("value"));
+					
 				}catch(Exception ex) {
 				}
 				

--- a/src/com/lilithsthrone/game/character/PregnancyPossibility.java
+++ b/src/com/lilithsthrone/game/character/PregnancyPossibility.java
@@ -16,6 +16,10 @@ import com.lilithsthrone.utils.XMLSaving;
  */
 public class PregnancyPossibility implements XMLSaving {
 	
+	public static int PREGNANCY_TIME_HOURS_MIN = 20;
+	public static int PREGNANCY_TIME_HOURS_MAX = Integer.MAX_VALUE;
+	public static int PREGNANCY_TIME_HOURS_DEFAULT = 160;
+	
 	private String motherId, fatherId;
 	private float probability;
 	

--- a/src/com/lilithsthrone/game/character/effects/StatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/StatusEffect.java
@@ -3036,8 +3036,9 @@ public enum StatusEffect {
 				}
 				
 				int pregnancyStageTimeHours = (int) Math.ceil(((double) Main.getProperties().pregnancyTimeHours) / 2);
+				int pregnancyTime = (int) Math.ceil(((double) pregnancyStageTimeHours) * 0.9);
 				int pregnancyAddedTime = (int) Math.ceil(((double) pregnancyStageTimeHours) * 0.15);
-				target.addStatusEffect(PREGNANT_1, 60 * (pregnancyStageTimeHours + Util.random.nextInt(pregnancyAddedTime)));
+				target.addStatusEffect(PREGNANT_1, 60 * (pregnancyTime + Util.random.nextInt(pregnancyAddedTime)));
 				
 				if (!Main.game.getPlayer().isQuestCompleted(QuestLine.SIDE_FIRST_TIME_PREGNANCY)) {
 					if(target.hasFetish(Fetish.FETISH_PREGNANCY)) {
@@ -3221,8 +3222,9 @@ public enum StatusEffect {
 		public String extraRemovalEffects(GameCharacter target) {
 
 			int pregnancyStageTimeHours = (int) Math.ceil(((double) Main.getProperties().pregnancyTimeHours) / 2);
+			int pregnancyTime = (int) Math.ceil(((double) pregnancyStageTimeHours) * 0.9);
 			int pregnancyAddedTime = (int) Math.ceil(((double) pregnancyStageTimeHours) * 0.15);
-			target.addStatusEffect(PREGNANT_2, 60 * (pregnancyStageTimeHours + Util.random.nextInt(pregnancyAddedTime)));
+			target.addStatusEffect(PREGNANT_2, 60 * (pregnancyTime + Util.random.nextInt(pregnancyAddedTime)));
 			
 			boolean breastGrowth = false;
 			if(Main.getProperties().pregnancyBreastGrowth>0 && target.getBreastRawSizeValue()<Main.getProperties().pregnancyBreastGrowthLimit) {

--- a/src/com/lilithsthrone/game/character/effects/StatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/StatusEffect.java
@@ -3003,11 +3003,11 @@ public enum StatusEffect {
 		public String getDescription(GameCharacter target) {
 			if(target.isPlayer()) {
 				return "After recently having unprotected sex, there's a risk that you'll get pregnant!"
-					+ " Due to the fact that the arcane accelerates people's pregnancies, you'll know if you're pregnant within a matter of hours.";
+					+ " Due to the fact that the arcane affects people's pregnancies, you'll know if you're pregnant within a matter of hours.";
 			} else {
 				return UtilText.parse(target,
 						"After recently having unprotected sex, there's a risk that "+target.getName("the")+" will get pregnant!"
-							+ " Due to the fact that the arcane accelerates people's pregnancies, [npc.she]'ll know if [npc.sheIs] pregnant within a matter of hours.");
+							+ " Due to the fact that the arcane affects people's pregnancies, [npc.she]'ll know if [npc.sheIs] pregnant within a matter of hours.");
 			}
 		}
 
@@ -3035,7 +3035,9 @@ public enum StatusEffect {
 					}
 				}
 				
-				target.addStatusEffect(PREGNANT_1, 60 * (72 + Util.random.nextInt(13)));
+				int pregnancyStageTimeHours = (int) Math.ceil(((double) Main.getProperties().pregnancyTimeHours) / 2);
+				int pregnancyAddedTime = (int) Math.ceil(((double) pregnancyStageTimeHours) * 0.15);
+				target.addStatusEffect(PREGNANT_1, 60 * (pregnancyStageTimeHours + Util.random.nextInt(pregnancyAddedTime)));
 				
 				if (!Main.game.getPlayer().isQuestCompleted(QuestLine.SIDE_FIRST_TIME_PREGNANCY)) {
 					if(target.hasFetish(Fetish.FETISH_PREGNANCY)) {
@@ -3195,12 +3197,16 @@ public enum StatusEffect {
 
 		@Override
 		public String getDescription(GameCharacter target) {
+			String pregnancySpeed = Main.getProperties().pregnancyTimeHours < 6400 ? "acelerates" :
+									(Main.getProperties().pregnancyTimeHours > 6600 ? "slows" : "doesn't affect the speed of");
+			String pregnancyStageTime = Main.getProperties().pregnancyTimeHours < 200 ? "days" :
+										(Main.getProperties().pregnancyTimeHours > 1400 ? "months" : "weeks");
 			if(target.isPlayer()) {
 				return "From one of your recent sexual encounters, you've been impregnated!"
 						+ (target.getBodyMaterial()==BodyMaterial.SLIME
 							?" Through the [pc.skinColour] [pc.skin] that makes up your body, you can see "+Util.intToString(target.getPregnantLitter().getTotalLitterCount())+" little slime core"
 								+(target.getPregnantLitter().getTotalLitterCount()==1?"":"s")+" growing inside of you..."
-							:" Due to the fact that the arcane accelerates people's pregnancies, you'll move onto the next stage in a matter of days.");
+							:" Due to the fact that the arcane " + pregnancySpeed + " people's pregnancies, you'll move onto the next stage in a matter of " + pregnancyStageTime + ".");
 			} else {
 				return UtilText.parse(target,
 							"From one of [npc.namePos] recent sexual encounters, [npc.sheIs] been impregnated!"
@@ -3214,7 +3220,9 @@ public enum StatusEffect {
 		@Override
 		public String extraRemovalEffects(GameCharacter target) {
 
-			target.addStatusEffect(PREGNANT_2, 60 * (72 + Util.random.nextInt(13)));
+			int pregnancyStageTimeHours = (int) Math.ceil(((double) Main.getProperties().pregnancyTimeHours) / 2);
+			int pregnancyAddedTime = (int) Math.ceil(((double) pregnancyStageTimeHours) * 0.15);
+			target.addStatusEffect(PREGNANT_2, 60 * (pregnancyStageTimeHours + Util.random.nextInt(pregnancyAddedTime)));
 			
 			boolean breastGrowth = false;
 			if(Main.getProperties().pregnancyBreastGrowth>0 && target.getBreastRawSizeValue()<Main.getProperties().pregnancyBreastGrowthLimit) {
@@ -3292,12 +3300,16 @@ public enum StatusEffect {
 
 		@Override
 		public String getDescription(GameCharacter target) {
+			String pregnancySpeed = Main.getProperties().pregnancyTimeHours < 6400 ? "acelerates" :
+									(Main.getProperties().pregnancyTimeHours > 6600 ? "slows" : "doesn't affect the speed of");
+			String pregnancyStageTime = Main.getProperties().pregnancyTimeHours < 200 ? "days" :
+										(Main.getProperties().pregnancyTimeHours > 1400 ? "months" : "weeks");
 			if(target.isPlayer()) {
 				return "Your stomach has swollen considerably, making it clearly obvious to anyone who glances your way that you're expecting to give birth soon."
 						+ (target.getBodyMaterial()==BodyMaterial.SLIME
 							?" Through the [pc.skinColour] [pc.skin] that makes up your body, you can see "+Util.intToString(target.getPregnantLitter().getTotalLitterCount())+" little slime core"
 								+(target.getPregnantLitter().getTotalLitterCount()==1?"":"s")+" growing inside of you..."
-							:" Due to the fact that the arcane accelerates people's pregnancies, you'll move onto the final stage in a matter of days.");
+							:" Due to the fact that the arcane " + pregnancySpeed + " people's pregnancies, you'll move onto the final stage in a matter of " + pregnancyStageTime + ".");
 			} else {
 				return UtilText.parse(target,
 							"[npc.NamePos] stomach has swollen considerably, making it clearly obvious to anyone who glances [npc.her] way that [npc.sheIs] expecting to give birth soon."

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Lab.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Lab.java
@@ -206,6 +206,8 @@ public class Lab {
 			} else {
 				if(Main.game.getDialogueFlags().values.contains(DialogueFlagValue.waitingOnLilayaPregnancyResults)) {
 					if(Main.game.getNpc(Lilaya.class).isVisiblyPregnant()) {
+						String pregnancyStageTime = Main.getProperties().pregnancyTimeHours < 200 ? "days" :
+													(Main.getProperties().pregnancyTimeHours > 1400 ? "months" : "weeks");
 						UtilText.nodeContentSB.append(
 								"<p>"
 									+ "Stepping inside Lilaya's laboratory, you quickly scan the interior for any sign of life."
@@ -221,7 +223,7 @@ public class Lab {
 								+ "<p>"
 									+ "You gulp nervously as you expect her to fly off in another angry fit, but, sensing your unease, Lilaya lets out a resigned sigh before lowering her voice,"
 									+ " [lilaya.speech(Don't worry, there's nothing that can be done about it now anyway. Being pregnant sucks, but I might have been a little too harsh on you."
-									+ " After all, it's only for a week or so that I've got to carry your kids around.)]"
+									+ " After all, it's only for a few " + pregnancyStageTime + " or so that I've got to carry your kids around.)]"
 								+ "</p>"
 								+ "<p>"
 									+ "As she's been speaking, Lilaya has been gently rubbing her pregnant bump, and as she looks up at you, she notices that you're staring at her belly."
@@ -2358,7 +2360,8 @@ public class Lab {
 				}
 				
 			}
-
+			
+			String arcanePregnancyInfluence = (Main.getProperties().pregnancyTimeHours < 6400 || Main.getProperties().pregnancyTimeHours > 6600) ? "has a big" : "doesn't have a big";
 			UtilText.nodeContentSB.append(
 					"<p>"
 						+ "She suddenly breaks off from fondling your abdomen, and, grabbing your wrist, starts pulling you into her lab."
@@ -2377,9 +2380,9 @@ public class Lab {
 							+ " starts walking back over towards you."
 					+ "</p>"
 					+ "<p>"
-						+ "[lilaya.speech(So, I'm guessing you've already realised that the arcane has a big influence on pregnancy speed around here,)]"
+						+ "[lilaya.speech(So, I'm guessing you've already realised that the arcane " + arcanePregnancyInfluence + " influence on pregnancy speed around here,)]"
 						+ " she laughs, stroking your belly once more before stepping back and tinkering with some small dials on the instrument she's just retrieved. "
-						+ UtilText.parseSpeech("I've actually done a fair bit of research on the arcane's influence on pregnancies, so I know that without its presence, pregnancies should really be taking about nine months...", aunt)
+						+ UtilText.parseSpeech("I've actually done a fair bit of research on the arcane's influence on pregnancies, so I know that without its presence, pregnancies should be taking about nine months...", aunt)
 					+ "</p>"
 					+ "<p>"
 						+ "As you try to assimilate the information Lilaya's giving you, the instrument in her hand starts giving off a faint pink glow, and, letting out a satisfied hum, she brings it down to your pregnant bump."

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Library.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Library.java
@@ -472,6 +472,8 @@ public class Library {
 
 		@Override
 		public String getContent() {
+			String pregnancyStageTime = Main.getProperties().pregnancyTimeHours < 200 ? "days" :
+								(Main.getProperties().pregnancyTimeHours > 1400 ? "months" : "weeks");
 			return "<p>"
 						+ "You slide the small paperback book out from the shelf, and, turning it over in your [pc.hands], you take a look at the front cover."
 						+ " On it, the title 'Knocked Up' is displayed in bold pink lettering, and beneath that, there's a picture of a heavily-pregnant rabbit-girl cradling her swollen belly."
@@ -479,7 +481,7 @@ public class Library {
 					+ "</p>"
 					+ "<p>"
 						+ "Opening its pages, you find that the information contained within the book is laid out in a very neat and easy-to-read format, and it only takes you a few minutes to read through the entire thing."
-						+ " One of the most striking facts is that in this world, the full cycle of pregnancy only lasts for a few weeks."
+						+ " One of the most interesting facts is that in this world, the full cycle of pregnancy lasts for a few " + pregnancyStageTime + "."
 						+ " What's more, once the mother is ready to give birth, she's able to stay in that state indefinitely, until such time as she feels comfortable giving birth."
 					+ "<p>"
 					+ "<p>"

--- a/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
@@ -15,6 +15,7 @@ import java.util.Properties;
 import com.lilithsthrone.game.Game;
 import com.lilithsthrone.game.PropertyValue;
 import com.lilithsthrone.game.character.CharacterUtils;
+import com.lilithsthrone.game.character.PregnancyPossibility;
 import com.lilithsthrone.game.character.attributes.Attribute;
 import com.lilithsthrone.game.character.body.valueEnums.AgeCategory;
 import com.lilithsthrone.game.character.body.valueEnums.CupSize;
@@ -2063,6 +2064,16 @@ public class OptionsDialogue {
 							0,
 							Lactation.SEVEN_MONSTROUS_AMOUNT_POURING.getMaximumValue()));
 			
+			UtilText.nodeContentSB.append(getContentPreferenceVariableDivExpanded(
+					"PREGNANCY_TIME",
+					Colour.BASE_PINK,
+					"Pregnancy Time",
+					"Set the pregnancy duration. Default value is the canon value.",
+					Main.getProperties().pregnancyTimeHours+" hours",
+					Main.getProperties().pregnancyTimeHours,
+					PregnancyPossibility.PREGNANCY_TIME_HOURS_MIN,
+					PregnancyPossibility.PREGNANCY_TIME_HOURS_MAX));
+			
 			return UtilText.nodeContentSB.toString();
 		}
 		
@@ -2160,6 +2171,40 @@ public class OptionsDialogue {
 				+ "</div>"
 				+ "<div id='"+id+"_OFF' class='normal-button"+(value==minimum?" disabled":"")+"' style='width:15%; margin:0 2.5%; text-align:center; float:right;'>"
 					+ (value==minimum?"[style.boldDisabled(-)]":"[style.boldBad(-)]")
+				+ "</div>");
+		
+		contentSB.append("</div>"
+				+"</div>");
+		
+		return contentSB.toString();
+	}
+	
+	private static String getContentPreferenceVariableDivExpanded(String id, Colour colour, String title, String description, String valueDisplay, int value, int minimum, int maximum) {
+		StringBuilder contentSB = new StringBuilder();
+
+		contentSB.append(
+				"<div class='container-full-width' style='padding:0;'>"
+					+ "<div class='container-half-width' style='width:calc(55% - 16px);'>"
+						+ "<b style='text-align:center; color:"+colour.toWebHexString()+";'>"+ title+"</b><b>:</b><br/>"
+						+ description
+					+ "</div>"
+					+ "<div class='container-half-width' style='width:calc(45% - 16px);'>");
+		
+		contentSB.append(
+				"<div id='"+id+"_ON_HUNDRED' class='normal-button"+(value==maximum?" disabled":"")+"' style='width:15%; margin:0 2.5%; text-align:center; float:right;'>"
+						+ (value==maximum?"[style.boldDisabled(+100)]":"[style.boldGood(+100)]")
+				+ "</div>"
+				+ "<div id='"+id+"_ON' class='normal-button"+(value==maximum?" disabled":"")+"' style='width:15%; margin:0 2.5%; text-align:center; float:right;'>"
+						+ (value==maximum?"[style.boldDisabled(+10)]":"[style.boldGood(+10)]")
+				+ "</div>"
+				+ "<div class='container-full-width' style='text-align:center; width:calc(20%); float:right; margin:0;'>"
+					+ "<b>"+valueDisplay+"</b>"
+				+ "</div>"
+				+ "<div id='"+id+"_OFF' class='normal-button"+(value==minimum?" disabled":"")+"' style='width:15%; margin:0 2.5%; text-align:center; float:right;'>"
+					+ (value==minimum?"[style.boldDisabled(-10)]":"[style.boldBad(-10)]")
+				+ "</div>"
+				+ "<div id='"+id+"_OFF_HUNDRED' class='normal-button"+(value==minimum?" disabled":"")+"' style='width:15%; margin:0 2.5%; text-align:center; float:right;'>"
+				+ (value==minimum?"[style.boldDisabled(-100)]":"[style.boldBad(-100)]")
 				+ "</div>");
 		
 		contentSB.append("</div>"


### PR DESCRIPTION
### Things to include in a large Pull Request:

- What is the purpose of the pull request?
Adds an option to define a custom pregnancy length, with a warning that it is not canon. Aimed to further game customization and add more replayability, not to change the lore. Aimed for people who like preg content (to make it pregnancy longer), and those who don't (to make it shorter, or make it longer as a punishment if a character does end up pregnant).
- Give a brief description of what you changed or added.
Adds an area in the 'Options' menu to define the pregnancy length in hours, with the default value (160 hours) being the length that is currently in the game. Doesn't affect the time where you don't know if the character is impregnated (from pregnant_0 to pregnant_1) or the development of children, only the periods from pregnant_1 to pregnant_2, and from pregnant_2 to pregnant_3 (each being roughly half of the chosen value). The formula for pregnancy duration modeled after the default formula, now without hard coded values.
Descriptions in some dialogue and books that mention pregnancy length customized to coincide with the chosen value (for example, if pregnancy lasts for 3 months, the description will say so, instead of the default 'a few days'). Not really required if people know they are not using the canon pregnancy duration, but might help with immersion nonetheless. If the default value is chosen, the descriptions remain the same.
- Are any new graphical assets required?
No.
- Has this change been tested? If so, mention the version number that the test was based on.
Tested on the last released version (0.3).
- So we have a better idea of who you are, what is your Discord Handle?
lanaya1437
