### PR TITLE
Fix #1151

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -20120,6 +20120,9 @@ public abstract class GameCharacter implements XMLSaving {
 	public int getPenisRawCumStorageValue() {
 		return body.getPenis().getTesticle().getRawCumStorageValue();
 	}
+	public int getCurrentPenisRawCumStorageValue() {
+		return getCurrentPenis().getTesticle().getRawCumStorageValue();
+	}
 	public String setPenisCumStorage(int cumProduction) {
 		return body.getPenis().getTesticle().setCumStorage(this, cumProduction);
 	}
@@ -20175,12 +20178,12 @@ public abstract class GameCharacter implements XMLSaving {
 	}
 	public int getPenisRawOrgasmCumQuantity() {
 		if (!Main.getProperties().hasValue(PropertyValue.cumRegenerationContent)) {
-			return body.getPenis().getTesticle().getRawCumStorageValue();
+			return getCurrentPenis().getTesticle().getRawCumStorageValue();
 		}
-		if(body.getPenis().getTesticle().getRawStoredCumValue() <= Testicle.MINIMUM_VALUE_FOR_ALL_CUM_TO_BE_EXPELLED) {
-			return (int) body.getPenis().getTesticle().getRawStoredCumValue();
+		if(getCurrentPenis().getTesticle().getRawStoredCumValue() <= Testicle.MINIMUM_VALUE_FOR_ALL_CUM_TO_BE_EXPELLED) {
+			return (int) getCurrentPenis().getTesticle().getRawStoredCumValue();
 		}
-		return (int) (body.getPenis().getTesticle().getRawStoredCumValue() * (getPenisRawCumExpulsionValue()/100f));
+		return (int) (getCurrentPenis().getTesticle().getRawStoredCumValue() * (getPenisRawCumExpulsionValue()/100f));
 	}
 	public void applyOrgasmCumEffect() {
 		if(Main.getProperties().hasValue(PropertyValue.cumRegenerationContent)) {

--- a/src/com/lilithsthrone/game/character/PlayerCharacter.java
+++ b/src/com/lilithsthrone/game/character/PlayerCharacter.java
@@ -909,7 +909,7 @@ public class PlayerCharacter extends GameCharacter implements XMLSaving {
 				&& Main.game.getNpc(Lilaya.class).getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
 				&& target==OrgasmCumTarget.INSIDE
 				&& !Main.game.getNpc(Lilaya.class).isVisiblyPregnant()
-				&& this.getPenisRawCumStorageValue()>0
+				&& this.getCurrentPenisRawCumStorageValue()>0
 				&& Sex.getContactingSexAreas(this, SexAreaPenetration.PENIS, Main.game.getNpc(Lilaya.class)).contains(SexAreaOrifice.VAGINA)) {
 			
 			StringBuilder sb = new StringBuilder();

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Lab.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Lab.java
@@ -810,7 +810,7 @@ public class Lab {
 							+ " [pc.speech(~Mmm!~ Yes Lilaya, that sounds good to me!)]"
 						+ "</p>"
 						+ "<p>"
-							+ (Main.game.getPlayer().hasPenis() && !Main.game.getNpc(Lilaya.class).isVisiblyPregnant() && Main.game.getNpc(Lilaya.class).getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
+							+ (Main.game.getPlayer().hasPenisIgnoreDildo() && !Main.game.getNpc(Lilaya.class).isVisiblyPregnant() && Main.game.getNpc(Lilaya.class).getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
 									?" [lilaya.speech(Mmm, yes! Just, if you want to fuck me, make sure you pull out, ok? I'm <b>not</b> getting pregnant!)] she demands."
 									:" [lilaya.speech(Mmm, yes!)] she giggles.")
 						+ "</p>"
@@ -839,7 +839,7 @@ public class Lab {
 							+ " [pc.speech(~Mmm!~ Yes Lilaya, that sounds good to me!)]"
 						+ "</p>"
 						+ "<p>"
-							+ (Main.game.getPlayer().hasPenis() && !Main.game.getNpc(Lilaya.class).isVisiblyPregnant() && Main.game.getNpc(Lilaya.class).getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
+							+ (Main.game.getPlayer().hasPenisIgnoreDildo() && !Main.game.getNpc(Lilaya.class).isVisiblyPregnant() && Main.game.getNpc(Lilaya.class).getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
 									?" [lilaya.speech(Mmm, yes! Just, if you want to fuck me, make sure you pull out, ok? I'm <b>not</b> getting pregnant!)] she demands."
 									:" [lilaya.speech(Mmm, yes!)] she giggles.")
 						+ "</p>"
@@ -1834,7 +1834,7 @@ public class Lab {
 							+ " Stepping around to one side, she quickly throws one leg over you and slides down to sit in your lap, face-to-face."
 						+ "</p>"
 						+ "<p>"
-							+ (Main.game.getPlayer().hasPenis() && !Main.game.getNpc(Lilaya.class).isVisiblyPregnant() && Main.game.getNpc(Lilaya.class).getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
+							+ (Main.game.getPlayer().hasPenisIgnoreDildo() && !Main.game.getNpc(Lilaya.class).isVisiblyPregnant() && Main.game.getNpc(Lilaya.class).getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
 									?" [lilaya.speech(Mmm, yes! Just, if you want to fuck me, make sure you pull out, ok? I'm <b>not</b> getting pregnant!)] she demands."
 									:" [lilaya.speech(Mmm, yes!)] she giggles.")
 						+ "</p>"
@@ -2087,7 +2087,7 @@ public class Lab {
 							+ " Stepping around to one side, she quickly throws one leg over you and slides down to sit in your lap, face-to-face."
 						+ "</p>"
 						+ "<p>"
-							+ (Main.game.getPlayer().hasPenis() && !Main.game.getNpc(Lilaya.class).isVisiblyPregnant() && Main.game.getNpc(Lilaya.class).getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
+							+ (Main.game.getPlayer().hasPenisIgnoreDildo() && !Main.game.getNpc(Lilaya.class).isVisiblyPregnant() && Main.game.getNpc(Lilaya.class).getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
 									?" [lilaya.speech(Mmm, yes! Just, if you want to fuck me, make sure you pull out, ok? I'm <b>not</b> getting pregnant!)] she demands."
 									:" [lilaya.speech(Mmm, yes!)] she giggles.")
 						+ "</p>"

--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericOrgasms.java
@@ -4680,7 +4680,8 @@ public class GenericOrgasms {
 		public SexActionPriority getPriority() {
 			if((Sex.getAllContactingSexAreas(Sex.getCharacterPerformingAction(), SexAreaOrifice.VAGINA).contains(SexAreaPenetration.PENIS)
 					&& Sex.getCharacterContactingSexArea(Sex.getCharacterPerformingAction(), SexAreaOrifice.VAGINA).contains(Sex.getCharacterTargetedForSexAction(this))
-					&& Sex.getCharacterPerformingAction().getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
+					&& (Sex.getCharacterPerformingAction().getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
+						&& Sex.getCharacterTargetedForSexAction(this).hasPenisIgnoreDildo())
 					&& !Sex.getCharacterPerformingAction().isVisiblyPregnant())
 				|| Sex.getCharacterPerformingAction().getFetishDesire(Fetish.FETISH_CUM_ADDICT).isNegative()) {
 				return SexActionPriority.HIGH;

--- a/src/com/lilithsthrone/game/sex/sexActions/dominion/SALilayaSpecials.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/dominion/SALilayaSpecials.java
@@ -55,7 +55,8 @@ public class SALilayaSpecials {
 					&& !SexFlags.characterRequestedPullOut
 					&& !Main.game.getNpc(Lilaya.class).isVisiblyPregnant()
 					&& Main.game.getNpc(Lilaya.class).getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
-					&& !Sex.getCharacterPerformingAction().isPlayer();
+					&& !Sex.getCharacterPerformingAction().isPlayer()
+					&& Main.game.getPlayer().hasPenisIgnoreDildo();
 		}
 
 		@Override
@@ -157,7 +158,8 @@ public class SALilayaSpecials {
 			return Sex.getAllContactingSexAreas(Sex.getActivePartner(), SexAreaOrifice.VAGINA).contains(SexAreaPenetration.PENIS)
 					&& !Main.game.getNpc(Lilaya.class).isVisiblyPregnant()
 					&& Main.game.getNpc(Lilaya.class).getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()
-					&& !Sex.getCharacterPerformingAction().isPlayer();
+					&& !Sex.getCharacterPerformingAction().isPlayer()
+					&& Main.game.getPlayer().hasPenisIgnoreDildo();
 		}
 
 		@Override


### PR DESCRIPTION
Fix #1151, and other emerging issues found from investigating that one.

Created `getCurrentPenisRawCumStorageValue()` at GameCharacter, to replace `getPenisRawCumStorageValue()` on code where the current penis is more important than the real one. (Ex: When using dildos, `getPenisRawCumStorageValue()` return the testicles from the (Maybe now non-existant) penis. `getCurrentPenisRawCumStorageValue()` returns the Dildo's stats, which will be zero for most dildos (all existant, I think)).

I didn't replaced all the instances where `getCurrentPenisRawCumStorageValue` may be preffered over `getPenisRawCumStorageValue`, but I think it's better to not overuse it if there's no related bug yet.

- Are any new graphical assets required? **Nope.**

- Has this change been tested? If so, mention the version number that the test was based on.

**Yes. Tested on up-to-date /dev. Should be [this one](https://github.com/Innoxia/liliths-throne-public/commit/d343510ad142190d6fcce3159c93bec6f145f098)**

- So we have a better idea of who you are, what is your Discord Handle? **@A-haron#3467**

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.

Not needed. Take your time if needed.

Good luck!
