### PR TITLE
Combat Multi-Target Effects Freeze/Crash Fix

### DIFF
--- a/src/com/lilithsthrone/game/combat/Combat.java
+++ b/src/com/lilithsthrone/game/combat/Combat.java
@@ -1543,6 +1543,9 @@ public enum Combat {
 				possibleTargets.add(character);
 			}
 		}
+		if(possibleTargets.size() == 0) {
+			return target;
+		}
 		return possibleTargets.get(Util.random.nextInt(possibleTargets.size()));
 	}
 


### PR DESCRIPTION

- What is the purpose of the pull request?
During combat, if a character uses an ability that has an effect that targets multiple combatants, it will fail thus freezing the turn when you end it. This is due to the fact that multi-target effects call the `getRandomAlliedPartyMember(GameCharacter target)` method. This method returns a random ally from the target's party. The problem is if the target is alone, the function still tries to find a random ally from the empty list, and since `random.nextInt()` can't accept a 0 value, it fails.

- Give a brief description of what you changed or added.
Basically, I just checked if the list of targeted allies was equal to 0, and if so just return the target itself, instead of trying to find a random ally from an empty list.

- Are any new graphical assets required?
No.

- Has this change been tested? If so, mention the version number that the test was based on.
Yes. Version 0.3.3.10

- So we have a better idea of who you are, what is your Discord Handle?
Shadowheart329#0896
