### PR TITLE
Issue 1046: Fix for potential divsion-by-zero error that breaks elements of the 0.3.1 GUI.

### DIFF
--- a/src/com/lilithsthrone/game/character/effects/StatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/StatusEffect.java
@@ -5097,6 +5097,14 @@ public enum StatusEffect {
 					new Value<Attribute, Float>(Attribute.RESISTANCE_PHYSICAL, -5f)),
 			null) {
 		@Override
+		public String getName(GameCharacter target) {
+			if ( ! target.hasBreasts() ) {
+				return "exposed nipples";
+			} else {
+				return super.getName(target);
+			}
+		}
+		@Override
 		public String getDescription(GameCharacter target) {
 			if(target==null) {
 				return "";
@@ -12089,6 +12097,8 @@ public enum StatusEffect {
 		
 		if(owner.hasBreasts() && owner.isCoverableAreaVisible(CoverableArea.NIPPLES)) {
 			names.add("breasts");
+		} else if ( owner.isFeminine() && owner.isCoverableAreaVisible(CoverableArea.NIPPLES)) {
+			names.add("nipples");
 		}
 		if(owner.hasBreastsCrotch() && owner.isCoverableAreaVisible(CoverableArea.NIPPLES_CROTCH)) {
 			names.add(UtilText.parse(owner, "[npc.crotchBoobs]"));
@@ -12116,6 +12126,7 @@ public enum StatusEffect {
 
 		
 		boolean breastsExposed = owner.hasBreasts() && owner.isCoverableAreaVisible(CoverableArea.NIPPLES);
+		boolean nipplesExposed = ! breastsExposed && owner.isFeminine() && owner.isCoverableAreaVisible(CoverableArea.NIPPLES);
 		boolean crotchBoobsExposed = owner.hasBreastsCrotch() && owner.isCoverableAreaVisible(CoverableArea.NIPPLES_CROTCH);
 
 		boolean anusExposed = owner.isCoverableAreaVisible(CoverableArea.ANUS);
@@ -12130,14 +12141,17 @@ public enum StatusEffect {
 		} else {
 			exposedAreas+= (penisExposed?1:0) + (vaginaExposed?1:0);
 		}
-		exposedAreas+= (anusExposed?1:0) + (breastsExposed?1:0) + (crotchBoobsExposed?1:0);
+		exposedAreas+= (anusExposed?1:0) + (breastsExposed || nipplesExposed?1:0) + (crotchBoobsExposed?1:0);
 		
-		int size = Math.min(50, (100/exposedAreas+1));
+		int size = Math.min(50, (100/(exposedAreas+1)));
 		int marginTop = (100-(exposedAreas*size))/2;
 		int marginLeft = (50-size)/2;
 
 		if(breastsExposed) {
 			SVGImageSB.append("<div style='width:"+size+"%;height:"+size+"%;position:absolute;left:"+marginLeft+"%;top:"+marginTop+"%;'>"+SVGImages.SVG_IMAGE_PROVIDER.getCoverableAreaBreasts()+"</div>");
+			marginTop+=size;
+		} else if ( nipplesExposed ) {
+			SVGImageSB.append("<div style='width:"+size+"%;height:"+size+"%;position:absolute;left:"+marginLeft+"%;top:"+marginTop+"%;'>"+SVGImages.SVG_IMAGE_PROVIDER.getCoverableAreaBreastsFlat()+"</div>");
 			marginTop+=size;
 		}
 		if(crotchBoobsExposed) {
@@ -12178,7 +12192,7 @@ public enum StatusEffect {
 		
 		int exposedAreas = (vaginaRecovering?1:0) + (anusRecovering?1:0) + (nipplesRecovering?1:0) + (nipplesCrotchRecovering?1:0) + (penileUrethraRecovering?1:0) + (vaginalUrethraRecovering?1:0);
 		
-		int size = Math.min(50, (100/exposedAreas+1));
+		int size = Math.min(50, (100/(exposedAreas+1)));
 		int marginTop = (100-(exposedAreas*size))/2;
 		int marginLeft = (50-size)/2;
 


### PR DESCRIPTION
Also, as discussed in issue #1046 :
Related fixes complete the separation of exposed chest status description  into exposed breasts and exposed nipples applying to feminine bodies.
No new graphical assets, leverages getCoverableAreaBreastsFlat() where appropriate.
Tested on 0.3.1