### PR TITLE
UtilText parsing for player career/background perks

### DIFF
--- a/src/com/lilithsthrone/game/character/effects/Perk.java
+++ b/src/com/lilithsthrone/game/character/effects/Perk.java
@@ -108,8 +108,8 @@ public enum Perk {
 			Util.newArrayListOfValues("[style.boldExcellent(Boosts)] 'Well Rested' bonus")) {
 		@Override
 		public String getDescription(GameCharacter owner) {
-			return "With so much free time on your hands, you've managed to improve yourself in several different ways."
-					+ " You also benefit from knowing exactly how best to relax, boosting the bonus you get from sleeping.";
+			return UtilText.parse(owner, "With so much free time on [npc.herPos] hands, [npc.nameHas] managed to improve [npc.herself] in several different ways."
+					+ " [npc.Name] also [npc.verb(benefit)] from knowing exactly how best to relax, boosting the bonus [npc.she] [npc.verb(get)] from sleeping.");
 		}
 	},
 	
@@ -132,8 +132,8 @@ public enum Perk {
 		}
 		@Override
 		public String getDescription(GameCharacter owner) {
-			return "From your considerable office experience, you know exactly how to motivate those working beneath you."
-					+ " The stressful work environment has caused you to bottle up a lot of frustration, which manifests in increased critical damage.";
+			return UtilText.parse(owner, "From [npc.herPos] considerable office experience, [npc.name] [npc.verb(know)] exactly how to motivate those working beneath [npc.herPro]."
+					+ " The stressful work environment has caused [npc.herPro] to bottle up a lot of frustration, which manifests in increased critical damage.");
 		}
 	},
 	
@@ -148,8 +148,8 @@ public enum Perk {
 			Util.newArrayListOfValues("[style.boldExcellent(25%)] discount in all stores")) {
 		@Override
 		public String getDescription(GameCharacter owner) {
-			return "Your student discount has never failed you before!"
-					+ " Along with a guaranteed 25% discount in all stores, you can be confident in your ability to quickly learn new things.";
+			return UtilText.parse(owner, "[npc.NamePos] student discount has never failed [npc.herPro] before!"
+					+ " Along with a guaranteed 25% discount in all stores, [npc.she] can be confident in [npc.herPos] ability to quickly learn new things.");
 		}
 	},
 	
@@ -164,8 +164,8 @@ public enum Perk {
 			Util.newArrayListOfValues("[style.boldExcellent(Double)] length of all spell effects")) {
 		@Override
 		public String getDescription(GameCharacter owner) {
-			return "You find that your abilities as a musician translate quite well into the art of seduction."
-					+ " You feel the same sort of rhythm in casting spells as you do with music, resulting in all of your spell effects lasting twice as long as usual.";
+			return UtilText.parse(owner, "[npc.Name] [npc.verb(find)] that [npc.herPos] abilities as a musician translate quite well into the art of seduction."
+					+ " [npc.She] [npc.verb(feel)] the same sort of rhythm in casting spells as [npc.she] [npc.do] with music, resulting in all of [npc.herPos] spell effects lasting twice as long as usual.");
 		}
 	},
 	
@@ -180,8 +180,8 @@ public enum Perk {
 			Util.newArrayListOfValues("[style.boldExcellent(Triple)] all slave obedience gains")) {
 		@Override
 		public String getDescription(GameCharacter owner) {
-			return "You know exactly how to deal with unruly students."
-					+ " Your ability to clearly understand and explain difficult subjects is reflected in a reduced cost of casting spells.";
+			return UtilText.parse(owner, "[npc.Name] [npc.verb(know)] exactly how to deal with unruly students."
+					+ " [npc.HerPos] ability to clearly understand and explain difficult subjects is reflected in a reduced cost of casting spells.");
 		}
 	},
 	
