### PR TITLE
[FIX] Changing position to Face sitting reversal caused exception

### DIFF
--- a/src/com/lilithsthrone/game/sex/positions/SexPositionOther.java
+++ b/src/com/lilithsthrone/game/sex/positions/SexPositionOther.java
@@ -2696,13 +2696,13 @@ public class SexPositionOther {
 					}
 				}
 				if(faceSittingReverse!=null) {
-					if(!faceSitting.isTaur()) {
-						sb.append(UtilText.parse(faceSitting, lyingDown,
+					if(!faceSittingReverse.isTaur()) {
+						sb.append(UtilText.parse(faceSittingReverse, lyingDown,
 								continuation
 								?" Meanwhile, [npc.nameHasFull] stepped over the top of [npc2.name], before turning around to face [npc2.her] lower body and then lowering [npc.herself] down in order to assume the reverse face-sitting position."
 								:" [npc.NameHasFull] stepped over the top of [npc2.name], before turning around to face [npc2.her] lower body and then lowering [npc.herself] down in order to assume the reverse face-sitting position."));
 					} else {
-						sb.append(UtilText.parse(faceSitting, lyingDown,
+						sb.append(UtilText.parse(faceSittingReverse, lyingDown,
 								continuation
 								?" Meanwhile, [npc.nameHasFull] stepped over the top of [npc2.name],"
 										+ " before turning around to face [npc2.her] lower body and then lowering [npc.her] feral [npc.legRace]'s body down in order to assume the reverse face-sitting position."


### PR DESCRIPTION
### What is the purpose of the pull request?
[5:30 PM] Pilcrow: trying to set up reverse-facesitting puts an error in the log instead;
Error: getContent() method is throwing an exception in the node: 'Positioning Selection: Lying down'
and accepting the position generates no 'new position' text.

### Give a brief description of what you changed or added.
Renamed variables in a conditional from `faceSitting` to `faceSittingReversal`. Error possibly caused due to copy/paste.

### Are any new graphical assets required?
No

### Has this change been tested? If so, mention the version number that the test was based on.
0.3.4.1 Alpha

### So we have a better idea of who you are, what is your Discord Handle?
Sphilia : @Reyvateil#5830 

