### PR TITLE
Issue 1065 For first time run, enhance tooltip on Resume button.

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
@@ -219,6 +219,8 @@ public class OptionsDialogue {
 								
 							}
 						};
+					} else if ( "".equals(Main.getProperties().lastSaveLocation) ) {
+						return new Response("Resume", "There is no previously saved game to resume.", null);
 					} else {
 						return new Response("Resume", "Previously saved game (by the title '"+Main.getProperties().lastSaveLocation+"') not found in 'data/saves' folder.", null);
 					}


### PR DESCRIPTION
Provide less techno-jargon version of tooltip for Resume button for new installation prior to any save.
No new graphical assets. Fix for issue #1065 
Tested in 0.3.1