### PR TITLE
fix health bug introduced in 03311

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -4988,7 +4988,7 @@ public abstract class GameCharacter implements XMLSaving {
 		}
 		
 		if(att == Attribute.HEALTH_MAXIMUM || att == Attribute.MANA_MAXIMUM) {
-			if(this.hasStatusEffect(StatusEffect.INTELLIGENCE_PERK_0)) {
+			if(att == Attribute.MANA_MAXIMUM && this.hasStatusEffect(StatusEffect.INTELLIGENCE_PERK_0)) {
 				return 5;
 			} else if(this.hasStatusEffect(StatusEffect.CLOTHING_ENCHANTMENT_OVER_LIMIT)) {
 				value *= 0.9f;


### PR DESCRIPTION
<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
Fix a bug with health calculation that  was introduced in 7cb874c.
- Give a brief description of what you changed or added.
Added an additional check so the Aura penalty for having a low Arcane stat no longer also applies to Health.
- Are any new graphical assets required?
No.
- Has this change been tested? If so, mention the version number that the test was based on.
On the newest dev version(0.3.4).
- So we have a better idea of who you are, what is your Discord Handle?
Alaco on Discord.