### PR TITLE
StatusEffect.java - Inflation Mechanic Updated

### DIFF
--- a/src/com/lilithsthrone/game/character/effects/StatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/StatusEffect.java
@@ -5263,8 +5263,8 @@ public enum StatusEffect {
 		@Override
 		public boolean isConditionsMet(GameCharacter target) {
 			float cumAmount = target.getTotalFluidInArea(SexAreaOrifice.ANUS) + target.getTotalFluidInArea(SexAreaOrifice.MOUTH) + target.getTotalFluidInArea(SexAreaOrifice.VAGINA);
-			return cumAmount >= CumProduction.SEVEN_MONSTROUS.getMinimumValue()
-					&& cumAmount < CumProduction.SEVEN_MONSTROUS.getMedianValue()
+			return cumAmount >= Math.pow((Math.cbrt(3785) / 182.88) * target.getHeightValue(), 3)
+					&& cumAmount < Math.pow((Math.cbrt(7570) / 182.88) * target.getHeightValue(), 3)
 					&& Main.getProperties().hasValue(PropertyValue.inflationContent);
 		}
 		
@@ -5303,8 +5303,8 @@ public enum StatusEffect {
 		@Override
 		public boolean isConditionsMet(GameCharacter target) {
 			float cumAmount = target.getTotalFluidInArea(SexAreaOrifice.ANUS) + target.getTotalFluidInArea(SexAreaOrifice.MOUTH) + target.getTotalFluidInArea(SexAreaOrifice.VAGINA);
-			return cumAmount >= CumProduction.SEVEN_MONSTROUS.getMedianValue()
-					&& cumAmount < CumProduction.SEVEN_MONSTROUS.getMaximumValue()
+			return cumAmount >= Math.pow((Math.cbrt(7570) / 182.88) * target.getHeightValue(), 3)
+					&& cumAmount < Math.pow((Math.cbrt(11356) / 182.88) * target.getHeightValue(), 3)
 					&& Main.getProperties().hasValue(PropertyValue.inflationContent);
 		}
 		
@@ -5343,7 +5343,7 @@ public enum StatusEffect {
 		@Override
 		public boolean isConditionsMet(GameCharacter target) {
 			float cumAmount = target.getTotalFluidInArea(SexAreaOrifice.ANUS) + target.getTotalFluidInArea(SexAreaOrifice.MOUTH) + target.getTotalFluidInArea(SexAreaOrifice.VAGINA);
-			return cumAmount >= CumProduction.SEVEN_MONSTROUS.getMaximumValue()
+			return cumAmount >= Math.pow((Math.cbrt(11356) / 182.88) * target.getHeightValue(), 3)
 					&& Main.getProperties().hasValue(PropertyValue.inflationContent);
 		}
 		
@@ -5382,8 +5382,8 @@ public enum StatusEffect {
 		@Override
 		public boolean isConditionsMet(GameCharacter target) {
 			float cumAmount = target.getTotalFluidInArea(SexAreaOrifice.NIPPLE);
-			return cumAmount >= CumProduction.SEVEN_MONSTROUS.getMinimumValue()
-					&& cumAmount < CumProduction.SEVEN_MONSTROUS.getMedianValue()
+			return cumAmount >= Math.pow((Math.cbrt(10) * (target.getBreastSize().getMeasurement() / 3) + 1), 3)
+					&& cumAmount < Math.pow((Math.cbrt(20) * (target.getBreastSize().getMeasurement() / 3) + 1), 3)
 					&& Main.getProperties().hasValue(PropertyValue.inflationContent);
 		}
 		
@@ -5422,8 +5422,8 @@ public enum StatusEffect {
 		@Override
 		public boolean isConditionsMet(GameCharacter target) {
 			float cumAmount = target.getTotalFluidInArea(SexAreaOrifice.NIPPLE);
-			return cumAmount >= CumProduction.SEVEN_MONSTROUS.getMedianValue()
-					&& cumAmount < CumProduction.SEVEN_MONSTROUS.getMaximumValue()
+			return cumAmount >= Math.pow((Math.cbrt(20) * (target.getBreastSize().getMeasurement() / 3) + 1), 3)
+					&& cumAmount < Math.pow((Math.cbrt(30) * (target.getBreastSize().getMeasurement() / 3) + 1), 3)
 					&& Main.getProperties().hasValue(PropertyValue.inflationContent);
 		}
 		
@@ -5462,7 +5462,7 @@ public enum StatusEffect {
 		@Override
 		public boolean isConditionsMet(GameCharacter target) {
 			float cumAmount = target.getTotalFluidInArea(SexAreaOrifice.NIPPLE);
-			return cumAmount >= CumProduction.SEVEN_MONSTROUS.getMaximumValue()
+			return cumAmount >= Math.pow((Math.cbrt(30) * (target.getBreastSize().getMeasurement() / 3) + 1), 3)
 					&& Main.getProperties().hasValue(PropertyValue.inflationContent);
 		}
 		


### PR DESCRIPTION
**Why I Do:**
Was making a personalized, modded version of game for self-use, reading through code.
Saw the usage of a static value, decided to fix.

**What It Do:**
Made the fluid volume properly scale with character height.

**How It Do:**
1)Cube-Rooting as a quick way to turn a fluid volume into a 3D scalable number
2)dividing by the height I had based fluid volume around. (6ft, 182.88cm)
3)Multiplying by affected character's height, to create scalability
4)power of 3 to De-Cube-Root, converting from 3D scalable number back into fluid volume.
(Feel free to change Fluid Volume in cbrt() or change the reference height.)

**It Do Comparisons:**
VARS:
A= 3785; (Fluid for 6ft / 182.88cm, 1 US Gallon in mL)
B= ##; (New Height to calc For)

**Calc for smallest extreme:** (2ft, B=61)
>Option 1: (basic Divide & Mult)
(A / 182.88) * B = 1,262 ml (0.3333 US Gal, way too much)
>Option 2: (Square Root)
((sqrt(A)/182.88)*B)^2 = 421 ml (0.1112 US Gal, still too much)
>Option 3: (Cube Root)
((cbrt(A)/182.88)*B)^3 = 140 ml (0.037 US Gal / 0.59 US Cup)

**Calc for avg height:** (6ft, B=182.88) [just for showing, otherwise useless]
>Option 1: (basic Divide & Mult)
(A / 182.88) * B = 3,785 ml (1 US Gal)
>Option 2: (Square Root)
((sqrt(A)/182.88)*B)^2 = 3,785 ml (1 US Gal)
>Option 3: (Cube Root)
((cbrt(A)/182.88)*B)^3 = 3,785 ml (1 US Gal)

**Calc for largestest extreme:** (12ft, B=366)
>Option 1: (basic Divide & Mult)
(A / 182.88) * B = 7,575 ml (2 US Gal, not enough)
>Option 2: (Square Root)
((sqrt(A)/182.88)*B)^2 = 15,160 ml (4 US Gal, enough? not really?)
>Option 3: (Cube Root)
((cbrt(A)/182.88)*B)^3 = 30,340 ml (8 US Gal, enough.)

**What It Could Do:** (Untested)
IF
target.getHeightValue()
INTO
(target.getHeightValue() * ((Bodysize + 100) / 150))
Results:
BodySize= 0 - would mult height by 0.6666...
BodySize= 50 - would mult height by 1, no change
BodySize= 100 - Would mult height by 1.3333...

**For Nipple&Breast inflation**
I decided to do a quicker method than what I was originally thinking of. I only did rough tuning. Feel free to adjust the number that is in 'cbrt()' and the divisor for breast size(by 0.1 increments probably)

Here's the math I used in my calculator: I'm too lazy to make more readable right now.
F=10; //Fluid base
CS=16; //Cup Size
DV=3; // Divisor
SN=(3#F); //Cube Rooting Fluid base
SF=SN * ((CS/DV)+1); // Smash the numbers together
SF^3 // De-Cube-Root to get result

**End Notes:**
This is just a quick fix to a lack of scaling. You could turn my math into function elsewhere and simplify process.

The Cube-Root process can be used elsewhere, You could overhaul Girth, Capacity, ETC using this math process.

<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
Updating Static values.
- Give a brief description of what you changed or added.
Added Math to Inflation Mechanics
- Are any new graphical assets required?
No?
- Has this change been tested? If so, mention the version number that the test was based on.
The suggested changes were lightly tested, code in description is probably not tested.
- So we have a better idea of who you are, what is your Discord Handle?
HolyDevil#6986
- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
Probably will do later.