### PR TITLE
Configurable chance for randomized body pref / forced-tf race

### DIFF
--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -73,6 +73,8 @@ public class Properties {
 	public int forcedTFPercentage = 40;
 	public int forcedFetishPercentage = 0;
 
+	public float randomRacePercentage = 0.15f;
+
 	public int pregnancyBreastGrowthVariance = 2;
 	public int pregnancyBreastGrowth = 1;
 	public int pregnancyBreastGrowthLimit = CupSize.E.getMeasurement();
@@ -237,6 +239,7 @@ public class Properties {
 			createXMLElementWithValue(doc, settings, "multiBreasts", String.valueOf(multiBreasts));
 			createXMLElementWithValue(doc, settings, "udders", String.valueOf(udders));
 			createXMLElementWithValue(doc, settings, "forcedTFPercentage", String.valueOf(forcedTFPercentage));
+			createXMLElementWithValue(doc, settings, "randomRacePercentage", String.valueOf(randomRacePercentage)); 
 
 			createXMLElementWithValue(doc, settings, "pregnancyBreastGrowthVariance", String.valueOf(pregnancyBreastGrowthVariance));
 			createXMLElementWithValue(doc, settings, "pregnancyBreastGrowth", String.valueOf(pregnancyBreastGrowth));
@@ -668,6 +671,10 @@ public class Properties {
 				if(element.getElementsByTagName("forcedFetishPercentage").item(0)!=null) {
 					forcedFetishPercentage = Integer.valueOf(((Element)element.getElementsByTagName("forcedFetishPercentage").item(0)).getAttribute("value"));
 				}
+				// Randomized percentage of body pref race.
+				if(element.getElementsByTagName("randomRacePercentage").item(0)!=null) {
+					randomRacePercentage = Float.parseFloat(((Element)element.getElementsByTagName("randomRacePercentage").item(0)).getAttribute("value"));
+				}
 
 				// Forced TF preference:
 				if(element.getElementsByTagName("forcedTFPreference").item(0)!=null) {
@@ -1065,5 +1072,10 @@ public class Properties {
 
 	public void setForcedFetishTendency(ForcedFetishTendency forcedFetishTendency) {
 		this.forcedFetishTendency = forcedFetishTendency;
+	}
+	
+	public float getRandomRacePercentage() {
+		return randomRacePercentage;
+		
 	}
 }

--- a/src/com/lilithsthrone/game/character/npc/NPC.java
+++ b/src/com/lilithsthrone/game/character/npc/NPC.java
@@ -1893,7 +1893,7 @@ public abstract class NPC extends GameCharacter implements XMLSaving {
 			}
 			
 			// Chance for race to be random:
-			if(Math.random()>0.85f) {
+			if(Math.random() =< Main.getProperties().getRandomRacePercentage()) {
 				List<Subspecies> availableRaces = new ArrayList<>();
 				availableRaces.add(Subspecies.CAT_MORPH);
 				availableRaces.add(Subspecies.DOG_MORPH);

--- a/src/com/lilithsthrone/game/character/npc/NPC.java
+++ b/src/com/lilithsthrone/game/character/npc/NPC.java
@@ -1893,7 +1893,7 @@ public abstract class NPC extends GameCharacter implements XMLSaving {
 			}
 			
 			// Chance for race to be random:
-			if(Math.random() =< Main.getProperties().getRandomRacePercentage()) {
+			if(Math.random() <= Main.getProperties().getRandomRacePercentage()) {
 				List<Subspecies> availableRaces = new ArrayList<>();
 				availableRaces.add(Subspecies.CAT_MORPH);
 				availableRaces.add(Subspecies.DOG_MORPH);


### PR DESCRIPTION
_This allows future in-client settings or pref file editing to adjust the randomization of npc forced-tf potions which I find tends toward same-race too often. Sometimes I want to spawn humans that prefer furry races in their tfs or want more surprise. Doesn't actually alter the probability. I would add an option to set the variable but not yet gotten around to figuring out the options menus._

Adds in configurable probability of the the racial body pref for NPCs being randomized (and therefor race of forced-tf potions). Saves/loads a float in the properties file as the percentage chance of a randomized race. Default still uses 15% random, 85% same-race.

New Properties config variable ( randomRacePercentage default 0.15f ), saving and loading in properties.xml, getter for variable ( getRandomRacePercentage() ), and using variable for randomized race body pref generation.

Tested and appears to work without issue.

- So we have a better idea of who you are...
Eliria