### PR TITLE
Fix some stores (e.g. Clothing Emporium) being broken

### DIFF
--- a/src/com/lilithsthrone/game/character/PlayerCharacter.java
+++ b/src/com/lilithsthrone/game/character/PlayerCharacter.java
@@ -737,7 +737,11 @@ public class PlayerCharacter extends GameCharacter implements XMLSaving {
 	}
 	
 	public Quest getQuest(QuestLine questLine) {
-		return quests.get(questLine).get(quests.get(questLine).size()-1);
+		List<Quest> quests = this.quests.get(questLine);
+		if (null == quests) {
+			return null;
+		}
+		return quests.get(quests.size()-1);
 	}
 	
 	public boolean hasQuest(QuestLine questLine) {


### PR DESCRIPTION
Added null check into PlayerCharacter.getQuest.
Without this patch some dialogues (e.g. Clothing Emporium, Arcane Arts) in v0.3.5.4 fail with NullPointerException.