@@ -196,8 +196,8 @@ public enum Perk {
 			Util.newArrayListOfValues("[style.boldExcellent(+25%)] to all experience gains")) {
 		@Override
 		public String getDescription(GameCharacter owner) {
-			return "You keep a diary of your personal thoughts and encounters, allowing you to reflect upon and learn from your experiences."
-					+ " Your keen interest in books also allows you to quickly read up on the most effective application of spells.";
+			return UtilText.parse(owner, "[npc.Name] [npc.verb(keep)] a diary of [npc.herPos] personal thoughts and encounters, allowing [npc.herPro] to reflect upon and learn from [npc.herPos] experiences."
+					+ " [npc.HerPos] keen interest in books also allows [npc.herPro] to quickly read up on the most effective application of spells.");
 		}
 	},
 
@@ -212,7 +212,7 @@ public enum Perk {
 			Util.newArrayListOfValues("[style.boldExcellent(Double)] all potions effects' strength and length")) {
 		@Override
 		public String getDescription(GameCharacter owner) {
-			return "Thanks to spending a considerable amount of time tasting food, you have both a significant resistance to poison, as well as the ability to make the most of things that are a culinary marvel.";
+			return UtilText.parse(owner, "Thanks to spending a considerable amount of time tasting food, [npc.name] [npc.has] both a significant resistance to poison, as well as the ability to make the most of things that are a culinary marvel.");
 		}
 	},
 
@@ -230,8 +230,8 @@ public enum Perk {
 			Util.newArrayListOfValues("Your first strike in combat deals [style.boldExcellent(double)] damage")) {
 		@Override
 		public String getDescription(GameCharacter owner) {
-			return "You've spent a considerable amount of time training to fight, and as a result, you are far stronger and healthier than a normal person."
-					+ " Thanks to this training, you are also able to channel your aggression into your attacks.";
+			return UtilText.parse(owner, "[npc.NameHas] spent a considerable amount of time training to fight, and as a result, [npc.she] [npc.is] far stronger and healthier than a normal person."
+					+ " Thanks to this training, [npc.she] [npc.is] also able to channel [npc.herPos] aggression into [npc.herPos] attacks.");
 		}
 	},
 
@@ -246,7 +246,7 @@ public enum Perk {
 			Util.newArrayListOfValues("All non-zero escape chances in combat are boosted to [style.boldExcellent(100%)]")) {
 		@Override
 		public String getDescription(GameCharacter owner) {
-			return "You are a world-class sprinter, and have a guaranteed 100% success of escaping any combat situation where running away is an option.";
+			return UtilText.parse(owner, "[npc.Name] [npc.is] a world-class sprinter, and [npc.has] a guaranteed 100% success of escaping any combat situation where running away is an option.");
 		}
 	},
 
@@ -264,8 +264,8 @@ public enum Perk {
 					"[style.boldExcellent(Double)] slave income from maids and butlers")) {
 		@Override
 		public String getDescription(GameCharacter owner) {
-			return "You are the perfect example of a hard-working maid, and while wearing a complete set of maid's clothes, the bonus that you receive is considerably boosted."
-					+ " You also know how to train butlers and other maids to be exceptional at their jobs.";
+			return UtilText.parse(owner, "[npc.Name] [npc.is] the perfect example of a hard-working maid, and while wearing a complete set of maid's clothes, the bonus that [npc.she] [npc.verb(receive)] is considerably boosted."
+					+ " [npc.She] also [npc.verb(know)] how to train butlers and other maids to be exceptional at their jobs.");
 		}
 	},
 
@@ -283,8 +283,8 @@ public enum Perk {
 					"[style.boldExcellent(Double)] slave income from maids and butlers")) {
 		@Override
 		public String getDescription(GameCharacter owner) {
-			return "You are the perfect example of a hard-working and composed butler, and while wearing a complete set of butler's clothes, the bonus that you receive is considerably boosted."
-					+ " You also know how to train maids and other butlers to be exceptional at their jobs.";
+			return UtilText.parse(owner, "[npc.name] [npc.is] the perfect example of a hard-working and composed butler, and while wearing a complete set of butler's clothes, the bonus that [npc.she] [npc.verb(receive)] is considerably boosted."
+					+ " [npc.She] also [npc.verb(know)] how to train maids and other butlers to be exceptional at their jobs.");
 		}
 	},
 	


### PR DESCRIPTION
This commit fixes parsing for player job perks so that, theoretically, they can be used for NPCs and would display their descriptions correctly. This was done as a prelude to looking into doing NPC job perks.