### PR TITLE
CoverableArea mouth can never be discovered, blocking knowledge of NPC's oral skills

### DIFF
--- a/src/com/lilithsthrone/game/character/body/CoverableArea.java
+++ b/src/com/lilithsthrone/game/character/body/CoverableArea.java
@@ -192,7 +192,7 @@ public enum CoverableArea {
 					InventorySlot.HORNS,
 					InventorySlot.HEAD)),
 	
-	MOUTH(false,
+	MOUTH(true,
 			"mouth",
 			Util.newArrayListOfValues(
 					InventorySlot.HAIR,
@@ -208,7 +208,7 @@ public enum CoverableArea {
 	private List<InventorySlot> associatedInventorySlots;
 
 	private CoverableArea(boolean saveDiscoveredStatus, String name, List<InventorySlot> associatedInventorySlots) {
-		this.saveDiscoveredStatus = saveDiscoveredStatus;
+		setSaveDiscoveredStatus(saveDiscoveredStatus);
 		this.name = name;
 		this.associatedInventorySlots = associatedInventorySlots;
 	}


### PR DESCRIPTION
<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
Fix the issue where an NPC's oral skill can never be discovered

- Give a brief description of what you changed or added.
CoverableArea mouth has saveDiscoveredArea set to false. 
There is a check in setAreaKnownByCharacter to see if it is true, and since it never is, 
this blocks gaining knowledge of this area by the MC

To fix this, the value has been set to true.

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, version 0.3.5.8