### PR TITLE
Duplicate characters on ResponseSex

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/responses/ResponseSex.java
+++ b/src/com/lilithsthrone/game/dialogue/responses/ResponseSex.java
@@ -394,6 +394,7 @@ public class ResponseSex extends Response {
 			}
 		}
 		
+		// Prevent duplicate characters on differente positions.
 		if(this.sexManager != null) {
 			
 			// We have to use iterator to be able to safely remove elements without "ConcurrentModificationException"
@@ -425,8 +426,9 @@ public class ResponseSex extends Response {
 				GameCharacter val = i.next();
 				if(this.sexManager.getDominants().containsKey(val)) 
 					i.remove();
-			}
+			}			
 		}
+		
 		this.postSexDialogue = postSexDialogue;
 		this.sexStartDescription = sexStartDescription;
 	}

--- a/src/com/lilithsthrone/game/dialogue/responses/ResponseSex.java
+++ b/src/com/lilithsthrone/game/dialogue/responses/ResponseSex.java
@@ -3,7 +3,6 @@ package com.lilithsthrone.game.dialogue.responses;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -379,7 +378,7 @@ public class ResponseSex extends Response {
 		if(dominantSpectators==null) {
 			this.dominantSpectators = new ArrayList<>();
 		} else {
-			this.dominantSpectators = new ArrayList<>(dominantSpectators);
+			this.dominantSpectators = dominantSpectators;
 			while(this.dominantSpectators.contains(null)) {
 				this.dominantSpectators.remove(null);
 			}
@@ -388,45 +387,10 @@ public class ResponseSex extends Response {
 		if(submissiveSpectators==null) {
 			this.submissiveSpectators = new ArrayList<>();
 		} else {
-			this.submissiveSpectators = new ArrayList<>(submissiveSpectators);
+			this.submissiveSpectators = submissiveSpectators;
 			while(this.submissiveSpectators.contains(null)) {
 				this.submissiveSpectators.remove(null);
 			}
-		}
-		
-		// Prevent duplicate characters on differente positions.
-		if(this.sexManager != null) {
-			
-			// We have to use iterator to be able to safely remove elements without "ConcurrentModificationException"
-			Iterator<GameCharacter> i;
-
-			// If in sex and dominant spectator,
-			// remove from spectator.
-			i = this.dominantSpectators.iterator();
-			while(i.hasNext()) {
-				GameCharacter val = i.next();
-				if(this.sexManager.getDominants().containsKey(val) || this.sexManager.getSubmissives().containsKey(val)) 
-					i.remove();
-			}
-			
-			// If in sex and submissive spectator, 
-			// or in dominant and submissive spectator, 
-			// remove from submissive spectator.
-			i = this.submissiveSpectators.iterator();
-			while(i.hasNext()) {
-				GameCharacter val = i.next();
-				if(this.dominantSpectators.contains(val) || this.sexManager.getDominants().containsKey(val) || this.sexManager.getSubmissives().containsKey(val)) 
-					i.remove();
-			}
-			
-			// If dominant and submissive, 
-			// remove from submissive.
-			i = this.sexManager.getSubmissives().keySet().iterator();
-			while(i.hasNext()) {
-				GameCharacter val = i.next();
-				if(this.sexManager.getDominants().containsKey(val)) 
-					i.remove();
-			}			
 		}
 		
 		this.postSexDialogue = postSexDialogue;

--- a/src/com/lilithsthrone/game/dialogue/responses/ResponseSex.java
+++ b/src/com/lilithsthrone/game/dialogue/responses/ResponseSex.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.dialogue.responses;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -378,7 +379,7 @@ public class ResponseSex extends Response {
 		if(dominantSpectators==null) {
 			this.dominantSpectators = new ArrayList<>();
 		} else {
-			this.dominantSpectators = dominantSpectators;
+			this.dominantSpectators = new ArrayList<>(dominantSpectators);
 			while(this.dominantSpectators.contains(null)) {
 				this.dominantSpectators.remove(null);
 			}
@@ -387,12 +388,45 @@ public class ResponseSex extends Response {
 		if(submissiveSpectators==null) {
 			this.submissiveSpectators = new ArrayList<>();
 		} else {
-			this.submissiveSpectators = submissiveSpectators;
+			this.submissiveSpectators = new ArrayList<>(submissiveSpectators);
 			while(this.submissiveSpectators.contains(null)) {
 				this.submissiveSpectators.remove(null);
 			}
 		}
 		
+		if(this.sexManager != null) {
+			
+			// We have to use iterator to be able to safely remove elements without "ConcurrentModificationException"
+			Iterator<GameCharacter> i;
+
+			// If in sex and dominant spectator,
+			// remove from spectator.
+			i = this.dominantSpectators.iterator();
+			while(i.hasNext()) {
+				GameCharacter val = i.next();
+				if(this.sexManager.getDominants().containsKey(val) || this.sexManager.getSubmissives().containsKey(val)) 
+					i.remove();
+			}
+			
+			// If in sex and submissive spectator, 
+			// or in dominant and submissive spectator, 
+			// remove from submissive spectator.
+			i = this.submissiveSpectators.iterator();
+			while(i.hasNext()) {
+				GameCharacter val = i.next();
+				if(this.dominantSpectators.contains(val) || this.sexManager.getDominants().containsKey(val) || this.sexManager.getSubmissives().containsKey(val)) 
+					i.remove();
+			}
+			
+			// If dominant and submissive, 
+			// remove from submissive.
+			i = this.sexManager.getSubmissives().keySet().iterator();
+			while(i.hasNext()) {
+				GameCharacter val = i.next();
+				if(this.sexManager.getDominants().containsKey(val)) 
+					i.remove();
+			}
+		}
 		this.postSexDialogue = postSexDialogue;
 		this.sexStartDescription = sexStartDescription;
 	}


### PR DESCRIPTION
- What is the purpose of the pull request?
Prevent duplicate characters on sex scenes. At least those that pass through ResponseSex.

- Give a brief description of what you changed or added.
Added a check at ResponseSex constructor that deletes spectators that are involved in the sex scene itself.

This caused some errors, commonly with party members. [Example](https://github.com/Innoxia/liliths-throne-public/blob/ab24f7ea537b5b2523255392b520658c2d4175e3/src/com/lilithsthrone/game/dialogue/places/submission/impFortress/ImpFortressDialogue.java#L3016) (Using the main companion in the scene, but adding all companions (Main included) as spectators).

- Are any new graphical assets required?
Nope.

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.3.2.3 dev branch.

- So we have a better idea of who you are, what is your Discord Handle?
A-haron#3467