### PR TITLE
Set apartment to true when occupant moves out

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/companions/OccupantDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/companions/OccupantDialogue.java
@@ -1127,6 +1127,7 @@ public class OccupantDialogue {
 					public void effects() {
 						occupant().setRandomUnoccupiedLocation(WorldType.DOMINION, true, PlaceType.DOMINION_STREET, PlaceType.DOMINION_STREET_HARPY_NESTS, PlaceType.DOMINION_BOULEVARD);
 						occupant().setHomeLocation();
+						OccupantDialogue.isApartment = true;
 						Main.game.getPlayer().setLocation(occupant().getWorldLocation(), occupant().getLocation(), false);
 					}
 				};


### PR DESCRIPTION
What is the purpose of the pull request?
Fix the minor issue with sex in an apartment being public when the occupant has just moved in

Give a brief description of what you changed or added.
Set the boolean IsApartment to true in the dialogue when the occupant moves to the apartment

Are any new graphical assets required?
No

Has this change been tested? If so, mention the version number that the test was based on.
Yes, version 0.3.5.8