### PR TITLE
Issue 1061 Fix "(Error in conditional parsing!)" seen in Alexa's nest

### DIFF
--- a/res/txt/places/dominion/harpyNests/alexa.xml
+++ b/res/txt/places/dominion/harpyNests/alexa.xml
@@ -27,7 +27,7 @@
 		Meeting with Alexa by appointment only.</i>
 	</p>
 	<p>
-		#IF pc.getQuest(QuestLine.MAIN) == QUEST_MAIN_1_E_REPORT_TO_ALEXA
+		#IF pc.getQuest(QUEST_LINE_MAIN) == QUEST_MAIN_1_E_REPORT_TO_ALEXA
 		#THEN
 			Stepping back, you wonder if you should call over one of the nearby harpies. After all, you do have business with Alexa, and you're sure that she'd want to hear about Scarlett as soon as possible.
 		#ELSE
@@ -54,7 +54,7 @@
 		Meeting with Alexa by appointment only.</i>
 	</p>
 	<p>
-		#IF pc.getQuest(QuestLine.MAIN) == QUEST_MAIN_1_E_REPORT_TO_ALEXA
+		#IF pc.getQuest(QUEST_LINE_MAIN) == QUEST_MAIN_1_E_REPORT_TO_ALEXA
 		#THEN
 			You do have business with Alexa, and you're sure that she'd want to hear about Scarlett as soon as possible, but you'll have to come back after the ongoing storm has passed.
 		#ELSE


### PR DESCRIPTION
Replace Java syntax in XML text with the javax.script.ScriptEngine variable conventions established by game.dialogue.utils.UtilText.initScriptEngine().
This issue #1061  seen in at least 0.3.0.7 and 0.3.1
Tested in  0.3.0.7 (with res change) and 0.3.1 (complete build)