### PR TITLE
Unit fixes

### DIFF
--- a/src/com/lilithsthrone/utils/Units.java
+++ b/src/com/lilithsthrone/utils/Units.java
@@ -507,7 +507,7 @@ public enum Units {
         value = roundTo(Math.abs(value), 0.25);
         double floor = Math.floor(value);
 
-        if (value == floor) return number(floor);
+        if (value == floor) return (negative ? '-' : "") + number(floor);
 
         int quarters = (int) Math.round((value - floor) / 0.25);
         return (negative ? '-' : "") + (floor == 0 ? "" : number(floor)) + getQuarterSymbol(quarters);

--- a/src/com/lilithsthrone/utils/Units.java
+++ b/src/com/lilithsthrone/utils/Units.java
@@ -262,6 +262,7 @@ public enum Units {
      * @param uType The format of the units, see {@link UnitType}
      * @return A string containing the imperial, formatted size, including unit
      */
+    @SuppressWarnings("incomplete-switch")
     public static String sizeAsImperial(double cm, ValueType vType, UnitType uType) {
         // Convert centimetres to inches
         double inches = cm / 2.54;
@@ -311,11 +312,6 @@ public enum Units {
                 case LONG:
                     output.append(" ").append(remainingInches > 1 ? "inches" : "inch");
                     break;
-				case LONG_SINGULAR: // Innoxia: I added these two case labels to remove the warning of this switch statement requiring them. I assume they're not used, but just in case, I copied over what is found in LONG:
-                    output.append(" ").append(remainingInches > 1 ? "inches" : "inch");
-					break;
-				case NONE:
-					break;
             }
         }
 

--- a/src/com/lilithsthrone/utils/Units.java
+++ b/src/com/lilithsthrone/utils/Units.java
@@ -290,7 +290,7 @@ public enum Units {
                 output.append(wrap ? FOOT_SYMBOL : INCH_SYMBOL);
                 break;
             case LONG:
-                if (Math.floor(Math.abs(inches)) == 0 && vType != ValueType.PRECISE) {
+                if (Math.floor(inches) == 0 && vType != ValueType.PRECISE) {
                     output.setLength(0);
                     return output.append("less than ")
                             .append(vType == ValueType.TEXT ? "one" : "1")
@@ -298,7 +298,7 @@ public enum Units {
                 }
 
                 output.append(" ");
-                if (Math.abs(usedValue) >= 1 + roundingFactor / 2) output.append(wrap ? "feet" : "inches");
+                if (Math.abs(usedValue) >= 1 + roundingFactor / 2 || usedValue == 0.0) output.append(wrap ? "feet" : "inches");
                 else output.append(wrap ? "foot" : "inch");
                 break;
             case LONG_SINGULAR:
@@ -473,6 +473,7 @@ public enum Units {
         StringBuilder output = new StringBuilder();
         boolean wrap = Math.abs(wrappedValue) >= 1 && vType != ValueType.PRECISE;
         double usedValue = wrap ? wrappedValue : value;
+        if (useQuarters) usedValue = roundTo(usedValue, 0.25);
 
         // Append value with increased precision if it is wrapped and numeric
         output.append(value(usedValue, wrap && vType == ValueType.NUMERIC ? ValueType.PRECISE : vType, useQuarters));
@@ -493,7 +494,7 @@ public enum Units {
                 }
 
                 output.append(" ").append(wrap ? wrappedUnit : unit);
-                if (Math.abs(usedValue) > 1) output.append("s");
+                if (Math.abs(usedValue) > 1 || usedValue == 0.0) output.append("s");
                 break;
             case LONG_SINGULAR:
                 output.append("-").append((wrap ? wrappedUnit : unit));

--- a/src/com/lilithsthrone/utils/Units.java
+++ b/src/com/lilithsthrone/utils/Units.java
@@ -275,7 +275,7 @@ public enum Units {
 
         StringBuilder output = new StringBuilder();
 
-        boolean both = (uType == UnitType.SHORT || uType == UnitType.LONG) && vType != ValueType.TEXT
+        boolean both = uType != UnitType.NONE && vType != ValueType.TEXT
                 && feet != 0 && remainingInches != 0;
         boolean wrap = (vType == ValueType.TEXT && Math.abs(inches) >= 11.5)
                 || both || (feet != 0 && remainingInches == 0);
@@ -308,6 +308,7 @@ public enum Units {
         // Append second unit for long or short notation and if neither value is 0
         if (both) {
             if (uType == UnitType.LONG) output.append(" and ");
+            if (uType == UnitType.LONG_SINGULAR) output.append("-");
             remainingInches = Math.abs(roundTo(remainingInches, roundingFactor));
             output.append(value(remainingInches, vType, true));
             switch (uType) {
@@ -316,6 +317,8 @@ public enum Units {
                     break;
                 case LONG:
                     output.append(" ").append(remainingInches >= 1 + roundingFactor / 2 ? "inches" : "inch");
+                    break;
+                case LONG_SINGULAR:
                     break;
             }
         }


### PR DESCRIPTION
And another one. Honestly, at 5000 lines changed there were bound to be some inconveniences. But since it's all about convenience, those shall also be fixed.

### Changes
- Fix missing sign of negative values
- Fix rounding issues (most notably for imperial sizes)
- Use plural for value 0
- Wrap long singular inches to \*-foot-\* (recommended to me as more readable than something like 80-inch, I have never used the imperial system so I wouldn't know)

### Testing
All changes have been tested on 0.3.1.1.