### PR TITLE
Threesome sex scene participant selection was inconsistantly substitu…

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/npcDialogue/OccupantDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/npcDialogue/OccupantDialogue.java
@@ -76,14 +76,6 @@ public class OccupantDialogue {
 //		return (NPC) Main.game.getPlayer().getMainCompanion();
 //	}
 	
-	private static NPC nonSexTargetedCharacter() {
-		if(characterForSex.equals(occupant())) {
-			return (NPC) Main.game.getPlayer().getMainCompanion();
-		} else {
-			return occupant();
-		}
-	}
-	
 	private static boolean hasJob() {
 		return occupant().hasJob();
 	}
@@ -108,7 +100,7 @@ public class OccupantDialogue {
 	}
 
 	private static String getThreesomeTextFilePath() {
-		if(occupant().isRelatedTo(Main.game.getPlayer()) || (characterForSexSecondary!=null && characterForSexSecondary.isRelatedTo(Main.game.getPlayer()))) {
+		if(characterForSex.isRelatedTo(Main.game.getPlayer()) || (characterForSexSecondary!=null && characterForSexSecondary.isRelatedTo(Main.game.getPlayer()))) {
 			return "characters/offspring/occupant";
 		} else {
 			return "misc/friendlyOccupantDialogue";
@@ -364,34 +356,34 @@ public class OccupantDialogue {
 					} else if(characterForSex.isPlayer()) {
 						return new Response("Spitroast (front)", "You cannot target yourself for this action!", null);
 						
-					} else if(!occupant().isAttractedTo(Main.game.getPlayer())) {
+					} else if(!characterForSex.isAttractedTo(Main.game.getPlayer())) {
 						if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-							return new Response("Spitroast (front)", UtilText.parse(characterForSexSecondary, occupant(), "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
+							return new Response("Spitroast (front)", UtilText.parse(characterForSexSecondary, characterForSex, "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
 						} else {
-							return new Response("Spitroast (front)", UtilText.parse(occupant(), "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
+							return new Response("Spitroast (front)", UtilText.parse(characterForSex, "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
 						}
 						
 					} else if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-						return new Response("Spitroast (front)", UtilText.parse(characterForSexSecondary, occupant(), "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
+						return new Response("Spitroast (front)", UtilText.parse(characterForSexSecondary, characterForSex, "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
 						
-					} else if(!characterForSexSecondary.isAttractedTo(occupant())) {
+					} else if(!characterForSexSecondary.isAttractedTo(characterForSex)) {
 						return new Response("Spitroast (front)",
-								UtilText.parse(characterForSexSecondary, occupant(), "[npc.Name] is not attracted to [npc2.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
+								UtilText.parse(characterForSexSecondary, characterForSex, "[npc.Name] is not attracted to [npc2.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
 								null);
 
-					} else if(!occupant().isAttractedTo(characterForSexSecondary)) {
+					} else if(!characterForSex.isAttractedTo(characterForSexSecondary)) {
 						return new Response("Spitroast (front)",
-								UtilText.parse(characterForSexSecondary, occupant(), "[npc2.Name] is not attracted to [npc.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
+								UtilText.parse(characterForSexSecondary, characterForSex, "[npc2.Name] is not attracted to [npc.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
 								null);
 						
 					} else {
 						return new ResponseSex(
 								"Spitroast (front)",
-								UtilText.parse(characterForSex, nonSexTargetedCharacter(), "Move around in front of [npc.name] so that you can use [npc.her] mouth while [npc2.name] takes [npc.her] rear."),
+								UtilText.parse(characterForSex, characterForSexSecondary, "Move around in front of [npc.name] so that you can use [npc.her] mouth while [npc2.name] takes [npc.her] rear."),
 								null, null, null, null, null, null,
 								true, true,
 								new SMGeneric(
-										Util.newArrayListOfValues(nonSexTargetedCharacter(), Main.game.getPlayer()),
+										Util.newArrayListOfValues(characterForSexSecondary, Main.game.getPlayer()),
 										Util.newArrayListOfValues(characterForSex),
 										null,
 										null,
@@ -402,7 +394,7 @@ public class OccupantDialogue {
 									}
 								},
 								getAfterSexDialogue(),
-								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SPITROAST_FRONT_START", characterForSex, nonSexTargetedCharacter())) {
+								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SPITROAST_FRONT_START", characterForSex, characterForSexSecondary)) {
 							@Override
 							public void effects() {
 								applyReactionReset();
@@ -417,34 +409,34 @@ public class OccupantDialogue {
 					} else if(characterForSex.isPlayer()) {
 						return new Response("Spitroast (behind)", "You cannot target yourself for this action!", null);
 						
-					} else if(!occupant().isAttractedTo(Main.game.getPlayer())) {
+					} else if(!characterForSex.isAttractedTo(Main.game.getPlayer())) {
 						if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-							return new Response("Spitroast (behind)", UtilText.parse(characterForSexSecondary, occupant(), "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
+							return new Response("Spitroast (behind)", UtilText.parse(characterForSexSecondary, characterForSex, "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
 						} else {
-							return new Response("Spitroast (behind)", UtilText.parse(occupant(), "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
+							return new Response("Spitroast (behind)", UtilText.parse(characterForSex, "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
 						}
 						
 					} else if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-						return new Response("Spitroast (behind)", UtilText.parse(characterForSexSecondary, occupant(), "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
+						return new Response("Spitroast (behind)", UtilText.parse(characterForSexSecondary, characterForSex, "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
 						
-					} else if(!characterForSexSecondary.isAttractedTo(occupant())) {
+					} else if(!characterForSexSecondary.isAttractedTo(characterForSex)) {
 						return new Response("Spitroast (front)",
-								UtilText.parse(characterForSexSecondary, occupant(), "[npc.Name] is not attracted to [npc2.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
+								UtilText.parse(characterForSexSecondary, characterForSex, "[npc.Name] is not attracted to [npc2.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
 								null);
 
-					} else if(!occupant().isAttractedTo(characterForSexSecondary)) {
+					} else if(!characterForSex.isAttractedTo(characterForSexSecondary)) {
 						return new Response("Spitroast (front)",
-								UtilText.parse(characterForSexSecondary, occupant(), "[npc2.Name] is not attracted to [npc.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
+								UtilText.parse(characterForSexSecondary, characterForSex, "[npc2.Name] is not attracted to [npc.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
 								null);
 						
 					} else {
 						return new ResponseSex(
 								"Spitroast (behind)",
-								UtilText.parse(characterForSex, nonSexTargetedCharacter(), "Move around behind [npc.name] so that you can use [npc.her] rear while [npc2.name] takes [npc.her] mouth."),
+								UtilText.parse(characterForSex, characterForSexSecondary, "Move around behind [npc.name] so that you can use [npc.her] rear while [npc2.name] takes [npc.her] mouth."),
 								null, null, null, null, null, null,
 								true, true,
 								new SMGeneric(
-										Util.newArrayListOfValues(Main.game.getPlayer(), nonSexTargetedCharacter()),
+										Util.newArrayListOfValues(Main.game.getPlayer(), characterForSexSecondary),
 										Util.newArrayListOfValues(characterForSex),
 										null,
 										null,
@@ -455,7 +447,7 @@ public class OccupantDialogue {
 									}
 								},
 								getAfterSexDialogue(),
-								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SPITROAST_BEHIND_START", characterForSex, nonSexTargetedCharacter())) {
+								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SPITROAST_BEHIND_START", characterForSex, characterForSexSecondary)) {
 							@Override
 							public void effects() {
 								applyReactionReset();
@@ -470,24 +462,24 @@ public class OccupantDialogue {
 					} else if(characterForSex.isPlayer()) {
 						return new Response("Side-by-side (as dom)", "You cannot target yourself for this action!", null);
 						
-					} else if(!occupant().isAttractedTo(Main.game.getPlayer())) {
+					} else if(!characterForSex.isAttractedTo(Main.game.getPlayer())) {
 						if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-							return new Response("Side-by-side (as dom)", UtilText.parse(characterForSexSecondary, occupant(), "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
+							return new Response("Side-by-side (as dom)", UtilText.parse(characterForSexSecondary, characterForSex, "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
 						} else {
-							return new Response("Side-by-side (as dom)", UtilText.parse(occupant(), "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
+							return new Response("Side-by-side (as dom)", UtilText.parse(characterForSex, "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
 						}
 						
 					} else if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-						return new Response("Side-by-side (as dom)", UtilText.parse(characterForSexSecondary, occupant(), "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
+						return new Response("Side-by-side (as dom)", UtilText.parse(characterForSexSecondary, characterForSex, "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
 						
 					} else {
 						return new ResponseSex("Side-by-side (as dom)",
-								UtilText.parse(characterForSex, nonSexTargetedCharacter(), "Push [npc.name] and [npc2.name] down onto all fours, before kneeling behind [npc.name], ready to fuck them both side-by-side."),
+								UtilText.parse(characterForSex, characterForSexSecondary, "Push [npc.name] and [npc2.name] down onto all fours, before kneeling behind [npc.name], ready to fuck them both side-by-side."),
 								null, null, null, null, null, null,
 								true, false,
 								new SMGeneric(
 										Util.newArrayListOfValues(Main.game.getPlayer()),
-										Util.newArrayListOfValues(characterForSex, nonSexTargetedCharacter()),
+										Util.newArrayListOfValues(characterForSex, characterForSexSecondary),
 										null,
 										null,
 										ResponseTag.PREFER_DOGGY) {
@@ -497,7 +489,7 @@ public class OccupantDialogue {
 									}
 								},
 								getAfterSexDialogue(),
-								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SIDE_BY_SIDE_START", characterForSex, nonSexTargetedCharacter())) {
+								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SIDE_BY_SIDE_START", characterForSex, characterForSexSecondary)) {
 							@Override
 							public void effects() {
 								applyReactionReset();
@@ -540,24 +532,24 @@ public class OccupantDialogue {
 					} else if(characterForSex.isPlayer()) {
 						return new Response("Spitroasted (front)", "You cannot target yourself for this action!", null);
 						
-					} else if(!occupant().isAttractedTo(Main.game.getPlayer())) {
+					} else if(!characterForSex.isAttractedTo(Main.game.getPlayer())) {
 						if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-							return new Response("Spitroasted (front)", UtilText.parse(characterForSexSecondary, occupant(), "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
+							return new Response("Spitroasted (front)", UtilText.parse(characterForSexSecondary, characterForSex, "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
 						} else {
-							return new Response("Spitroasted (front)", UtilText.parse(occupant(), "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
+							return new Response("Spitroasted (front)", UtilText.parse(characterForSex, "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
 						}
 						
 					} else if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-						return new Response("Spitroasted (front)", UtilText.parse(characterForSexSecondary, occupant(), "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
+						return new Response("Spitroasted (front)", UtilText.parse(characterForSexSecondary, characterForSex, "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
 						
 					} else {
 						return new ResponseSex(
 								"Spitroasted (front)",
-								UtilText.parse(characterForSex, nonSexTargetedCharacter(), "Get down on all fours facing [npc.name], so that [npc.she] can use your mouth while [npc2.name] takes your rear."),
+								UtilText.parse(characterForSex, characterForSexSecondary, "Get down on all fours facing [npc.name], so that [npc.she] can use your mouth while [npc2.name] takes your rear."),
 								null, null, null, null, null, null,
 								true, true,
 								new SMGeneric(
-										Util.newArrayListOfValues(nonSexTargetedCharacter(), characterForSex),
+										Util.newArrayListOfValues(characterForSexSecondary, characterForSex),
 										Util.newArrayListOfValues(Main.game.getPlayer()),
 										null,
 										null,
@@ -568,7 +560,7 @@ public class OccupantDialogue {
 									}
 								},
 								getAfterSexDialogue(),
-								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SPITROASTED_START", characterForSex, nonSexTargetedCharacter())) {
+								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SPITROASTED_START", characterForSex, characterForSexSecondary)) {
 							@Override
 							public void effects() {
 								applyReactionReset();
@@ -583,24 +575,24 @@ public class OccupantDialogue {
 					} else if(characterForSex.isPlayer()) {
 						return new Response("Spitroasted (behind)", "You cannot target yourself for this action!", null);
 						
-					} else if(!occupant().isAttractedTo(Main.game.getPlayer())) {
+					} else if(!characterForSex.isAttractedTo(Main.game.getPlayer())) {
 						if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-							return new Response("Spitroasted (behind)", UtilText.parse(characterForSexSecondary, occupant(), "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
+							return new Response("Spitroasted (behind)", UtilText.parse(characterForSexSecondary, characterForSex, "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
 						} else {
-							return new Response("Spitroasted (behind)", UtilText.parse(occupant(), "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
+							return new Response("Spitroasted (behind)", UtilText.parse(characterForSex, "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
 						}
 						
 					} else if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-						return new Response("Spitroasted (behind)", UtilText.parse(characterForSexSecondary, occupant(), "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
+						return new Response("Spitroasted (behind)", UtilText.parse(characterForSexSecondary, characterForSex, "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
 						
 					} else {
 						return new ResponseSex(
 								"Spitroasted (behind)",
-								UtilText.parse(characterForSex, nonSexTargetedCharacter(), "Get down on all fours and present your rear to [npc.name], so that [npc.she] can fuck you while [npc2.name] uses your mouth."),
+								UtilText.parse(characterForSex, characterForSexSecondary, "Get down on all fours and present your rear to [npc.name], so that [npc.she] can fuck you while [npc2.name] uses your mouth."),
 								null, null, null, null, null, null,
 								true, true,
 								new SMGeneric(
-										Util.newArrayListOfValues(characterForSex, nonSexTargetedCharacter()),
+										Util.newArrayListOfValues(characterForSex, characterForSexSecondary),
 										Util.newArrayListOfValues(Main.game.getPlayer()),
 										null,
 										null,
@@ -611,7 +603,7 @@ public class OccupantDialogue {
 									}
 								},
 								getAfterSexDialogue(),
-								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SPITROASTED_START", nonSexTargetedCharacter(), characterForSex)) {
+								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SPITROASTED_START", characterForSexSecondary, characterForSex)) {
 							@Override
 							public void effects() {
 								applyReactionReset();
@@ -621,39 +613,39 @@ public class OccupantDialogue {
 				
 				} else if (index == 9) {
 					if(characterForSexSecondary==null || charactersPresent.size()<2) {
-						return new Response("Side-by-side (as sub)", UtilText.parse(occupant(), "You'd need a third person to be present in order to get fucked alongside either them or [npc.name]..."), null);
+						return new Response("Side-by-side (as sub)", UtilText.parse(characterForSex, "You'd need a third person to be present in order to get fucked alongside either them or [npc.name]..."), null);
 						
 					} else if(characterForSex.isPlayer()) {
 						return new Response("Side-by-side (as sub)", "You cannot target yourself for this action!", null);
 						
-					} else if(!occupant().isAttractedTo(Main.game.getPlayer())) {
+					} else if(!characterForSex.isAttractedTo(Main.game.getPlayer())) {
 						if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-							return new Response("Side-by-side (as sub)", UtilText.parse(characterForSexSecondary, occupant(), "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
+							return new Response("Side-by-side (as sub)", UtilText.parse(characterForSexSecondary, characterForSex, "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
 						} else {
-							return new Response("Side-by-side (as sub)", UtilText.parse(occupant(), "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
+							return new Response("Side-by-side (as sub)", UtilText.parse(characterForSex, "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
 						}
 						
 					} else if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-						return new Response("Side-by-side (as sub)", UtilText.parse(characterForSexSecondary, occupant(), "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
+						return new Response("Side-by-side (as sub)", UtilText.parse(characterForSexSecondary, characterForSex, "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
 						
-					} else if(!characterForSexSecondary.isAttractedTo(occupant())) {
+					} else if(!characterForSexSecondary.isAttractedTo(characterForSex)) {
 						return new Response("Side-by-side (as sub)",
-								UtilText.parse(characterForSexSecondary, occupant(), "[npc.Name] is not attracted to [npc2.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
+								UtilText.parse(characterForSexSecondary, characterForSex, "[npc.Name] is not attracted to [npc2.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
 								null);
 
-					} else if(!occupant().isAttractedTo(characterForSexSecondary)) {
+					} else if(!characterForSex.isAttractedTo(characterForSexSecondary)) {
 						return new Response("Side-by-side (as sub)",
-								UtilText.parse(characterForSexSecondary, occupant(), "[npc2.Name] is not attracted to [npc.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
+								UtilText.parse(characterForSexSecondary, characterForSex, "[npc2.Name] is not attracted to [npc.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
 								null);
 						
 					} else {
 						return new ResponseSex("Side-by-side (as sub)",
-								UtilText.parse(characterForSex, nonSexTargetedCharacter(), "Get down on all fours beside [npc2.name], so that [npc.name] can kneel down behind the two of you, ready to fuck you both side-by-side."),
+								UtilText.parse(characterForSex, characterForSexSecondary, "Get down on all fours beside [npc2.name], so that [npc.name] can kneel down behind the two of you, ready to fuck you both side-by-side."),
 								null, null, null, null, null, null,
 								true, false,
 								new SMGeneric(
 										Util.newArrayListOfValues(characterForSex),
-										Util.newArrayListOfValues(Main.game.getPlayer(), nonSexTargetedCharacter()),
+										Util.newArrayListOfValues(Main.game.getPlayer(), characterForSexSecondary),
 										null,
 										null,
 										ResponseTag.PREFER_DOGGY) {
@@ -663,7 +655,7 @@ public class OccupantDialogue {
 									}
 								},
 								getAfterSexDialogue(),
-								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SIDE_BY_SIDE_AS_SUB_START", characterForSex, nonSexTargetedCharacter())) {
+								UtilText.parseFromXMLFile(getThreesomeTextFilePath(), "SEX_SIDE_BY_SIDE_AS_SUB_START", characterForSex, characterForSexSecondary)) {
 							@Override
 							public void effects() {
 								applyReactionReset();
@@ -707,6 +699,42 @@ public class OccupantDialogue {
 								null); 
 					}
 					
+				} else if(index==12) {
+					if(characterForSexSecondary!=null) {
+						return new ResponseEffectsOnly(
+								UtilText.parse(characterForSexSecondary, "Secondary: <b style='color:"+characterForSexSecondary.getFemininity().getColour().toWebHexString()+";'>[npc.Name]</b>"),
+								"Cycle the secondary targeted character for group sex.") {
+							@Override
+							public void effects() {
+								if(charactersPresent.size()>1) {
+									for(int i=0; i<charactersPresent.size();i++) {
+										if(charactersPresent.get(i).equals(characterForSexSecondary)) {
+											if(i==charactersPresent.size()-1) {
+												characterForSexSecondary = charactersPresent.get(0);
+												if(characterForSexSecondary.equals(characterForSex)) {
+													characterForSex = charactersPresent.get(1);
+												}
+											} else {
+												characterForSexSecondary = charactersPresent.get(i+1);
+												if(characterForSexSecondary.equals(characterForSex)) {
+													characterForSex = charactersPresent.get((i+2)<charactersPresent.size()?(i+2):0);
+												}
+											}
+											break;
+										}
+									}
+								}
+								Main.game.updateResponses();
+							}
+						};
+
+					} else {
+						return new Response(
+								UtilText.parse(characterForSex, "Secondary: <b>[npc.Name]</b>"),
+								"Cycle the secondary targeted character for group sex.<br/>[style.italicsBad(You'd need to have a companion with you for this action to be unlocked!)]",
+								null);
+					}
+
 				} else if (index == 0) {
 					return new Response("Leave", "Tell [npc.name] that you'll catch up with [npc.herHim] some other time.", Main.game.getDefaultDialogueNoEncounter()) {
 						@Override

--- a/src/com/lilithsthrone/game/dialogue/npcDialogue/SlaveDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/npcDialogue/SlaveDialogue.java
@@ -77,7 +77,7 @@ public class SlaveDialogue {
 	}
 
 	private static String getThreesomeTextFilePath() {
-		if(getSlave().isRelatedTo(Main.game.getPlayer()) || (characterForSexSecondary!=null && characterForSexSecondary.isRelatedTo(Main.game.getPlayer()))) {
+		if(characterForSex.isRelatedTo(Main.game.getPlayer()) || (characterForSexSecondary!=null && characterForSexSecondary.isRelatedTo(Main.game.getPlayer()))) {
 			return "characters/offspring/slave";
 		} else {
 			return "misc/slaveDialogue";
@@ -1034,10 +1034,10 @@ public class SlaveDialogue {
 						} else if(characterForSex.isPlayer()) {
 							return new Response("Spitroasted (front)", "You cannot target yourself for this action!", null);
 							
-						} else if(!getSlave().isAttractedTo(Main.game.getPlayer())) {
+						} else if(!characterForSex.isAttractedTo(Main.game.getPlayer())) {
 							if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
 								return new Response("Spitroasted (front)",
-										UtilText.parse(characterForSexSecondary, getSlave(),
+										UtilText.parse(characterForSexSecondary, characterForSex,
 												"Neither [npc.name] nor [npc2.name] are attracted to you,"
 												+ (Main.game.isNonConEnabled() && characterForSexSecondary.isSlave()
 														?" so if you wanted to have sex with them, you'd need to rape them as the dominant partner."
@@ -1045,7 +1045,7 @@ public class SlaveDialogue {
 										null);
 							} else {
 								return new Response("Spitroasted (front)",
-										UtilText.parse(getSlave(),
+										UtilText.parse(characterForSex,
 												"[npc.Name] is not attracted to you,"
 												+ (Main.game.isNonConEnabled()
 													?" so if you wanted to have sex with [npc.herHim], you'd need to rape [npc.herHim] as the dominant partner."
@@ -1096,10 +1096,10 @@ public class SlaveDialogue {
 						} else if(characterForSex.isPlayer()) {
 							return new Response("Spitroasted (behind)", "You cannot target yourself for this action!", null);
 							
-						} else if(!getSlave().isAttractedTo(Main.game.getPlayer())) {
+						} else if(!characterForSex.isAttractedTo(Main.game.getPlayer())) {
 							if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
 								return new Response("Spitroasted (behind)",
-										UtilText.parse(characterForSexSecondary, getSlave(),
+										UtilText.parse(characterForSexSecondary, characterForSex,
 												"Neither [npc.name] nor [npc2.name] are attracted to you,"
 												+ (Main.game.isNonConEnabled() && characterForSexSecondary.isSlave()
 														?" so if you wanted to have sex with them, you'd need to rape them as the dominant partner."
@@ -1107,7 +1107,7 @@ public class SlaveDialogue {
 										null);
 							} else {
 								return new Response("Spitroasted (behind)",
-										UtilText.parse(getSlave(),
+										UtilText.parse(characterForSex,
 												"[npc.Name] is not attracted to you,"
 												+ (Main.game.isNonConEnabled()
 													?" so if you wanted to have sex with [npc.herHim], you'd need to rape [npc.herHim] as the dominant partner."
@@ -1152,29 +1152,29 @@ public class SlaveDialogue {
 					
 					} else if (index == 9) {
 						if(characterForSexSecondary==null || charactersPresent.size()<2) {
-							return new Response("Side-by-side (as sub)", UtilText.parse(getSlave(), "You'd need a third person to be present in order to get fucked alongside either them or [npc.name]..."), null);
+							return new Response("Side-by-side (as sub)", UtilText.parse(characterForSex, "You'd need a third person to be present in order to get fucked alongside either them or [npc.name]..."), null);
 							
 						} else if(characterForSex.isPlayer()) {
 							return new Response("Side-by-side (as sub)", "You cannot target yourself for this action!", null);
 							
-						} else if(!getSlave().isAttractedTo(Main.game.getPlayer())) {
+						} else if(!characterForSex.isAttractedTo(Main.game.getPlayer())) {
 							if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-								return new Response("Side-by-side (as sub)", UtilText.parse(characterForSexSecondary, getSlave(), "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
+								return new Response("Side-by-side (as sub)", UtilText.parse(characterForSexSecondary, characterForSex, "Neither [npc.name] nor [npc2.name] are attracted to you..."), null);
 							} else {
-								return new Response("Side-by-side (as sub)", UtilText.parse(getSlave(), "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
+								return new Response("Side-by-side (as sub)", UtilText.parse(characterForSex, "[npc.Name] is not attracted to you, and so would be unwilling to participate in a threesome..."), null);
 							}
 							
 						} else if(!characterForSexSecondary.isAttractedTo(Main.game.getPlayer())) {
-							return new Response("Side-by-side (as sub)", UtilText.parse(characterForSexSecondary, getSlave(), "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
+							return new Response("Side-by-side (as sub)", UtilText.parse(characterForSexSecondary, characterForSex, "[npc.Name] is not attracted to you, and so neither [npc.she] nor [npc2.name] would be willing to have a threesome..."), null);
 							
-						} else if(!characterForSexSecondary.isAttractedTo(getSlave())) {
+						} else if(!characterForSexSecondary.isAttractedTo(characterForSex)) {
 							return new Response("Side-by-side (as sub)",
-									UtilText.parse(characterForSexSecondary, getSlave(), "[npc.Name] is not attracted to [npc2.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
+									UtilText.parse(characterForSexSecondary, characterForSex, "[npc.Name] is not attracted to [npc2.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
 									null);
 
-						} else if(!getSlave().isAttractedTo(characterForSexSecondary)) {
+						} else if(!characterForSex.isAttractedTo(characterForSexSecondary)) {
 							return new Response("Side-by-side (as sub)",
-									UtilText.parse(characterForSexSecondary, getSlave(), "[npc2.Name] is not attracted to [npc.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
+									UtilText.parse(characterForSexSecondary, characterForSex, "[npc2.Name] is not attracted to [npc.name], and so neither of them would be willing to be in a threesome position in which they are expected to interact with one other..."),
 									null);
 							
 						} else {
@@ -1271,9 +1271,9 @@ public class SlaveDialogue {
 							return new Response(
 									UtilText.parse(characterForSex, "Secondary: <b>[npc.Name]</b>"),
 									"Cycle the secondary targeted character for group sex.<br/>[style.italicsBad(You'd need to have a companion with you for this action to be unlocked!)]",
-									null); 
+									null);
 						}
-						
+
 					} else if (index == 0) {
 						return new Response("Leave", "Tell [npc.name] that you'll catch up with [npc.herHim] some other time.", Main.game.getDefaultDialogueNoEncounter()) {
 							@Override


### PR DESCRIPTION
- What is the purpose of the pull request?
Fix erroneous threesome participant selection

- Give a brief description of what you changed or added.
Changed some references from getslave or occupant to characterforsex or characterforsexsecondary in situations where the conditionals were already evaluating against characterforsex but the code for who to add to the sex scene would add getslave or occupant so you could end up with scenarios where you spoke to A who was not interested in sex with you, changed the targeting to B and C to enable the sex scene. The button text would mention A and C for example instead of B and C and then when you clicked start scene it would be A and C despite A not wanting to participate.

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Tested against 3.4.1hotfix

- So we have a better idea of who you are, what is your Discord Handle?
 GammaMike 6081

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.