### PR TITLE
Add .jar files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target/
 *.class
 *.log
 *.iml
+*.jar
 
 # Ignore all generic character images
 res/images/characters/generic/


### PR DESCRIPTION
Adds .jar files to .gitignore so that they don't get repeatedly added to the GitHub tree, or updated, or all of that. Anti-frustration feature for people building the game on Eclipse to actually play it and to develop the game concurrently.

(No credit needed for this one.)