### PR TITLE
Add difficulty option: Opportunistic Attackers

### DIFF
--- a/src/com/lilithsthrone/controller/MainControllerInitMethod.java
+++ b/src/com/lilithsthrone/controller/MainControllerInitMethod.java
@@ -5028,7 +5028,9 @@ public class MainControllerInitMethod {
 		
 		// Content preferences:
 
-		if (Main.game.getCurrentDialogueNode() == OptionsDialogue.CONTENT_PREFERENCE || Main.game.getCurrentDialogueNode() == CharacterCreation.CONTENT_PREFERENCES) {
+		if (Main.game.getCurrentDialogueNode() == OptionsDialogue.CONTENT_PREFERENCE
+				|| Main.game.getCurrentDialogueNode() == CharacterCreation.CONTENT_PREFERENCES
+				|| Main.game.getCurrentDialogueNode() == OptionsDialogue.OPTIONS) {
 			createToggleListener("ARTWORK_ON", PropertyValue.artwork, true);
 			createToggleListener("ARTWORK_OFF", PropertyValue.artwork, false);
 			createToggleListener("SILLY_ON", PropertyValue.sillyMode, true);
@@ -5081,7 +5083,8 @@ public class MainControllerInitMethod {
 					new Value<>("HAIR_ASS", PropertyValue.assHairContent),
 					new Value<>("FEMININE_BEARD", PropertyValue.feminineBeardsContent),
 					new Value<>("FURRY_TAIL_PENETRATION", PropertyValue.furryTailPenetrationContent),
-					new Value<>("INFLATION_CONTENT", PropertyValue.inflationContent));
+					new Value<>("INFLATION_CONTENT", PropertyValue.inflationContent),
+					new Value<>("OPPORTUNISTIC_ATTACKERS", PropertyValue.opportunisticAttackers));
 			
 			for(Entry<String, PropertyValue> entry : settingsMap.entrySet()) {
 				createToggleListener(entry.getKey()+"_ON", entry.getValue(), true);

--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -3532,5 +3532,8 @@ public class Game implements XMLSaving {
 	public void setRequestAutosave(boolean requestAutosave) {
 		this.requestAutosave = requestAutosave;
 	}
-	
+
+	public boolean isOpportunisticAttackersEnabled() {
+		return Main.getProperties().hasValue(PropertyValue.opportunisticAttackers);
+	}
 }

--- a/src/com/lilithsthrone/game/PropertyValue.java
+++ b/src/com/lilithsthrone/game/PropertyValue.java
@@ -52,6 +52,8 @@ public enum PropertyValue {
 	voluntaryNTR(false),
 	involuntaryNTR(false),
 
+	opportunisticAttackers(false),
+
 	levelUpHightlight(false),
 	newWeaponDiscovered(false),
 	newClothingDiscovered(false),

--- a/src/com/lilithsthrone/game/character/attributes/LustLevel.java
+++ b/src/com/lilithsthrone/game/character/attributes/LustLevel.java
@@ -329,18 +329,28 @@ public enum LustLevel {
 					break;
 				case ONE_HORNY:
 					sb.append("[npc.NameIsFull] currently quite horny, but [npc.is] still in control of [npc.her] lust.");
+					if(Main.game.isOpportunisticAttackersEnabled() && character.isPlayer())
+						sb.append("<br><b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>It seems you're beginning to attract trouble.");
 					break;
 				case TWO_AMOROUS:
 					sb.append("[npc.NameIsFull] currently feeling more than a little lustful, and [npc.is] thinking about sex quite a lot.");
+					if(Main.game.isOpportunisticAttackersEnabled() && character.isPlayer())
+						sb.append("<br><b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>You can feel more and more troublesome gazes.");
 					break;
 				case THREE_LUSTFUL:
 					sb.append("[npc.NameIsFull] currently burning with lust, and [npc.is] struggling to think of anything other than sex.");
+					if(Main.game.isOpportunisticAttackersEnabled() && character.isPlayer())
+						sb.append("<br><b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Your lust-filled aura can no longer be denied.");
 					break;
 				case FOUR_IMPASSIONED:
 					sb.append("[npc.NameIsFull] completely burning with lust, and [npc.is] struggling to think of anything other than sex.");
+					if(Main.game.isOpportunisticAttackersEnabled() && character.isPlayer())
+						sb.append("<br><b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Almost every passerby turns to you with lustful gazes.");
 					break;
 				case FIVE_BURNING:
 					sb.append("[npc.NameIsFull] completely overwhelmed with lust, and [npc.is] incapable of thinking of anything but sex.");
+					if(Main.game.isOpportunisticAttackersEnabled() && character.isPlayer())
+						sb.append("<br><b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Everyone can tell you're completely filled with lust. Some will probably try take advantage.");
 					break;
 			}
 		}

--- a/src/com/lilithsthrone/game/character/effects/StatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/StatusEffect.java
@@ -1970,6 +1970,13 @@ public enum StatusEffect {
 		}
 
 		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Your smelly clothes seem to attract trouble.";
+			return super.getAdditionalDescription(target);
+		}
+
+		@Override
 		public boolean isConditionsMet(GameCharacter target) {
 			if(!isCumEffectPositive(target)) {
 				for (AbstractClothing c : target.getClothingCurrentlyEquipped()) {
@@ -2008,6 +2015,13 @@ public enum StatusEffect {
 				return UtilText.parse(target, "Some of [npc.namePos] clothes have been covered in cum, milk or other sexual fluids."
 						+ " [npc.sheIs] feeling incredibly turned on to be walking around in such filthy clothing.");
 			}
+		}
+
+		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Your smelly clothes seem to attract trouble.";
+			return super.getAdditionalDescription(target);
 		}
 
 		@Override
@@ -2097,6 +2111,12 @@ public enum StatusEffect {
 						+ " [npc.sheIs] feeling incredibly embarrassed to be walking around in such a filthy state.");
 			}
 		}
+		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Your smelly body seems to attract trouble.";
+			return super.getAdditionalDescription(target);
+		}
 
 		@Override
 		public boolean isConditionsMet(GameCharacter target) {
@@ -2127,6 +2147,13 @@ public enum StatusEffect {
 				return UtilText.parse(target, "Some parts of [npc.namePos] body have been covered in cum, milk or other sexual fluids."
 						+ " [npc.sheIs] feeling incredibly turned on by walking around in such a filthy state.");
 			}
+		}
+
+		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Your smelly body seems to attract trouble.";
+			return super.getAdditionalDescription(target);
 		}
 
 		@Override
