### PR TITLE
Fix the display for bj stats in the phone menu. Currently, giving and receiving stats are reversed.

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/companions/OccupantDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/companions/OccupantDialogue.java
@@ -1127,6 +1127,7 @@ public class OccupantDialogue {
 					public void effects() {
 						occupant().setRandomUnoccupiedLocation(WorldType.DOMINION, true, PlaceType.DOMINION_STREET, PlaceType.DOMINION_STREET_HARPY_NESTS, PlaceType.DOMINION_BOULEVARD);
 						occupant().setHomeLocation();
+						OccupantDialogue.isApartment = true;
 						Main.game.getPlayer().setLocation(occupant().getWorldLocation(), occupant().getLocation(), false);
 					}
 				};

--- a/src/com/lilithsthrone/game/dialogue/utils/PhoneDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/PhoneDialogue.java
@@ -1097,10 +1097,10 @@ public class PhoneDialogue {
 							:"")
 					
 					+ sexStatRow(Colour.AROUSAL_STAGE_ONE, "Blowjobs",
-							Main.game.getPlayer().getSexCount(new SexType(SexParticipantType.NORMAL, SexAreaPenetration.PENIS, SexAreaOrifice.MOUTH)),
-							Main.game.getPlayer().getCumCount(new SexType(SexParticipantType.NORMAL, SexAreaPenetration.PENIS, SexAreaOrifice.MOUTH)),
-							Main.game.getPlayer().getSexCount(new SexType(SexParticipantType.NORMAL, SexAreaOrifice.MOUTH, SexAreaPenetration.PENIS)),
-							Main.game.getPlayer().getCumCount(new SexType(SexParticipantType.NORMAL, SexAreaOrifice.MOUTH, SexAreaPenetration.PENIS)),
+  					        Main.game.getPlayer().getSexCount(new SexType(SexParticipantType.NORMAL, SexAreaOrifice.MOUTH, SexAreaPenetration.PENIS)),
+					        Main.game.getPlayer().getCumCount(new SexType(SexParticipantType.NORMAL, SexAreaPenetration.PENIS, SexAreaOrifice.MOUTH)),
+					        Main.game.getPlayer().getSexCount(new SexType(SexParticipantType.NORMAL, SexAreaPenetration.PENIS, SexAreaOrifice.MOUTH)),
+					        Main.game.getPlayer().getCumCount(new SexType(SexParticipantType.NORMAL, SexAreaOrifice.MOUTH, SexAreaPenetration.PENIS)),
 							true)
 					
 					+ sexStatRow(Colour.AROUSAL_STAGE_ONE, "Cunnilingus",


### PR DESCRIPTION
What is the purpose of the pull request?
Fix the display of sex stats in the phone menu.

Give a brief description of what you changed or added.
The display of stats for bj's given and received were reversed. (The creampie stats are OK).

Are any new graphical assets required?
No

Has this change been tested? If so, mention the version number that the test was based on.
Yes, version 0.3.5.8