### PR TITLE
Fixing NullPointerExceptions when visiting Lyssieth

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -19301,6 +19301,14 @@ public abstract class GameCharacter implements XMLSaving {
 		}
 	}
 
+	public Race getSubspeciesOverrideRace() {
+		try {
+			return getSubspeciesOverride().getRace();
+		} catch(Exception ex) {
+			return Race.NONE;
+		}
+	}
+
 	public void setSubspeciesOverride(Subspecies subspeciesOverride) {
 		body.setSubspeciesOverride(subspeciesOverride);
 	}

--- a/src/com/lilithsthrone/game/dialogue/places/submission/LyssiethPalaceDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/places/submission/LyssiethPalaceDialogue.java
@@ -514,7 +514,7 @@ public class LyssiethPalaceDialogue {
 				};
 				
 			} else if(index==8) {
-				if(Main.game.getPlayer().getSubspeciesOverride().getRace()==Race.DEMON) {
+				if(Main.game.getPlayer().getSubspeciesOverrideRace()==Race.DEMON) {
 					return new ResponseSex("Lilin sex (pussy)",
 							"Tell Lyssieth that you want her to take on her lilin form, and that you want to use her pussy.",
 							true,
@@ -560,7 +560,7 @@ public class LyssiethPalaceDialogue {
 					}
 				}
 				
-			} else if(index==9 && Main.game.getPlayer().getSubspeciesOverride().getRace()==Race.DEMON) {
+			} else if(index==9 && Main.game.getPlayer().getSubspeciesOverrideRace()==Race.DEMON) {
 				return new ResponseSex("Lilin sex (cock)",
 						"Tell Lyssieth that you want her to take on her lilin form, and that she should grow a cock and fuck you.",
 						true,


### PR DESCRIPTION
Added a wrapper around getSubspeciesOverride().getRace() named getSubspeciesOverrideRace() which returns Race.NONE as a fallback. I simply wanted a fix, that avoids if (xyz() != null)-checks.