### PR TITLE
Fix DayPeriodCalculation to prevent eternal night.

### DIFF
--- a/src/com/lilithsthrone/controller/MainController.java
+++ b/src/com/lilithsthrone/controller/MainController.java
@@ -1544,8 +1544,8 @@ public class MainController implements Initializable {
 			TooltipInformationEventListener el2 = new TooltipInformationEventListener().setInformation(
 					(Main.game.isDayTime()?"Day-time":"Night-time"),
 					"Current time: "+Units.time(Main.game.getDateNow())+" (<span style='color:"+dp.getColour().toWebHexString()+";'>"+Util.capitaliseSentence(dp.getName())+"</span>)<br/>"
-					+ "Sunrise: [style.colourYellow("+Units.dateTime(ldt[0])+")]<br/>"
-					+ "Sunset: [style.colourOrange("+Units.dateTime(ldt[1])+")]<br/>"
+					+ "Sunrise: [style.colourYellow("+Units.time(ldt[0])+")]<br/>"
+					+ "Sunset: [style.colourOrange("+Units.time(ldt[1])+")]<br/>"
 					+ "<i>Click to toggle the time display between a 24-hour and 12-hour clock.</i>");
 			addEventListener(documentAttributes, id, "mouseenter", el2, false);
 		}

--- a/src/com/lilithsthrone/utils/time/DateAndTime.java
+++ b/src/com/lilithsthrone/utils/time/DateAndTime.java
@@ -264,22 +264,22 @@ public class DateAndTime {
 	public static DayPeriod getDayPeriod(LocalDateTime date, double latitude, double longitudeWest) {
 		
 		LocalDateTime[] times = getTimeOfSolarElevationChange(date, SolarElevationAngle.SUN_ALTITUDE_SUNRISE_SUNSET, latitude, longitudeWest);
-		if(times[0]==null || (date.isAfter(times[0]) && date.isBefore(times[1]))) {
+		if(times[0]==null || (date.toLocalTime().isAfter(times[0].toLocalTime()) && date.toLocalTime().isBefore(times[1].toLocalTime()))) {
 			return DayPeriod.DAY;
 		}
 
 		times = getTimeOfSolarElevationChange(date, SolarElevationAngle.SUN_ALTITUDE_CIVIL_TWILIGHT, latitude, longitudeWest);
-		if(times[0]==null || (date.isAfter(times[0]) && date.isBefore(times[1]))) {
+		if(times[0]==null || (date.toLocalTime().isAfter(times[0].toLocalTime()) && date.toLocalTime().isBefore(times[1].toLocalTime()))) {
 			return DayPeriod.CIVIL_TWILIGHT;
 		}
 
 		times = getTimeOfSolarElevationChange(date, SolarElevationAngle.SUN_ALTITUDE_NAUTICAL_TWILIGHT, latitude, longitudeWest);
-		if(times[0]==null || (date.isAfter(times[0]) && date.isBefore(times[1]))) {
+		if(times[0]==null || (date.toLocalTime().isAfter(times[0].toLocalTime()) && date.toLocalTime().isBefore(times[1].toLocalTime()))) {
 			return DayPeriod.NAUTICAL_TWILIGHT;
 		}
 
 		times = getTimeOfSolarElevationChange(date, SolarElevationAngle.SUN_ALTITUDE_ASTRONOMICAL_TWILIGHT, latitude, longitudeWest);
-		if(times[0]==null || (date.isAfter(times[0]) && date.isBefore(times[1]))) {
+		if(times[0]==null || (date.toLocalTime().isAfter(times[0].toLocalTime()) && date.toLocalTime().isBefore(times[1].toLocalTime()))) {
 			return DayPeriod.ASTRONOMICAL_TWILIGHT;
 		}
 		


### PR DESCRIPTION
<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
Fix the issue where the DayPeriod (daytime, twilight, nighttime) is not calculated correctly resulting in eternal night.

- Give a brief description of what you changed or added.
Use only time when determining DayPeriod, since the date can be (is always?) a day off. If the sunrise is calculated as time xx:xx tomorrow (as frequently happens), the current Dayperiod is always Night. The actual date used in the calculation (be it today, tomorrow or yesterday) doesn't matter all that much. It's comparing the current time with sunrise and sunset that's important.

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, version 0.3.5.8

@Innoxia: In public static LocalDateTime julianDayToDate(double julianDate) there was a plusDays(1) added in return LocalDateTime.of(year, month, day, hours, minutes, seconds).plusDays(1). Removing this again may also solve the problem, but I think it was put there for a reason?