### PR TITLE
Issue 1067 Fix ConcurrentModificationException while iterating over Properties.values

### DIFF
--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -219,7 +219,8 @@ public class Properties {
 
 			Element valuesElement = doc.createElement("propertyValues");
 			properties.appendChild(valuesElement);
-			for(PropertyValue value : values) {
+			for(PropertyValue value : PropertyValue.values()) {
+				if(! values.contains(value)) continue;
 				CharacterUtils.createXMLElementWithValue(doc, valuesElement, "propertyValue", value.toString());
 			}
 			


### PR DESCRIPTION
This fixes game-ending ConcurrentModificationException seen on 2 different JVMs on a MacBook Air at initial writing of data/properties.xml when Properties.setValue() was called by one thread while Properties.savePropertiesAsXML() was still iterating over Properties.values.

The key change is we loop over an enum possible values instead of the mutable HashSet.

I didn't see this issue #1067  in 0.3.0.7 official builds, but it broke my attempts to test my own builds of 0.3.1

No new graphical assets.
Tested in 0.3.1