### PR TITLE
Solve NullReference exception with permit positioning

### DIFF
--- a/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericActions.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/baseActionsMisc/GenericActions.java
@@ -9,6 +9,7 @@ import com.lilithsthrone.game.character.body.types.PenisType;
 import com.lilithsthrone.game.character.body.valueEnums.PenisGirth;
 import com.lilithsthrone.game.character.body.valueEnums.TesticleSize;
 import com.lilithsthrone.game.character.fetishes.Fetish;
+import com.lilithsthrone.game.character.npc.NPC;
 import com.lilithsthrone.game.character.race.Race;
 import com.lilithsthrone.game.character.race.RacialBody;
 import com.lilithsthrone.game.character.race.Subspecies;
@@ -1213,6 +1214,7 @@ public class GenericActions {
 			Sex.stopAllOngoingActions(Sex.getCharacterTargetedForSexAction(this), Sex.getCharacterTargetedForSexAction(this));
 			
 			Sex.addCharacterForbiddenByOthersFromPositioning(Sex.getCharacterTargetedForSexAction(this));
+			((NPC)Sex.getCharacterTargetedForSexAction(this)).generateSexChoices(false, Main.game.getPlayer());
 		}
 	};
 	
@@ -1255,6 +1257,7 @@ public class GenericActions {
 		@Override
 		public void applyEffects() {
 			Sex.removeCharacterForbiddenByOthersFromPositioning(Sex.getCharacterTargetedForSexAction(this));
+			((NPC)Sex.getCharacterTargetedForSexAction(this)).generateSexChoices(false, Main.game.getPlayer());
 		}
 	};
 	


### PR DESCRIPTION
- What is the purpose of the pull request?
Fix issue  #1170  and #1158 

- Give a brief description of what you changed or added.
Invoked generateSexChoices after Permit or Restrict positioning is use to fix offending null reference exception

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, 3.3.6

- So we have a better idea of who you are, what is your Discord Handle?
TheKingInYellow
