### PR TITLE
Animated GIF support

### DIFF
--- a/res/images/characters/modding.txt
+++ b/res/images/characters/modding.txt
@@ -1,6 +1,7 @@
 ----- CUSTOM ARTWORK GUIDE -----
 
 All images must be in PNG (.png) or JPEG (.jpg) format and are scaled down internally to at most 600x600.
+Animations in GIF (.gif) format are also supported. Note that large GIFs may slow down the game, which is why the animation is not played in tooltips and may not be over 10 MB in size.
 
 In order to add your own images to the game, you first need to figure out where to put the files. For unique NPCs, the folder has the same name as the class. For reference, check:
 https://github.com/Innoxia/liliths-throne-public/tree/master/src/com/lilithsthrone/game/character/npc

--- a/src/com/lilithsthrone/controller/MainControllerInitMethod.java
+++ b/src/com/lilithsthrone/controller/MainControllerInitMethod.java
@@ -262,7 +262,7 @@ public class MainControllerInitMethod {
 				MainController.addEventListener(MainController.document, id, "mousemove", MainController.moveTooltipListener, false);
 				MainController.addEventListener(MainController.document, id, "mouseleave", MainController.hideTooltipListener, false);
 				MainController.addEventListener(MainController.document, id, "mouseenter", new TooltipInformationEventListener().setInformation(
-						"Add custom artwork","Browse your own images and add them to the character."),false);
+						"Add custom artwork","Browse your own images and add them to the character. Large files such as long GIF animations may slow down the game."),false);
 			}
 
 			if (character.hasArtwork()) {

--- a/src/com/lilithsthrone/controller/MainControllerInitMethod.java
+++ b/src/com/lilithsthrone/controller/MainControllerInitMethod.java
@@ -244,7 +244,7 @@ public class MainControllerInitMethod {
 					// Create file chooser for .jpg and .png images in the most recently used directory
 					FileChooser chooser = new FileChooser();
 					chooser.setTitle("Add Images");
-					chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("Images", "*.jpg", "*.png"));
+					chooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("Images", "*.jpg", "*.png", "*.gif"));
 					if (lastOpened != null)
 						chooser.setInitialDirectory(lastOpened);
 

--- a/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipInformationEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipInformationEventListener.java
@@ -771,7 +771,7 @@ public class TooltipInformationEventListener implements EventListener {
 						tooltipSB.append("</div>"
 								+ "<div style='float: left;'>"
 									+ "<img id='CHARACTER_IMAGE' style='"+(revealed?"":"-webkit-filter: brightness(0%);")
-										+" width: auto; height: auto; max-width: 300; max-height: 445; padding-top: " + imagePadding + "px;' src='" + image.getImageString()+ "'/>"
+										+" width: auto; height: auto; max-width: 300; max-height: 445; padding-top: " + imagePadding + "px;' src='" + image.getThumbnailString()+ "'/>"
 										+(revealed?"":"<p style='position:absolute; top:33%; right:0; width:"+imageWidth+"; font-weight:bold; text-align:center; color:"+Colour.BASE_GREY.toWebHexString()+";'>Unlocked through sex!</p>")
 								+ "</div>");
 					}