@@ -2585,6 +2612,13 @@ public enum StatusEffect {
 		}
 
 		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>You're obviously drunk and some might think you're easy prey.";
+			return super.getAdditionalDescription(target);
+		}
+
+		@Override
 		public boolean isSexEffect() {
 			return true;
 		}
@@ -2625,6 +2659,13 @@ public enum StatusEffect {
 		}
 
 		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>You're obviously drunk and some might think you're easy prey.";
+			return super.getAdditionalDescription(target);
+		}
+
+		@Override
 		public boolean isSexEffect() {
 			return true;
 		}
@@ -2662,6 +2703,13 @@ public enum StatusEffect {
 				return (UtilText.parse(target, "After recently drinking an alcoholic liquid, [npc.name] is feeling completely wasted...<br/>"
 						+ "Intoxication: "+target.getIntoxicationPercentage()+"%"));
 			}
+		}
+
+		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>You're obviously drunk and some might think you're easy prey.";
+			return super.getAdditionalDescription(target);
 		}
 
 		@Override
@@ -5157,6 +5205,12 @@ public enum StatusEffect {
 			return UtilText.parse(target, "[npc.NamePos] clothing doesn't conceal [npc.her] "+getExposedPartsNamesList(target)+", and [npc.she] [npc.verb(feel)] highly embarrassed to be walking around in such an exposed fashion.");
 		}
 		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Your exposed body parts attract all kind of lewd gazes.";
+			return super.getAdditionalDescription(target);
+		}
+		@Override
 		public boolean isConditionsMet(GameCharacter target) {
 			return !target.hasFetish(Fetish.FETISH_EXHIBITIONIST)
 					&& target.getLegConfiguration()==LegConfiguration.BIPEDAL
@@ -5233,6 +5287,12 @@ public enum StatusEffect {
 			return UtilText.parse(target, "[npc.NamePos] clothing doesn't conceal [npc.her] "+getExposedPartsNamesList(target)+", and [npc.she] [npc.verb(feel)] highly embarrassed to be walking around in such an exposed fashion.");
 		}
 		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Your exposed body parts attract all kind of lewd gazes.";
+			return super.getAdditionalDescription(target);
+		}
+		@Override
 		public boolean isConditionsMet(GameCharacter target) {
 			return !target.hasFetish(Fetish.FETISH_EXHIBITIONIST)
 					&& (target.getLegConfiguration()==LegConfiguration.BIPEDAL || ((target.hasBreasts() || target.isFeminine()) && target.isCoverableAreaVisible(CoverableArea.NIPPLES)))
@@ -5264,6 +5324,12 @@ public enum StatusEffect {
 				return "";
 			}
 			return UtilText.parse(target, "[npc.NamePos] clothing doesn't conceal [npc.her] "+getExposedPartsNamesList(target)+", and [npc.she] [npc.verb(feel)] highly embarrassed to be walking around in such an exposed fashion.");
+		}
+		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Your exposed body parts attract all kind of lewd gazes.";
+			return super.getAdditionalDescription(target);
 		}
 
 		@Override
