### PR TITLE
Two minor Maven configuration adjustments

### DIFF
--- a/lilithsThroneBuildTutorial.md
+++ b/lilithsThroneBuildTutorial.md
@@ -67,8 +67,8 @@ The GIT plugin of Eclipse tries to run the "bash" command, and if you hadn't ins
 6. Try Importing once again.
 
 ## Using Maven
-[Maven](https://maven.apache.org) is a Java build system that can be used to build applications.  
-Support is integrated into Eclipse, but it can be used without an IDE, so you can build the game without Eclipse.  
+[Maven](https://maven.apache.org) is a Java build system that can be used to build applications.
+Support is integrated into Eclipse, but it can be used without an IDE, so you can build the game without Eclipse.
 All build information is provided in [pom.xml](/pom.xml).
 
 ### Building
@@ -78,7 +78,7 @@ From the root of the repository (the folder where `pom.xml` is) run:
 mvn package
 ```
 
-This creates the JAR file in `/target/game-1.jar`.  
+This creates the JAR file in `/target/game-1.jar`.
 Your first build will take longer than the subsequent ones as only changed files are recompiled.
 
 ## Using NetBeans
@@ -121,8 +121,7 @@ Since this does not create a .jar file, you can add Maven run configurations to 
 
 Running the newly created configuration (Shift + F10, make sure that the correct configuration is selected in the top right corner) should create a runnable .jar file in the "target" directory within your working directory. You can rename this file to whatever you want.
 
-Note that executing it will display a warning that the "res" folder wasn't found. This is because it is copied to the wrong location during the Maven building process. You can manually copy it either from your project root directory or from "target/classes" so that it resides in the same directory as the .jar file.
-Also note that the "data" directory (that stores settings and save games) may be overriden during the building process, so make a backup of it beforehand.
+Note that the "data" directory (that stores settings and save games) may be overriden during the building process, so make a backup of it beforehand.
 
 ### Common issues
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
 	<packaging>jar</packaging>
 	<version>1</version>
 	<name>lilithsthrone</name>
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<resources>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,9 @@
 	<packaging>jar</packaging>
 	<version>1</version>
 	<name>lilithsthrone</name>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<resources>
@@ -16,7 +19,7 @@
 			</resource>
 			<resource>
 				<directory>res</directory>
-				<targetPath>res</targetPath>
+				<targetPath>../res</targetPath>
 			</resource>
 		</resources>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 			</resource>
 			<resource>
 				<directory>res</directory>
-				<targetPath>../res</targetPath>
+				<targetPath>${project.build.directory}/res</targetPath>
 			</resource>
 		</resources>
 		<plugins>


### PR DESCRIPTION
This pull request replaces #1126 .
I have tried in vain to do the whole "rebasing" thing in git, but luckily Github offers this cheap workaround.

**- What is the purpose of the pull request?**

1. fixed mvn warnings about platform-dependent encoding; cp-1252 (Windows default) is probably not the best choice for... anything ever
2. eliminated one paragraph from "Tutorial for Building Liliths Throne" by adjusting output to be simply "as expected"

**- Give a brief description of what you changed or added.**

1. added default encoding to pom.xml
2. changed target path for res folder to be outside of classes
3. removed obsolete paragraph from lilithsThroneBuildTutorial.md
4. accidentally eliminated some trailing whitespaces from lilithsThroneBuildTutorial.md... but chose not to revert this change, as it is not harmful

**- Are any new graphical assets required?**
nay

**- Has this change been tested? If so, mention the version number that the test was based on.**
cursory testing on "0.3.2.2 Alpha":

1. rebuilding project with "mvn clean package" and starting new game
2. using Umlauts äÄß in new PC name

**- So we have a better idea of who you are, what is your Discord Handle?**
Zsar#7336