### PR TITLE
Bat arms should block clothing

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -19301,6 +19301,14 @@ public abstract class GameCharacter implements XMLSaving {
 		}
 	}
 
+	public Race getSubspeciesOverrideRace() {
+		try {
+			return getSubspeciesOverride().getRace();
+		} catch(Exception ex) {
+			return Race.NONE;
+		}
+	}
+
 	public void setSubspeciesOverride(Subspecies subspeciesOverride) {
 		body.setSubspeciesOverride(subspeciesOverride);
 	}

--- a/src/com/lilithsthrone/game/character/body/types/ArmType.java
+++ b/src/com/lilithsthrone/game/character/body/types/ArmType.java
@@ -354,6 +354,18 @@ public class ArmType {
 		public boolean allowsFlight() {
 			return true;
 		}
+
+		private BodyPartClothingBlock clothingBlock = new BodyPartClothingBlock(
+				Util.newArrayListOfValues(
+						InventorySlot.HAND,
+						InventorySlot.WRIST),
+				Race.BAT_MORPH,
+				"Due to the fact that [npc.nameHasFull] bat-like wings instead of arms, only specialist clothing can be worn in this slot.",
+				Util.newArrayListOfValues(ItemTag.FITS_BAT_WINGS_EXCLUSIVE, ItemTag.FITS_ARM_WINGS));
+		@Override
+		public BodyPartClothingBlock getBodyPartClothingBlock() {
+			return clothingBlock;
+		}
 	};
 
 	public static AbstractArmType HARPY = new AbstractArmType(BodyCoveringType.FEATHERS,
@@ -391,7 +403,7 @@ public class ArmType {
 						InventorySlot.WRIST),
 				Race.HARPY,
 				"Due to the fact that [npc.nameHasFull] bird-like wings instead of arms, only specialist clothing can be worn in this slot.",
-				Util.newArrayListOfValues(ItemTag.FITS_HARPY_WINGS_EXCLUSIVE, ItemTag.FITS_HARPY_WINGS));
+				Util.newArrayListOfValues(ItemTag.FITS_HARPY_WINGS_EXCLUSIVE, ItemTag.FITS_ARM_WINGS));
 		@Override
 		public BodyPartClothingBlock getBodyPartClothingBlock() {
 			return clothingBlock;

--- a/src/com/lilithsthrone/game/dialogue/places/submission/LyssiethPalaceDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/places/submission/LyssiethPalaceDialogue.java
@@ -514,7 +514,7 @@ public class LyssiethPalaceDialogue {
 				};
 				
 			} else if(index==8) {
-				if(Main.game.getPlayer().getSubspeciesOverride().getRace()==Race.DEMON) {
+				if(Main.game.getPlayer().getSubspeciesOverrideRace()==Race.DEMON) {
 					return new ResponseSex("Lilin sex (pussy)",
 							"Tell Lyssieth that you want her to take on her lilin form, and that you want to use her pussy.",
 							true,
@@ -560,7 +560,7 @@ public class LyssiethPalaceDialogue {
 					}
 				}
 				
-			} else if(index==9 && Main.game.getPlayer().getSubspeciesOverride().getRace()==Race.DEMON) {
+			} else if(index==9 && Main.game.getPlayer().getSubspeciesOverrideRace()==Race.DEMON) {
 				return new ResponseSex("Lilin sex (cock)",
 						"Tell Lyssieth that you want her to take on her lilin form, and that she should grow a cock and fuck you.",
 						true,

--- a/src/com/lilithsthrone/game/inventory/ItemTag.java
+++ b/src/com/lilithsthrone/game/inventory/ItemTag.java
@@ -125,9 +125,13 @@ public enum ItemTag {
 	
 	FITS_HARPY_WINGS_EXCLUSIVE(
 			Util.newArrayListOfValues(
-					"[style.colourBestial(Only fits arm-wings)]"),
+					"[style.colourBestial(Only fits harpy-wings)]"),
 			false),
-	FITS_HARPY_WINGS(
+	FITS_BAT_WINGS_EXCLUSIVE(
+			Util.newArrayListOfValues(
+					"[style.colourBestial(Only fits bat-wings)]"),
+			false),
+	FITS_ARM_WINGS(
 			Util.newArrayListOfValues(
 					"[style.colourBestial(Fits arm-wings)]"),
 			false),

--- a/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
+++ b/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
@@ -1802,7 +1802,10 @@ public abstract class AbstractClothingType extends AbstractCoreType {
 			return new Value<>(false, UtilText.parse(clothingOwner,"The "+this.getName()+" "+(isPlural()?"are":"is")+" only suitable for cephalopod bodies, and as such, [npc.name] cannot wear "+(isPlural()?"them":"it")+"."));
 		}
 		if(tags.contains(ItemTag.FITS_HARPY_WINGS_EXCLUSIVE) && clothingOwner.getArmType()!=ArmType.HARPY) {
-			return new Value<>(false, UtilText.parse(clothingOwner,"The "+this.getName()+" "+(isPlural()?"are":"is")+" only suitable for arm-wings, and as such, [npc.name] cannot wear "+(isPlural()?"them":"it")+"."));
+			return new Value<>(false, UtilText.parse(clothingOwner,"The "+this.getName()+" "+(isPlural()?"are":"is")+" only suitable for harpy-wings, and as such, [npc.name] cannot wear "+(isPlural()?"them":"it")+"."));
+		}
+		if(tags.contains(ItemTag.FITS_BAT_WINGS_EXCLUSIVE) && clothingOwner.getArmType()!=ArmType.BAT_MORPH) {
+			return new Value<>(false, UtilText.parse(clothingOwner,"The "+this.getName()+" "+(isPlural()?"are":"is")+" only suitable for bat-wings, and as such, [npc.name] cannot wear "+(isPlural()?"them":"it")+"."));
 		}
 		if(tags.contains(ItemTag.FITS_HOOFS_EXCLUSIVE) && clothingOwner.getLegType().getFootType()!=FootType.HOOFS) {
 			return new Value<>(false, UtilText.parse(clothingOwner,"The "+this.getName()+" "+(isPlural()?"are":"is")+" only suitable for hoofs, and as such, [npc.name] cannot wear "+(isPlural()?"them":"it")+"."));


### PR DESCRIPTION
### What is the purpose of the pull request?
Bat wings and harpy wings basically match their descriptions as being arms turned into wings. However: Bat wings don't block any clothing. This should fix that.

### Give a brief description of what you changed or added.
- Refactored `FITS_HARPY_WINGS` to `FITS_ARM_WINGS` -> meaning: fits any type of arm wings, whether it be harpy, bat or for example wyvern wings.
- Added `FITS_BAT_WINGS_EXCLUSIVE` and implemented it where applicable since I see that as for arm clothing that is made specifically for that race only. e. g. wyvern arms clothing only.

### Are any new graphical assets required?
no

### Has this change been tested? If so, mention the version number that the test was based on.
Version 0.3.5.8

### So we have a better idea of who you are, what is your Discord Handle?
Stadler#3007