@@ -5299,6 +5365,12 @@ public enum StatusEffect {
 			}
 			return UtilText.parse(target, "[npc.NamePos] clothing doesn't conceal [npc.her] "+getExposedPartsNamesList(target)+", and [npc.she] [npc.verb(feel)] incredibly sexy and empowered to be walking around in such an exposed fashion.");
 		}
+		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Your exposed body parts attract all kind of lewd gazes.";
+			return super.getAdditionalDescription(target);
+		}
 
 		@Override
 		public boolean isConditionsMet(GameCharacter target) {
@@ -5332,6 +5404,12 @@ public enum StatusEffect {
 			}
 			return UtilText.parse(target, "[npc.NamePos] clothing doesn't conceal [npc.her] "+getExposedPartsNamesList(target)+", and [npc.she] [npc.verb(feel)] incredibly sexy and empowered to be walking around in such an exposed fashion.");
 		}
+		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Your exposed body parts attract all kind of lewd gazes.";
+			return super.getAdditionalDescription(target);
+		}
 
 		@Override
 		public boolean isConditionsMet(GameCharacter target) {
@@ -5364,6 +5442,12 @@ public enum StatusEffect {
 				return "";
 			}
 			return UtilText.parse(target, "[npc.NamePos] clothing doesn't conceal [npc.her] "+getExposedPartsNamesList(target)+", and [npc.she] [npc.verb(feel)] incredibly sexy and empowered to be walking around in such an exposed fashion.");
+		}
+		@Override
+		public String getAdditionalDescription(GameCharacter target) {
+			if(Main.game.isOpportunisticAttackersEnabled() && target.isPlayer())
+				return "<b style='color:" + Colour.BASE_GREY.toWebHexString() +";'>Opportunistic Attackers</b><br>Your exposed body parts attract all kind of lewd gazes.";
+			return super.getAdditionalDescription(target);
 		}
 
 		@Override

--- a/src/com/lilithsthrone/game/dialogue/encounters/Encounter.java
+++ b/src/com/lilithsthrone/game/dialogue/encounters/Encounter.java
@@ -988,8 +988,52 @@ public enum Encounter {
 			}
 			r *= Math.random();
 		}
