### PR TITLE
Add SLIME to discovered coverings (also when loading)

### DIFF
--- a/src/com/lilithsthrone/game/character/body/Body.java
+++ b/src/com/lilithsthrone/game/character/body/Body.java
@@ -319,6 +319,7 @@ public class Body implements XMLSaving {
 	
 	public void addDiscoveredBodyCoveringsFromMaterial(BodyMaterial bodyMaterial) {
 		if(bodyMaterial==BodyMaterial.SLIME) {
+			coveringsDiscovered.add(BodyCoveringType.SLIME);
 			coveringsDiscovered.add(BodyCoveringType.SLIME_EYE);
 			coveringsDiscovered.add(BodyCoveringType.SLIME_HAIR);
 			coveringsDiscovered.add(BodyCoveringType.SLIME_PUPILS);
@@ -1815,9 +1816,11 @@ public class Body implements XMLSaving {
 			} catch(Exception ex) {
 			}
 		}
-		
+
+		body.addDiscoveredBodyCoveringsFromMaterial(importedBodyMaterial);
+
 		body.calculateRace(null);
-		
+
 		if(Main.isVersionOlderThan(Game.loadingVersion, "0.3.0.5")) {
 			body.updateNippleCrotchColouring();
 		}


### PR DESCRIPTION
- What is the purpose of the pull request?
Fix issue #1304: The main color of slime characters is not saved.

- Give a brief description of what you changed or added.
Add SLIME as a body covering part, so it will also be added to the save file. And on loading back the save, also update the list with coverings.

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, version 0.3.6.9

- So we have a better idea of who you are, what is your Discord Handle?
ACEXP