--- a/src/com/lilithsthrone/rendering/Artwork.java
+++ b/src/com/lilithsthrone/rendering/Artwork.java
@@ -88,7 +88,7 @@ public class Artwork {
 		this.nakedImages = new ArrayList<>();
 
 		// Add all images to their respective lists
-		for (File f : folder.listFiles((dir, name) -> name.endsWith(".jpg") || name.endsWith(".png"))) {
+		for (File f : folder.listFiles((dir, name) -> name.endsWith(".jpg") || name.endsWith(".png") || name.endsWith(".gif"))) {
 			if (f.getName().startsWith("partial"))
 				partialImages.add(f.getAbsolutePath());
 			else if (f.getName().startsWith("naked"))

--- a/src/com/lilithsthrone/rendering/CachedGif.java
+++ b/src/com/lilithsthrone/rendering/CachedGif.java
@@ -1,0 +1,51 @@
+package com.lilithsthrone.rendering;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Base64;
+
+/**
+ * @since 0.3.0
+ * @version 0.3.0
+ * @author Addi
+ */
+public class CachedGif extends CachedImage {
+    private String thumbnailString;
+
+    @Override
+    public boolean load(File f) {
+        try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream()) {
+            // Load the first frame of the image
+            BufferedImage firstFrame = ImageIO.read(f);
+            updatePercentageWidth(firstFrame);
+            width = firstFrame.getWidth();
+            height = firstFrame.getHeight();
+
+            // Resize the frame
+            int[] targetSize = getAdjustedSize(300, 300);
+            firstFrame = scaleDown(firstFrame, targetSize[0], targetSize[1]);
+
+            // Convert to string
+            ImageIO.setUseCache(false);
+            ImageIO.write(firstFrame, "PNG", byteStream);
+            thumbnailString = "data:image/png;base64," + Base64.getEncoder().encodeToString(byteStream.toByteArray());
+
+            // Load the animation
+            imageString = "data:image/gif;base64," + Base64.getEncoder().encodeToString(Files.readAllBytes(f.toPath()));
+
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String getThumbnailString() {
+        return thumbnailString;
+    }
+}

--- a/src/com/lilithsthrone/rendering/CachedGif.java
+++ b/src/com/lilithsthrone/rendering/CachedGif.java
@@ -26,6 +26,7 @@ public class CachedGif extends CachedImage {
         if (f.length() / 1024 > 10240) {
             // Animated image is too large, use the first frame instead
             imageString = firstFrame.getImageString();
+            System.err.println("Warning: Animated image " + f.getName() + " is too large. Using first frame instead.");
         } else {
             // Load the animation
             try {

--- a/src/com/lilithsthrone/rendering/CachedImage.java
+++ b/src/com/lilithsthrone/rendering/CachedImage.java
@@ -12,7 +12,7 @@ import javax.imageio.ImageIO;
 
 /**
  * @since 0.2.5.5
- * @version 0.2.9
+ * @version 0.3.0
  * @author Addi
  */
 public class CachedImage {
@@ -28,13 +28,7 @@ public class CachedImage {
 		try (ByteArrayOutputStream byteStream = new ByteArrayOutputStream()) {
 			// Load the image
 			BufferedImage image = ImageIO.read(f);
-			width = image.getWidth();
-			height = image.getHeight();
-			if(height == width) {
-				percentageWidth = 45;
-			} else if(height < width) {
-				percentageWidth = 65;
-			}
+			updatePercentageWidth(image);
 
 			// Resize image
 			int[] targetSize = getAdjustedSize(600, 600);
@@ -53,6 +47,16 @@ public class CachedImage {
 		return true;
 	}
 
+	void updatePercentageWidth(BufferedImage image) {
+		width = image.getWidth();
+		height = image.getHeight();
+		if(height == width) {
+			percentageWidth = 45;
+		} else if(height < width) {
+			percentageWidth = 65;
+		}
+	}
+
 	/**
 	 * Retrieve the image in base 64 encoded string format. The string must start with 'data:image/png;base64'.
 	 * @return The image as base64 string
@@ -61,11 +65,21 @@ public class CachedImage {
 		return imageString;
 	}
 
+	/**
+	 * Retrieve the thumbnail of the image.
+	 * @return The thumbnail image as base64 string
+	 */
+	public String getThumbnailString() {
+		return imageString;
+	}
+
 	public int getWidth() {
 		return width;
 	}
 
-	public int getHeight() { return height; }
+	public int getHeight() {
+		return height;
+	}
 
 	/**
 	 * Retrieve the width percentage that the image is supposed to take on the character information page. The value is
@@ -98,9 +112,9 @@ public class CachedImage {
 	 * @param original The BufferedImage to scale
 	 * @param targetWidth The targeted width, ignoring aspect ratio
 	 * @param targetHeight The targeted height, ignoring aspect ratio
-	 * @return
+	 * @return The rescaled image
 	 */
-	public static BufferedImage scaleDown(BufferedImage original, int targetWidth, int targetHeight) {
+	static BufferedImage scaleDown(BufferedImage original, int targetWidth, int targetHeight) {
 		int width = original.getWidth();
 		int height = original.getHeight();
 		BufferedImage rv = original;

--- a/src/com/lilithsthrone/rendering/ImageCache.java
+++ b/src/com/lilithsthrone/rendering/ImageCache.java
@@ -88,7 +88,7 @@ public enum ImageCache {
 	public CachedImage getImage(File f) {
 		CachedImage image = cache.get(f);
 		if (image == null) {
-			image = new CachedImage();
+			image = f.getName().endsWith(".gif") ? new CachedGif() : new CachedImage();
 			if (image.load(f)) cache.put(f, image);
 			else return null;
 		}


### PR DESCRIPTION
### Goals

This is a relatively simple PR to allow adding animated GIFs as character images.

### Changes

It is now possible to select .gif files when adding character images. Mostly due to performance considerations, they are loaded slightly differently than static images:
- Only the first frame is used for tooltips (prevents lag when hovering)
- Only the first frame is used if the file is larger than 10 MB (prevents huge files filling cache and memory); A warning is printed to the console
- The animation is not rescaled before caching (prevents long loading times as we'd have to rescale each frame separately and then reassemble the animation)
- Warnings have been added to the image readme and button description

All of these were implemented due to the simple fact that animations can have completely unpredictable sizes depending on their length. Unlike static images, which have a very predictable size after scaling, resizing animations is not as simple and due to the lack of support from native libraries not worth implementing.
To avoid memory issues, overloading the cache and significant lag when opening character pages with animations, the above restrictions are always applied.

### Testing

All changes have been tested with 0.3.0.