-		
+
+		float opportunisticMultiplier = 1;
+		if(Main.game.isOpportunisticAttackersEnabled()) {
+			// lust: linear boost; 25% max
+			opportunisticMultiplier += Main.game.getPlayer().getLust() / 200;
+			// energy: linear boost; 25% (theoretical) max
+			opportunisticMultiplier += 0.25f - Main.game.getPlayer().getHealthPercentage() * 0.25f;
+			// smelly body: 25% boost
+			if(Main.game.getPlayer().hasStatusEffect(StatusEffect.BODY_CUM)
+					|| Main.game.getPlayer().hasStatusEffect(StatusEffect.BODY_CUM_MASOCHIST))
+				opportunisticMultiplier += 0.25f;
+			// smelly clothes: 25% boost
+			if(Main.game.getPlayer().hasStatusEffect(StatusEffect.CLOTHING_CUM)
+					|| Main.game.getPlayer().hasStatusEffect(StatusEffect.CLOTHING_CUM_MASOCHIST))
+				opportunisticMultiplier += 0.25f;
+			// exposure: 50% or 75% boost
+			if(!Collections.disjoint(Util.newArrayListOfValues(
+					StatusEffect.EXPOSED,
+					StatusEffect.EXPOSED_BREASTS,
+					StatusEffect.FETISH_EXHIBITIONIST,
+					StatusEffect.FETISH_EXHIBITIONIST_BREASTS
+			), Main.game.getPlayer().getStatusEffects()))
+				opportunisticMultiplier += 0.5f;
+			if(!Collections.disjoint(Util.newArrayListOfValues(
+					StatusEffect.EXPOSED_PLUS_BREASTS,
+					StatusEffect.FETISH_EXHIBITIONIST_PLUS_BREASTS
+			), Main.game.getPlayer().getStatusEffects()))
+				opportunisticMultiplier += 0.75f;
+			// drunk: 50% boost
+			if(!Collections.disjoint(Util.newArrayListOfValues(
+					StatusEffect.DRUNK_3,
+					StatusEffect.DRUNK_4,
+					StatusEffect.DRUNK_5
+			), Main.game.getPlayer().getStatusEffects()))
+				opportunisticMultiplier += 0.5f;
+		}
+
 		for (Entry<EncounterType, Float> e : getDialogues().entrySet()) {
+			EncounterType encounter = e.getKey();
+			float encounterChance = e.getValue();
+			// opportunistic attackers: compare with amplified chance
+			if(encounter.isOpportunistic()) encounterChance *= opportunisticMultiplier;
+			if (r <= total + encounterChance) {
+				return initialiseEncounter(encounter);
+			}
+			// add unmodified chance
 			total += e.getValue();
 			if (r <= total) {
 				return initialiseEncounter(e.getKey());

--- a/src/com/lilithsthrone/game/dialogue/encounters/EncounterType.java
+++ b/src/com/lilithsthrone/game/dialogue/encounters/EncounterType.java
@@ -9,7 +9,7 @@ public enum EncounterType {
 
 	SPECIAL_DOMINION_CULTIST,
 	
-	SLAVE_USES_YOU,
+	SLAVE_USES_YOU(true),
 	
 	DOMINION_STREET_FIND_HAPPINESS, // Kinariu
 	DOMINION_STREET_RENTAL_MOMMY,
@@ -19,19 +19,30 @@ public enum EncounterType {
 	DOMINION_FIND_CLOTHING,
 	DOMINION_FIND_WEAPON,
 
-	DOMINION_ALLEY_ATTACK,
-	DOMINION_STORM_ATTACK,
+	DOMINION_ALLEY_ATTACK(true),
+	DOMINION_STORM_ATTACK(true),
 	
 	
-	HARPY_NEST_ATTACK,
-	HARPY_NEST_ATTACK_STORM,
+	HARPY_NEST_ATTACK(true),
+	HARPY_NEST_ATTACK_STORM(true),
 	HARPY_NEST_FIND_ITEM,
 	
-	SUBMISSION_TUNNEL_ATTACK,
+	SUBMISSION_TUNNEL_ATTACK(true),
 	SUBMISSION_FIND_ITEM,
 
-	BAT_CAVERN_BAT_ATTACK,
-	BAT_CAVERN_SLIME_ATTACK,
+	BAT_CAVERN_BAT_ATTACK(true),
+	BAT_CAVERN_SLIME_ATTACK(true),
 	BAT_CAVERN_FIND_ITEM
 	;
+
+	EncounterType() {}
+	EncounterType(boolean opportunistic) {
+		this.opportunistic = opportunistic;
+	}
+
+	private boolean opportunistic = false;
+
+	public boolean isOpportunistic() {
+		return opportunistic;
+	}
 }

--- a/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
@@ -583,7 +583,15 @@ public class OptionsDialogue {
 							:"<span style='color:"+dl.getColour().getShades()[0]+";'>"+Util.capitaliseSentence(dl.getName())+"</span> [style.colourDisabled("+dl.getDescription()+")]")
 						 );
 			}
-			
+
+			UtilText.nodeContentSB.append("<p><b>Other difficulty/scenario options:<b></p>");
+			UtilText.nodeContentSB.append(getContentPreferenceDiv(
+					"OPPORTUNISTIC_ATTACKERS",
+					Colour.BASE_CRIMSON,
+					"Opportunistic attackers",
+					"This makes random attacks more likely when you're aroused, low on health or otherwise obviously easy prey.",
+					Main.game.isOpportunisticAttackersEnabled()));
+
 			UtilText.nodeContentSB.append("</p>");
 			
 			return UtilText.nodeContentSB.toString();


### PR DESCRIPTION
### Things to include in a large Pull Request:

- What is the purpose of the pull request?
*This adds one of some proposed optional difficulty/scenario options.*

- Give a brief description of what you changed or added.
*This difficulty option will increase the probability of random encounters when the player is beat up or obviously easy prey. The increased probability is only applied to encounters that want to take advantage of the player. The encounter probability "boost" is determined by:*
  - *energy level*
  - *lust level*
  - *dirty clothing/body*
  - *exposed body parts*
  - *"drunk" state*

- Are any new graphical assets required?
*no*

- Has this change been tested? If so, mention the version number that the test was based on.
*by me, with various versions from 3.0+*

- So we have a better idea of who you are, what is your Discord Handle?
*none currently*

Since i'm not a native english speaker, the wording may seem a bit odd at times and i'll appreciate corrections/suggestions!
