### PR TITLE
Fix unintentional randomness in horn enchanting

### DIFF
--- a/src/com/lilithsthrone/game/inventory/enchanting/AbstractItemEffectType.java
+++ b/src/com/lilithsthrone/game/inventory/enchanting/AbstractItemEffectType.java
@@ -4416,7 +4416,7 @@ public abstract class AbstractItemEffectType {
 
 	private static RacialEffectUtil getHornTypeRacialEffectUtil(Race race, GameCharacter target, int index) {
 		List<AbstractHornType> hornTypes = RacialBody.valueOfRace(race).getHornTypes(true);
-		AbstractHornType selectedHornType = hornTypes.isEmpty()?HornType.NONE:Util.randomItemFrom(hornTypes);
+		AbstractHornType selectedHornType = index >= hornTypes.size() ? HornType.NONE : hornTypes.get(index);
 		
 		return new RacialEffectUtil("Grows "+selectedHornType.getTransformName()+" horn"+(selectedHornType==HornType.HORSE_STRAIGHT?"":"s")+".") {
 			@Override public String applyEffect() { return target.setHornType(selectedHornType); } };


### PR DESCRIPTION
- **What is the purpose of the pull request?**
  If you have multiple horn types the enchantment UI randomized the selected horn type.

- **Give a brief description of what you changed or added.**
  The param `int index` wasn't being used in that corresponding function. Instead the `HornType` was chosen randomly. Changed that to actually use the index of the choice.

- **Are any new graphical assets required?**
  No

- **Has this change been tested? If so, mention the version number that the test was based on.**
  Yes, 0.3.3.6 Alpha.
  I haven't checked, if that breaks elsewhere aka, if the randomness was intended for 'other stuff', although I highly doubt that.

- **So we have a better idea of who you are, what is your Discord Handle?**
  Stadler#3007