### PR TITLE
Fix for over-eager comment removal and other rendering foibles

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -677,7 +677,7 @@ public class UtilText {
 				parserVariableCalls.add(matcherVAR.group().replaceAll("#VAR", "").replaceAll("#ENDVAR", ""));
 			}
 			input = input.replaceAll("(?s)#VAR(.*?)#ENDVAR", "");
-			input = input.replaceAll("\\/\\/(.*?)\n", "\n"); // Replace comments
+			input = input.replaceAll("(?<!:)//(.*?)\n", "\n"); // Replace comments (but not URLs, like http://)
 		}
 		
 		try {

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -406,7 +406,7 @@ public class UtilText {
 
 	public static String getCurrencySymbol() {
 //		return "&#9679;"; // Circle
-		return "&#164"; // 'Generic' currency symbol
+		return "&#164;"; // 'Generic' currency symbol
 	}
 	
 	public static String getPentagramSymbol() {

--- a/src/com/lilithsthrone/rendering/RenderingEngine.java
+++ b/src/com/lilithsthrone/rendering/RenderingEngine.java
@@ -122,7 +122,7 @@ public enum RenderingEngine {
 	private StringBuilder inventorySB = new StringBuilder(), equippedPanelSB = new StringBuilder();
 	
 	public String getInventoryPanel(GameCharacter charactersInventoryToRender, boolean buyback) {
-		return "<div class='container-full-width' style=''background:#45aac1>"
+		return "<div class='container-full-width' style='background:#19191a'>"
 					+getInventoryDiv(Main.game.getPlayer(), false) + getInventoryDiv(charactersInventoryToRender, buyback)
 				+"</div>";
 	}

--- a/src/com/lilithsthrone/utils/SvgUtil.java
+++ b/src/com/lilithsthrone/utils/SvgUtil.java
@@ -14,6 +14,8 @@ public class SvgUtil {
 	
 		s = s.replaceAll("linearGradient\\d|innoGrad\\d|radialGradient\\d",
 				gradientReplacementID + colour.toString() + (colourSecondary!=null?colourSecondary.toString():"") + (colourTertiary!=null?colourTertiary.toString():"") + "$0");
+
+		s = sanitizeImageString(s, false);
 		
 		if(colour!=null) {
 			s = s.replaceAll("#f4d7d7", colour.getShades()[0]);
@@ -53,9 +55,8 @@ public class SvgUtil {
 			s = s.replaceAll("linearGradient\\d|innoGrad\\d|radialGradient\\d",
 					gradientReplacementID + colour.toString() + (colourSecondary!=null?colourSecondary.toString():"") + (colourTertiary!=null?colourTertiary.toString():"") + "$0");
 		}
-		
-		// Fixes issue of SVG icons overflowing:
-		s = s.replaceFirst("width=\"100%\"\\R   height=\"100%\"", "");
+
+		s = sanitizeImageString(s, true);
 		
 		if(colour!=null) {
 			s = s.replaceAll("#ff2a2a", colour.getShades()[0]);
@@ -97,9 +98,8 @@ public class SvgUtil {
 			s = s.replaceAll("linearGradient\\d|innoGrad\\d|radialGradient\\d",
 					gradientReplacementID + colour.toString() + (colourSecondary!=null?colourSecondary.toString():"") + (colourTertiary!=null?colourTertiary.toString():"") + "$0");
 		}
-		
-		// Fixes issue of SVG icons overflowing:
-		s = s.replaceFirst("width=\"100%\"\\R   height=\"100%\"", "");
+
+		s = sanitizeImageString(s, true);
 		
 		if(colour!=null) {
 			s = s.replaceAll("#ff2a2a", colour.getShades()[0]);
@@ -136,9 +136,8 @@ public class SvgUtil {
 			s = s.replaceAll("linearGradient\\d|innoGrad\\d|radialGradient\\d",
 					gradientReplacementID + colour.toString() + "$0");
 		}
-		
-		// Fixes issue of SVG icons overflowing:
-		s = s.replaceFirst("width=\"100%\"\\R   height=\"100%\"", "");
+
+		s = sanitizeImageString(s, true);
 		
 		if(colour!=null) {
 			s = s.replaceAll("#ff2a2a", colour);
@@ -150,5 +149,18 @@ public class SvgUtil {
 		
 		return s;
 	}
-	
+
+	private static String sanitizeImageString(String imageString, boolean sanitizeSizes) {
+		String s = imageString;
+
+		// Remove xml header from svg, if it has one
+		s = s.replaceFirst("<\\?xml[^?]*\\?>", "");
+
+		if (sanitizeSizes) {
+			// Fixes issue of SVG icons overflowing:
+			s = s.replaceFirst("width=\"100%\"\\R   height=\"100%\"", "");
+		}
+
+		return s;
+	}
 }


### PR DESCRIPTION
The game's text parser recently got the ability to parse out comments,
denoted by //, but it was a bit overzealous. It would consume things that
shouldn't be comments, such as urls like http://lilithsthrone.blogspot.co.uk,
leaving just http: hanging, and obliterating everything else on that line.
This caused the start screen to look weird, and nearly every svg to be rendered
at the wrong size.

I've put in a fix for this by adding a negative lookbehind for ':'. Other
options could be to require comments are on their own line (not ideal),
comments begin with ' //' (that is a space, then two slashes), or similar,
but I think this is the least restrictive option.

This issue was introduced in commit f04832cb. Bad Inno, you should be
doing smaller commits more often, even if you don't push them to Github.

I have tested this fix in my own environment, which is 0.3.1.01. My discord
handle is CognitiveMist|Phlarx.