### PR TITLE
Performance fixes for savefiles

### DIFF
--- a/res/clothing/innoxia/foot/heels.xml
+++ b/res/clothing/innoxia/foot/heels.xml
@@ -38,7 +38,7 @@
 		<primaryColoursDye/>
 		<secondaryColours values="JUST_TAN"/>
 		<secondaryColoursDye values="ALL"/>
-		<tertiaryColours values="JSUT_BLACK"/>
+		<tertiaryColours values="JUST_BLACK"/>
 		<tertiaryColoursDye values="ALL"/>
 		
 		<itemTags> 

--- a/src/com/lilithsthrone/controller/MainController.java
+++ b/src/com/lilithsthrone/controller/MainController.java
@@ -2131,7 +2131,7 @@ public class MainController implements Initializable {
 								@Override
 								public void initStartingLustAndArousal(GameCharacter character) {
 									if(!character.isPlayer()) {
-										character.setLust(100);
+										character.setLustNoText(100);
 										character.setArousal(25);
 									} else {
 										super.initStartingLustAndArousal(character);
@@ -2208,7 +2208,7 @@ public class MainController implements Initializable {
 								}
 								@Override
 								public void initStartingLustAndArousal(GameCharacter character) {
-									character.setLust(100);
+									character.setLustNoText(100);
 									character.setArousal(25);
 								}
 								@Override

--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -4032,12 +4032,7 @@ public abstract class GameCharacter implements XMLSaving {
 	}
 	
 	public boolean hasDiscoveredElemental() {
-		try {
-			Main.game.getNPCById(elementalID);
-			return true;
-		}catch(Exception e) {
-			return false;
-		}
+		return Main.game.isCharacterExisting(elementalID);
 	}
 	
 	public boolean isElementalSummoned() {

--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -535,7 +535,7 @@ public abstract class GameCharacter implements XMLSaving {
 		
 		health = getAttributeValue(Attribute.HEALTH_MAXIMUM);
 		mana = getAttributeValue(Attribute.MANA_MAXIMUM);
-		setLust(getRestingLust());
+		setLustNoText(getRestingLust());
 		
 		//Companion initialization
 		elementalID = "";
@@ -13388,7 +13388,7 @@ public abstract class GameCharacter implements XMLSaving {
 	
 	public void alignLustToRestingLust(int secondsPassed) {
 		if(hasStatusEffect(StatusEffect.WEATHER_STORM_VULNERABLE)) {
-			setLust(75);
+			setLustNoText(75);
 		} else {
 			if(getLust()>getRestingLust()) {
 				incrementLust(-Math.min(getLust()-getRestingLust(), 0.008f*secondsPassed), false);
@@ -13407,18 +13407,9 @@ public abstract class GameCharacter implements XMLSaving {
 	
 	public String setLust(float lust) {
 		int increment = (int) (lust-this.getLust());
-		if (lust < 0) {
-			setAttribute(Attribute.LUST, 0, false);
-			
-		} else if (lust > 100) {
-			setAttribute(Attribute.LUST, 100, false);
-			
-		} else {
-			setAttribute(Attribute.LUST, lust, false);
-		}
 
-		updateAttributeListeners();
-		
+		setLustNoText(lust);
+
 		if(this.isPlayer()) {
 			return "<p style='text-align:center;'>"
 						+ "You "+(increment>0?"gained":"lost")+" [style.boldDmgLust("+increment+" lust)], and are now feeling"
@@ -13430,6 +13421,18 @@ public abstract class GameCharacter implements XMLSaving {
 							+ " <b style='color:"+this.getLustLevel().getColour().toWebHexString()+";'>"+this.getLustLevel().getName()+"</b>.")
 				+ "</p>";
 		}
+	}
+
+	public void setLustNoText(float lust) {
+		if (lust < 0) {
+			setAttribute(Attribute.LUST, 0, false);
+		} else if (lust > 100) {
+			setAttribute(Attribute.LUST, 100, false);
+		} else {
+			setAttribute(Attribute.LUST, lust, false);
+		}
+
+		updateAttributeListeners();
 	}
 	
 	/**

--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -13419,14 +13419,7 @@ public abstract class GameCharacter implements XMLSaving {
 	}
 
 	public void setLustNoText(float lust) {
-		if (lust < 0) {
-			setAttribute(Attribute.LUST, 0, false);
-		} else if (lust > 100) {
-			setAttribute(Attribute.LUST, 100, false);
-		} else {
-			setAttribute(Attribute.LUST, lust, false);
-		}
-
+		setAttribute(Attribute.LUST, Math.max(0, Math.min(lust, 100)), false);
 		updateAttributeListeners();
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/submission/ImpAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/ImpAttacker.java
@@ -362,7 +362,7 @@ public class ImpAttacker extends NPC {
 						if(Main.game.getPlayer().getLocationPlace().getPlaceType().equals(PlaceType.FORTRESS_LAB)) {
 							if(Main.game.isNonConEnabled() && (Main.game.getPlayer().isFeminine() || (ImpCitadelDialogue.isCompanionDialogue() && ImpCitadelDialogue.getMainCompanion().isFeminine()))) {
 								ImpCitadelDialogue.getArcanist().displaceClothingForAccess(CoverableArea.VAGINA);
-								ImpCitadelDialogue.getArcanist().setLust(50);
+								ImpCitadelDialogue.getArcanist().setLustNoText(50);
 							}
 						}
 						ImpCitadelDialogue.getArcanist().setLocation(WorldType.IMP_FORTRESS_DEMON, PlaceType.FORTRESS_LAB);

--- a/src/com/lilithsthrone/game/combat/Spell.java
+++ b/src/com/lilithsthrone/game/combat/Spell.java
@@ -2136,7 +2136,7 @@ public enum Spell {
 				if(success) {
 					target.setHealthPercentage(0);
 					target.setManaPercentage(0);
-					target.setLust(100);
+					target.setLustNoText(100);
 					descriptionSB.append(getStatusEffectApplication(caster, target, isHit, isCritical));
 					if(target.isPlayer()) {
 						descriptionSB.append(

--- a/src/com/lilithsthrone/game/dialogue/npcDialogue/OccupantDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/npcDialogue/OccupantDialogue.java
@@ -1157,7 +1157,7 @@ public class OccupantDialogue {
 						public void effects() {
 							Main.game.getPlayer().setHealth(Main.game.getPlayer().getAttributeValue(Attribute.HEALTH_MAXIMUM));
 							Main.game.getPlayer().setMana(Main.game.getPlayer().getAttributeValue(Attribute.MANA_MAXIMUM));
-							Main.game.getPlayer().setLust(0);
+							Main.game.getPlayer().setLustNoText(0);
 							if(Main.game.getPlayer().hasTrait(Perk.JOB_UNEMPLOYED, true)) {
 								Main.game.getPlayer().addStatusEffect(StatusEffect.WELL_RESTED_BOOSTED, (8*60*60) + sleepTimer);
 							} else {

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/EnforcerHQDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/EnforcerHQDialogue.java
@@ -1478,7 +1478,7 @@ public class EnforcerHQDialogue {
 				return new ResponseCombat("Fight", "[brax.name] looks extremely embarrassed, and you're sure that you've given yourself at least a small advantage by tricking him like this!", Main.game.getNpc(Brax.class)){
 					@Override
 					public void effects(){
-						Main.game.getNpc(Brax.class).setLust(30);
+						Main.game.getNpc(Brax.class).setLustNoText(30);
 					}
 				};
 					
@@ -1638,7 +1638,7 @@ public class EnforcerHQDialogue {
 				return new ResponseCombat("Fight", "[brax.name] looks extremely embarrassed, and you're sure that you've given yourself a big advantage by tricking him like this!", Main.game.getNpc(Brax.class)){
 					@Override
 					public void effects(){
-						Main.game.getNpc(Brax.class).setLust(50);
+						Main.game.getNpc(Brax.class).setLustNoText(50);
 					}
 				};
 					

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/RoomPlayer.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/RoomPlayer.java
@@ -47,7 +47,7 @@ public class RoomPlayer {
 				public void effects() {
 					Main.game.getPlayer().setHealth(Main.game.getPlayer().getAttributeValue(Attribute.HEALTH_MAXIMUM));
 					Main.game.getPlayer().setMana(Main.game.getPlayer().getAttributeValue(Attribute.MANA_MAXIMUM));
-					Main.game.getPlayer().setLust(0);
+					Main.game.getPlayer().setLustNoText(0);
 					if(Main.game.getPlayer().hasTrait(Perk.JOB_UNEMPLOYED, true)) {
 						Main.game.getPlayer().addStatusEffect(StatusEffect.WELL_RESTED_BOOSTED, (8*60*60) + 240);
 					} else {
@@ -66,7 +66,7 @@ public class RoomPlayer {
 				public void effects() {
 					Main.game.getPlayer().setHealth(Main.game.getPlayer().getAttributeValue(Attribute.HEALTH_MAXIMUM));
 					Main.game.getPlayer().setMana(Main.game.getPlayer().getAttributeValue(Attribute.MANA_MAXIMUM));
-					Main.game.getPlayer().setLust(0);
+					Main.game.getPlayer().setLustNoText(0);
 					if(Main.game.getPlayer().hasTrait(Perk.JOB_UNEMPLOYED, true)) {
 						Main.game.getPlayer().addStatusEffect(StatusEffect.WELL_RESTED_BOOSTED, (8*60*60) + sleepTimer*60);
 					} else {

--- a/src/com/lilithsthrone/game/dialogue/places/submission/GamblingDenDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/places/submission/GamblingDenDialogue.java
@@ -1216,7 +1216,7 @@ public class GamblingDenDialogue {
 							public void initStartingLustAndArousal(GameCharacter character) {
 								if(!character.isPlayer()) {
 									character.setArousal(75);
-									character.setLust(80);
+									character.setLustNoText(80);
 								}
 							}
 							@Override
@@ -1253,7 +1253,7 @@ public class GamblingDenDialogue {
 							public void initStartingLustAndArousal(GameCharacter character) {
 								if(!character.isPlayer()) {
 									character.setArousal(75);
-									character.setLust(80);
+									character.setLustNoText(80);
 								}
 							}
 							@Override
@@ -1312,7 +1312,7 @@ public class GamblingDenDialogue {
 								public void initStartingLustAndArousal(GameCharacter character) {
 									if(!character.isPlayer()) {
 										character.setArousal(75);
-										character.setLust(80);
+										character.setLustNoText(80);
 									}
 								}
 								@Override
@@ -1349,7 +1349,7 @@ public class GamblingDenDialogue {
 								public void initStartingLustAndArousal(GameCharacter character) {
 									if(!character.isPlayer()) {
 										character.setArousal(75);
-										character.setLust(80);
+										character.setLustNoText(80);
 									}
 								}
 								@Override
@@ -1532,7 +1532,7 @@ public class GamblingDenDialogue {
 							@Override
 							public void initStartingLustAndArousal(GameCharacter character) {
 								character.setArousal(50);
-								character.setLust(80);
+								character.setLustNoText(80);
 							}
 						},
 						null,

--- a/src/com/lilithsthrone/game/dialogue/places/submission/SlimeQueensLair.java
+++ b/src/com/lilithsthrone/game/dialogue/places/submission/SlimeQueensLair.java
@@ -715,7 +715,7 @@ public class SlimeQueensLair {
 					return new Response("Seduce", "Seduce [slimeRoyalGuard.name] and encourage [slimeRoyalGuard.him] to show off to you in an attempt to get [slimeRoyalGuard.him] to wear [slimeRoyalGuard.himself] out.", ROYAL_GUARD_POST_ADMIRE_SEDUCE) {
 						@Override
 						public void effects() {
-							Main.game.getNpc(SlimeRoyalGuard.class).setLust(80);
+							Main.game.getNpc(SlimeRoyalGuard.class).setLustNoText(80);
 						}
 					};
 					

--- a/src/com/lilithsthrone/game/inventory/clothing/AbstractClothing.java
+++ b/src/com/lilithsthrone/game/inventory/clothing/AbstractClothing.java
@@ -1370,12 +1370,7 @@ public abstract class AbstractClothing extends AbstractCoreItem implements XMLSa
 		
 		for(ItemEffect ie : getEffects()) {
 			if(ie.getPrimaryModifier() == TFModifier.CLOTHING_ATTRIBUTE || ie.getPrimaryModifier() == TFModifier.CLOTHING_MAJOR_ATTRIBUTE) {
-				if(attributeModifiers.containsKey(ie.getSecondaryModifier().getAssociatedAttribute())) {
-					attributeModifiers.put(ie.getSecondaryModifier().getAssociatedAttribute(), attributeModifiers.get(ie.getSecondaryModifier().getAssociatedAttribute()) + ie.getPotency().getClothingBonusValue());
-				} else {
-					attributeModifiers.put(ie.getSecondaryModifier().getAssociatedAttribute(), ie.getPotency().getClothingBonusValue());
-				}
-				
+				attributeModifiers.merge(ie.getSecondaryModifier().getAssociatedAttribute(), ie.getPotency().getClothingBonusValue(), Integer::sum);
 			}
 		}
 		

--- a/src/com/lilithsthrone/game/sex/Sex.java
+++ b/src/com/lilithsthrone/game/sex/Sex.java
@@ -427,25 +427,25 @@ public class Sex {
 				}
 				switch(sexManager.getStartingSexPaceModifier(character)) {
 					case DOM_GENTLE:
-						character.setLust(10);
+						character.setLustNoText(10);
 						break;
 					case DOM_NORMAL:
 						character.setArousal(5);
 						break;
 					case DOM_ROUGH:
-						character.setLust(85);
+						character.setLustNoText(85);
 						character.setArousal(10);
 						break;
 					case SUB_EAGER:
-						character.setLust(85);
+						character.setLustNoText(85);
 						character.setArousal(10);
 						break;
 					case SUB_NORMAL:
-						character.setLust(Math.max(character.getLust(), 10));
+						character.setLustNoText(Math.max(character.getLust(), 10));
 						character.setArousal(5);
 						break;
 					case SUB_RESISTING:
-						character.setLust(0);
+						character.setLustNoText(0);
 						break;
 				}
 			}
@@ -454,25 +454,25 @@ public class Sex {
 				forceSexPaceMap.put(character, sexManager.getForcedSexPace(character));
 				switch(sexManager.getForcedSexPace(character)) {
 					case DOM_GENTLE:
-						character.setLust(10);
+						character.setLustNoText(10);
 						break;
 					case DOM_NORMAL:
 						character.setArousal(5);
 						break;
 					case DOM_ROUGH:
-						character.setLust(85);
+						character.setLustNoText(85);
 						character.setArousal(10);
 						break;
 					case SUB_EAGER:
-						character.setLust(85);
+						character.setLustNoText(85);
 						character.setArousal(10);
 						break;
 					case SUB_NORMAL:
-						character.setLust(Math.max(character.getLust(), 10));
+						character.setLustNoText(Math.max(character.getLust(), 10));
 						character.setArousal(5);
 						break;
 					case SUB_RESISTING:
-						character.setLust(0);
+						character.setLustNoText(0);
 						break;
 				}
 			}
@@ -666,7 +666,7 @@ public class Sex {
 			}
 			
 			if(getNumberOfOrgasms(participant) > 0) {
-				participant.setLust(0);
+				participant.setLustNoText(0);
 			}
 		}
 		

--- a/src/com/lilithsthrone/game/sex/managers/SexManagerInterface.java
+++ b/src/com/lilithsthrone/game/sex/managers/SexManagerInterface.java
@@ -174,18 +174,18 @@ public interface SexManagerInterface {
 	}
 	
 	public default void initStartingLustAndArousal(GameCharacter character) {
-		character.setLust(50);
+		character.setLustNoText(50);
 		character.setArousal(0);
 		if(Sex.isDom(character)) {
 			if(character.hasFetish(Fetish.FETISH_DOMINANT)) {
-				character.setLust(85);
+				character.setLustNoText(85);
 				character.setArousal(10);
 			} else if(character.hasFetish(Fetish.FETISH_SUBMISSIVE)) {
-				character.setLust(10);
+				character.setLustNoText(10);
 			}
 		} else {
 			if(character.hasFetish(Fetish.FETISH_SUBMISSIVE)) {
-				character.setLust(85);
+				character.setLustNoText(85);
 				character.setArousal(10);
 			}
 		}
@@ -202,9 +202,9 @@ public interface SexManagerInterface {
 					}
 				}
 				if(attracted==0) {
-					character.setLust(0); // If they aren't attracted to anyone, start resisting
+					character.setLustNoText(0); // If they aren't attracted to anyone, start resisting
 				} else if(unattracted>0) {
-					character.setLust(character.getLust()/2); // If they are attracted to some, but not all, halve starting lust
+					character.setLustNoText(character.getLust()/2); // If they are attracted to some, but not all, halve starting lust
 				}
 			}
 		}

--- a/src/com/lilithsthrone/utils/Util.java
+++ b/src/com/lilithsthrone/utils/Util.java
@@ -963,6 +963,9 @@ public class Util {
 	}
 	
 	public static String getClosestStringMatch(String input, Collection<String> choices) {
+		if (choices.contains(input)) {
+			return input;
+		}
 		int distance = Integer.MAX_VALUE;
 		String closestString = input;
 		for(String choice : choices) {


### PR DESCRIPTION
After noticing that loading a savefile could take up to 19 seconds, Bast and I checked with a profiler to find places with performance issues. The resulting fixes brought the loading times back down to 4 seconds. It probably also significantly affected game startup time.

- Fixes a typo in clothing file which means we don't have to run the string matcher in that case
- Fixes the string matcher to check for the best case first, which seems to apply in pretty much all cases after fixing the one typo I saw earlier.

That's one's a massive speed up.

I tried some other assorted attempts at speeding the game up, which may or may not really have worked. It at least seems sensible to not go printing how a character feels about their lust being loaded, but it's not something that you'd notice as much as not comparing all the strings everywhere.