### PR TITLE
Forced tf should fix leg config

### DIFF
--- a/src/com/lilithsthrone/game/character/body/types/AbstractLegType.java
+++ b/src/com/lilithsthrone/game/character/body/types/AbstractLegType.java
@@ -633,4 +633,12 @@ public abstract class AbstractLegType implements BodyPartTypeInterface {
 	public boolean isLegConfigurationAvailable(LegConfiguration legConfiguration) {
 		return allowedLegConfigurations.contains(legConfiguration);
 	}
+
+	/**
+	 * Returns the first item in the list of allowedLegConfigurations as the default.
+	 * @return The default LegConfiguration
+	 */
+	public LegConfiguration getDefaultLegConfiguration() {
+		return allowedLegConfigurations.get(0);
+	}
 }

--- a/src/com/lilithsthrone/game/character/body/types/ArmType.java
+++ b/src/com/lilithsthrone/game/character/body/types/ArmType.java
@@ -354,6 +354,18 @@ public class ArmType {
 		public boolean allowsFlight() {
 			return true;
 		}
+
+		private BodyPartClothingBlock clothingBlock = new BodyPartClothingBlock(
+				Util.newArrayListOfValues(
+						InventorySlot.HAND,
+						InventorySlot.WRIST),
+				Race.BAT_MORPH,
+				"Due to the fact that [npc.nameHasFull] bat-like wings instead of arms, only specialist clothing can be worn in this slot.",
+				Util.newArrayListOfValues(ItemTag.FITS_BAT_WINGS_EXCLUSIVE, ItemTag.FITS_ARM_WINGS));
+		@Override
+		public BodyPartClothingBlock getBodyPartClothingBlock() {
+			return clothingBlock;
+		}
 	};
 
 	public static AbstractArmType HARPY = new AbstractArmType(BodyCoveringType.FEATHERS,
@@ -391,7 +403,7 @@ public class ArmType {
 						InventorySlot.WRIST),
 				Race.HARPY,
 				"Due to the fact that [npc.nameHasFull] bird-like wings instead of arms, only specialist clothing can be worn in this slot.",
-				Util.newArrayListOfValues(ItemTag.FITS_HARPY_WINGS_EXCLUSIVE, ItemTag.FITS_HARPY_WINGS));
+				Util.newArrayListOfValues(ItemTag.FITS_HARPY_WINGS_EXCLUSIVE, ItemTag.FITS_ARM_WINGS));
 		@Override
 		public BodyPartClothingBlock getBodyPartClothingBlock() {
 			return clothingBlock;

--- a/src/com/lilithsthrone/game/character/body/valueEnums/LegConfiguration.java
+++ b/src/com/lilithsthrone/game/character/body/valueEnums/LegConfiguration.java
@@ -19,6 +19,7 @@ import com.lilithsthrone.game.character.body.types.WingType;
 import com.lilithsthrone.game.inventory.InventorySlot;
 import com.lilithsthrone.game.inventory.ItemTag;
 import com.lilithsthrone.game.inventory.clothing.BodyPartClothingBlock;
+import com.lilithsthrone.game.inventory.enchanting.TFModifier;
 import com.lilithsthrone.utils.Util;
 
 /**
@@ -58,6 +59,10 @@ public enum LegConfiguration {
 		public void setLegsToDemon(GameCharacter character) {
 			character.setLegType(LegType.DEMON_COMMON);
 		}
+		@Override
+		public TFModifier getTFModifier() {
+			return TFModifier.TF_MOD_LEG_CONFIG_BIPEDAL;
+		}
 	},
 
 	/**
@@ -91,6 +96,10 @@ public enum LegConfiguration {
 			@Override
 			public void setLegsToDemon(GameCharacter character) {
 				character.setLegType(LegType.DEMON_HOOFED);
+			}
+			@Override
+			public TFModifier getTFModifier() {
+				return TFModifier.TF_MOD_LEG_CONFIG_TAUR;
 			}
 	},
 
@@ -147,6 +156,10 @@ public enum LegConfiguration {
 							ItemTag.FITS_NON_BIPED_BODY_HUMANOID,
 							ItemTag.FITS_LONG_TAIL_BODY));
 		}
+		@Override
+		public TFModifier getTFModifier() {
+			return TFModifier.TF_MOD_LEG_CONFIG_TAIL_LONG;
+		}
 	},
 
 	/**
@@ -176,6 +189,10 @@ public enum LegConfiguration {
 					Util.newArrayListOfValues(
 							ItemTag.FITS_NON_BIPED_BODY_HUMANOID,
 							ItemTag.FITS_TAIL_BODY));
+		}
+		@Override
+		public TFModifier getTFModifier() {
+			return TFModifier.TF_MOD_LEG_CONFIG_TAIL;
 		}
 	},
 
@@ -211,6 +228,10 @@ public enum LegConfiguration {
 		@Override
 		public boolean isGenitalsExposed(GameCharacter character) { // When genitals are in a cloaca (i.e. beneath the arachnid body), they are not visible.
 			return character.getGenitalArrangement()==GenitalArrangement.NORMAL;
+		}
+		@Override
+		public TFModifier getTFModifier() {
+			return TFModifier.TF_MOD_LEG_CONFIG_ARACHNID;
 		}
 	},
 
@@ -263,6 +284,10 @@ public enum LegConfiguration {
 		@Override
 		public boolean isGenitalsExposed(GameCharacter character) { // Genitals are under tentacles, so are not visible even when naked.
 			return false;
+		}
+		@Override
+		public TFModifier getTFModifier() {
+			return TFModifier.TF_MOD_LEG_CONFIG_CEPHALOPOD;
 		}
 	};
 
@@ -392,6 +417,10 @@ public enum LegConfiguration {
 	
 	public void setLegsToDemon(GameCharacter character) {
 		throw new IllegalArgumentException("Demon legs for this leg configuration is not yet implemented!");
+	}
+
+	public TFModifier getTFModifier() {
+		throw new IllegalArgumentException("TF modifier for this leg configuration has not been defined!");
 	}
 
 	public void setWingsToDemon(GameCharacter character) {

--- a/src/com/lilithsthrone/game/character/npc/NPC.java
+++ b/src/com/lilithsthrone/game/character/npc/NPC.java
@@ -1489,8 +1489,12 @@ public abstract class NPC extends GameCharacter implements XMLSaving {
 						possibleEffects.put(new ItemEffect(itemType.getEnchantmentEffect(), TFModifier.TF_ARMS, TFModifier.NONE, TFPotency.MINOR_BOOST, 1),
 								"Your arms could do with a change!");
 					}
+					TFModifier legSecondaryTFMod = TFModifier.NONE;
+					if(!body.getLeg().getType().isLegConfigurationAvailable(target.getLegConfiguration())) {
+						legSecondaryTFMod = body.getLeg().getType().getDefaultLegConfiguration().getTFModifier();
+					}
 					if(target.getLegType() != body.getLeg().getType()) {
-						possibleEffects.put(new ItemEffect(itemType.getEnchantmentEffect(), TFModifier.TF_LEGS, TFModifier.NONE, TFPotency.MINOR_BOOST, 1),
+						possibleEffects.put(new ItemEffect(itemType.getEnchantmentEffect(), TFModifier.TF_LEGS, legSecondaryTFMod, TFPotency.MINOR_BOOST, 1),
 								"I'm sure you'll love getting some new legs!");
 					}
 					if(possibleEffects.size()>=numberOfTransformations) { return new Value<>(itemType, possibleEffects); } // Apply arms & legs at the same time

--- a/src/com/lilithsthrone/game/inventory/ItemTag.java
+++ b/src/com/lilithsthrone/game/inventory/ItemTag.java
@@ -125,9 +125,13 @@ public enum ItemTag {
 	
 	FITS_HARPY_WINGS_EXCLUSIVE(
 			Util.newArrayListOfValues(
-					"[style.colourBestial(Only fits arm-wings)]"),
+					"[style.colourBestial(Only fits harpy-wings)]"),
 			false),
-	FITS_HARPY_WINGS(
+	FITS_BAT_WINGS_EXCLUSIVE(
+			Util.newArrayListOfValues(
+					"[style.colourBestial(Only fits bat-wings)]"),
+			false),
+	FITS_ARM_WINGS(
 			Util.newArrayListOfValues(
 					"[style.colourBestial(Fits arm-wings)]"),
 			false),

--- a/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
+++ b/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
@@ -1802,7 +1802,10 @@ public abstract class AbstractClothingType extends AbstractCoreType {
 			return new Value<>(false, UtilText.parse(clothingOwner,"The "+this.getName()+" "+(isPlural()?"are":"is")+" only suitable for cephalopod bodies, and as such, [npc.name] cannot wear "+(isPlural()?"them":"it")+"."));
 		}
 		if(tags.contains(ItemTag.FITS_HARPY_WINGS_EXCLUSIVE) && clothingOwner.getArmType()!=ArmType.HARPY) {
-			return new Value<>(false, UtilText.parse(clothingOwner,"The "+this.getName()+" "+(isPlural()?"are":"is")+" only suitable for arm-wings, and as such, [npc.name] cannot wear "+(isPlural()?"them":"it")+"."));
+			return new Value<>(false, UtilText.parse(clothingOwner,"The "+this.getName()+" "+(isPlural()?"are":"is")+" only suitable for harpy-wings, and as such, [npc.name] cannot wear "+(isPlural()?"them":"it")+"."));
+		}
+		if(tags.contains(ItemTag.FITS_BAT_WINGS_EXCLUSIVE) && clothingOwner.getArmType()!=ArmType.BAT_MORPH) {
+			return new Value<>(false, UtilText.parse(clothingOwner,"The "+this.getName()+" "+(isPlural()?"are":"is")+" only suitable for bat-wings, and as such, [npc.name] cannot wear "+(isPlural()?"them":"it")+"."));
 		}
 		if(tags.contains(ItemTag.FITS_HOOFS_EXCLUSIVE) && clothingOwner.getLegType().getFootType()!=FootType.HOOFS) {
 			return new Value<>(false, UtilText.parse(clothingOwner,"The "+this.getName()+" "+(isPlural()?"are":"is")+" only suitable for hoofs, and as such, [npc.name] cannot wear "+(isPlural()?"them":"it")+"."));


### PR DESCRIPTION
#### What is the purpose of the pull request?
Forced TF didn't change the legs, if the leg configuration was incompatible

#### Give a brief description of what you changed or added.
- The leg TF chunk of the forced TF checks, if the targeted LegConfiguration is compatible with the current one and sets the secondary TF modifier to set it to the default, if needed.
- Added `getDefaultLegConfiguration` to AbstractLegType.java: Returned the first entry in `allowedLegConfigurations` as the default.
- Added `getTFModifier` to the `LegConfiguration`s.

#### Are any new graphical assets required?
No

#### Has this change been tested? If so, mention the version number that the test was based on.
Version 0.3.5.8

#### So we have a better idea of who you are, what is your Discord Handle?
Stadler#3007