### PR TITLE
Avoid assumption of slime for debug body transform, unless already no…

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/BodyChanging.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/BodyChanging.java
@@ -877,7 +877,7 @@ public class BodyChanging {
 		public String getHeaderContent() {
 			UtilText.nodeContentSB.setLength(0);
 			
-			if(isDemonTFMenu()) {
+			if(isDemonTFMenu() || debugMenu) {
 				UtilText.nodeContentSB.append("<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your ass and hips.</i>"
@@ -1130,7 +1130,7 @@ public class BodyChanging {
 		public String getHeaderContent() {
 			UtilText.nodeContentSB.setLength(0);
 			
-			if(isDemonTFMenu()) {
+			if(isDemonTFMenu() || debugMenu) {
 				UtilText.nodeContentSB.append("<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your vagina.</i>"
@@ -1271,7 +1271,7 @@ public class BodyChanging {
 		public String getHeaderContent() {
 			UtilText.nodeContentSB.setLength(0);
 			
-			if(isDemonTFMenu()) {
+			if(isDemonTFMenu() || debugMenu) {
 				UtilText.nodeContentSB.append("<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your penis.</i>"
@@ -1422,7 +1422,7 @@ public class BodyChanging {
 
 		@Override
 		public String getHeaderContent() {
-			if(isDemonTFMenu()) {
+			if(isDemonTFMenu() || debugMenu) {
 				return "<div class='container-full-width' style='text-align:center;'>"
 						+ (BodyChanging.getTarget().isPlayer()
 								?"<i>Focus your demonic transformative powers on changing aspects of your [pc.crotchBoobs].</i>"


### PR DESCRIPTION
- What is the purpose of the pull request?

Avoid assumption of slime for debug body transform, unless already noted in comments as "slime/debug" or similar.

- Give a brief description of what you changed or added.

Changed "isDemonTFMenu()" in dialogue/utils/BodyChanging.java to "isDemonTFMenu() || debugMenu" in appropriate places.

- Are any new graphical assets required?

No.

- Has this change been tested? If so, mention the version number that the test was based on.

0.3.5.4

- So we have a better idea of who you are, what is your Discord Handle?

Kinsey/kinsey.