### PR TITLE
Have maven download required JavaFX/openjfx code; slight debug menu fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,33 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-base</artifactId>
+			<version>13</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-fxml</artifactId>
+			<version>13</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-controls</artifactId>
+			<version>13</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-graphics</artifactId>
+			<version>13</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-web</artifactId>
+			<version>13</version>
+		</dependency>
+        </dependencies>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<resources>
@@ -42,6 +69,17 @@
 					<source>1.8</source>
 					<target>1.8</target>
 					<useIncrementalCompilation>false</useIncrementalCompilation>
+					<!-- <compilerArgs>
+						<arg>-Xlint:all</arg>
+					</compilerArgs> -->
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.openjfx</groupId>
+				<artifactId>javafx-maven-plugin</artifactId>
+				<version>0.0.3</version>
+				<configuration>
+					<mainClass>com.lilithstrone.main.Main</mainClass>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/com/lilithsthrone/game/dialogue/utils/BodyChanging.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/BodyChanging.java
@@ -877,7 +877,7 @@ public class BodyChanging {
 		public String getHeaderContent() {
 			UtilText.nodeContentSB.setLength(0);
 			
-			if(isDemonTFMenu()) {
+			if(isDemonTFMenu() || debugMenu) {
 				UtilText.nodeContentSB.append("<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your ass and hips.</i>"
@@ -1130,7 +1130,7 @@ public class BodyChanging {
 		public String getHeaderContent() {
 			UtilText.nodeContentSB.setLength(0);
 			
-			if(isDemonTFMenu()) {
+			if(isDemonTFMenu() || debugMenu) {
 				UtilText.nodeContentSB.append("<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your vagina.</i>"
@@ -1271,7 +1271,7 @@ public class BodyChanging {
 		public String getHeaderContent() {
 			UtilText.nodeContentSB.setLength(0);
 			
-			if(isDemonTFMenu()) {
+			if(isDemonTFMenu() || debugMenu) {
 				UtilText.nodeContentSB.append("<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your penis.</i>"
@@ -1422,7 +1422,7 @@ public class BodyChanging {
 
 		@Override
 		public String getHeaderContent() {
-			if(isDemonTFMenu()) {
+			if(isDemonTFMenu() || debugMenu) {
 				return "<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your [pc.crotchBoobs].</i>"

--- a/src/com/lilithsthrone/game/dialogue/utils/BodyChanging.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/BodyChanging.java
@@ -877,7 +877,7 @@ public class BodyChanging {
 		public String getHeaderContent() {
 			UtilText.nodeContentSB.setLength(0);
 			
-			if(isDemonTFMenu() || debugMenu) {
+			if(isDemonTFMenu()) {
 				UtilText.nodeContentSB.append("<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your ass and hips.</i>"
@@ -1130,7 +1130,7 @@ public class BodyChanging {
 		public String getHeaderContent() {
 			UtilText.nodeContentSB.setLength(0);
 			
-			if(isDemonTFMenu() || debugMenu) {
+			if(isDemonTFMenu()) {
 				UtilText.nodeContentSB.append("<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your vagina.</i>"
@@ -1271,7 +1271,7 @@ public class BodyChanging {
 		public String getHeaderContent() {
 			UtilText.nodeContentSB.setLength(0);
 			
-			if(isDemonTFMenu() || debugMenu) {
+			if(isDemonTFMenu()) {
 				UtilText.nodeContentSB.append("<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your penis.</i>"
@@ -1422,7 +1422,7 @@ public class BodyChanging {
 
 		@Override
 		public String getHeaderContent() {
-			if(isDemonTFMenu() || debugMenu) {
+			if(isDemonTFMenu()) {
 				return "<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your [pc.crotchBoobs].</i>"


### PR DESCRIPTION
<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?

Have maven download the required JavaFX/openjfx code. Otherwise, maven installation will not work on Mac OS X, even with openjfx installed.

- Give a brief description of what you changed or added.

Added dependencies and plugin to pom.xml. (Also adds a commented-out compiler linting command.)

- Are any new graphical assets required?

No.

- Has this change been tested? If so, mention the version number that the test was based on.

Yes; 0.3.5.4-dev for original download and installation of JavaFX/openjfx; confirmed that maven still works (with this pom.xml) for 0.3.5.8-dev.

- So we have a better idea of who you are, what is your Discord Handle?

None currently; will try to get around to it eventually...

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
