### PR TITLE
Fix issue #1153

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/npcDialogue/OccupantDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/npcDialogue/OccupantDialogue.java
@@ -218,7 +218,7 @@ public class OccupantDialogue {
 						} else if(Main.game.getPlayer().canHaveMoreCompanions()) {
 							return new Response("Add to party",
 									UtilText.parse(occupant(), "Ask [npc.name] if [npc.she] would like to accompany you for a while."),
-									OCCUPANT_START){
+									Main.game.getDefaultDialogueNoEncounter()){
 								@Override
 								public void effects() {
 									applyReactionReset();


### PR DESCRIPTION
Fix issue #1153 

Return to the room after adding a occupant as party member, preventing access to options now unavailable.

Changed the nextDialogue from "OCCUPANT_START" to "Main.game.getDefaultDialogueNoEncounter()" after adding an occupant to the party.

~~**This change have not been tested yet, I haven't created the build environment yet.**~~
**Edit: Already tested, see [below](https://github.com/Innoxia/liliths-throne-public/pull/1154#issuecomment-491531990).**

If you want to test if this fixes the issue:

- Have an occupant able to join your party.
- Talk to it.
- Add it to the party.
- You shouldn't be able to keep talking in the occupant menu, as it's now disabled because "this character is currently working", effectively keeping you from initiating sex from the character's occupant menu, which produced the bug.

Going to test it later, once I have the build environment ready.