### PR TITLE
Potential copy error or typo in PlaceUpgrade.java

### DIFF
--- a/src/com/lilithsthrone/world/places/PlaceUpgrade.java
+++ b/src/com/lilithsthrone/world/places/PlaceUpgrade.java
@@ -704,7 +704,7 @@ public enum PlaceUpgrade {
 
 	public static ArrayList<PlaceUpgrade> getSlaveQuartersUpgradesQuadruple() {
 		if(Main.game.getDialogueFlags().hasFlag(DialogueFlagValue.arthursRoomInstalled) || Main.game.getPlayer().isQuestProgressLessThan(QuestLine.MAIN, Quest.MAIN_1_J_ARTHURS_ROOM)) {
-			ArrayList<PlaceUpgrade> listArthurRemoved = new ArrayList<>(slaveQuartersUpgradesDouble);
+			ArrayList<PlaceUpgrade> listArthurRemoved = new ArrayList<>(slaveQuartersUpgradesQuadruple);
 			listArthurRemoved.remove(PlaceUpgrade.LILAYA_ARTHUR_ROOM);
 			return listArthurRemoved;
 		}


### PR DESCRIPTION
Potential Typo / Copy Error
There was a reference to salve room double's list when defining slave room quadruple's list but that sort of cross reference is not seen elsewhere.

Discord tag GammaMike#6081
