### PR TITLE
Deprecated Method Used

### DIFF
--- a/src/com/lilithsthrone/utils/Units.java
+++ b/src/com/lilithsthrone/utils/Units.java
@@ -574,7 +574,7 @@ public enum Units {
      */
     public static float round(double value, int places) {
         if (places < 0) throw new IllegalArgumentException("Amount of fractional places cannot be less than 0.");
-        return BigDecimal.valueOf(value).setScale(places, java.math.RoundingMode.HALF_UP).floatValue();
+        return BigDecimal.valueOf(value).setScale(places, RoundingMode.HALF_UP).floatValue();
     }
 
     /**

--- a/src/com/lilithsthrone/utils/Units.java
+++ b/src/com/lilithsthrone/utils/Units.java
@@ -574,7 +574,7 @@ public enum Units {
      */
     public static float round(double value, int places) {
         if (places < 0) throw new IllegalArgumentException("Amount of fractional places cannot be less than 0.");
-        return BigDecimal.valueOf(value).setScale(places, BigDecimal.ROUND_HALF_UP).floatValue();
+        return BigDecimal.valueOf(value).setScale(places, java.math.RoundingMode.HALF_UP).floatValue();
     }
 
     /**


### PR DESCRIPTION
The method BigDecimal.setScale(int, int) is deprecated in favor of BigDecimal.setScale(int, RoundingMode)

- What is the purpose of the pull request?
Mostly I'm learning to use GitHub, focusing on minor fixes.
- Give a brief description of what you changed or added.
Replacing deprecated code with the up-to-date version.
- Has this change been tested? If so, mention the version number that the test was based on.
The deprecated code will still compile in Java 12, but gives a deprecation warning in Java 10 or higher.  The fix is compatible starting in Java 5, and should be functional indefinitely.  Since Lilith's Throne is compiled in Java 8 to avoid issues with JavaFX, this should not be a major concern.
- So we have a better idea of who you are, what is your Discord Handle?
JJoseph#3701
