### PR TITLE
Saving game default color fix for clothing

### DIFF
--- a/src/com/lilithsthrone/game/inventory/clothing/AbstractClothing.java
+++ b/src/com/lilithsthrone/game/inventory/clothing/AbstractClothing.java
@@ -308,10 +308,10 @@ public abstract class AbstractClothing extends AbstractCoreItem implements XMLSa
 		if(this.getColour()!=AbstractClothingType.DEFAULT_COLOUR_VALUE) {
 			CharacterUtils.addAttribute(doc, element, "colour", this.getColour().toString());
 		}
-		if(this.getSecondaryColour()!=AbstractClothingType.DEFAULT_COLOUR_VALUE) {
+		if(this.getSecondaryColour()!=this.clothingType.getDefaultSecondaryColour()) {
 			CharacterUtils.addAttribute(doc, element, "colourSecondary", this.getSecondaryColour().toString());
 		}
-		if(this.getTertiaryColour()!=AbstractClothingType.DEFAULT_COLOUR_VALUE) {
+		if(this.getTertiaryColour()!=this.clothingType.getDefaultTertiaryColour()) {
 			CharacterUtils.addAttribute(doc, element, "colourTertiary", this.getTertiaryColour().toString());
 		}
 		
@@ -319,10 +319,10 @@ public abstract class AbstractClothing extends AbstractCoreItem implements XMLSa
 			if(this.getPatternColour()!=AbstractClothingType.DEFAULT_COLOUR_VALUE) {
 				CharacterUtils.addAttribute(doc, element, "patternColour", this.getPatternColour().toString());
 			}
-			if(this.getPatternSecondaryColour()!=AbstractClothingType.DEFAULT_COLOUR_VALUE) {
+			if(this.getPatternSecondaryColour()!=this.clothingType.getDefaultSecondaryColour()) {
 				CharacterUtils.addAttribute(doc, element, "patternColourSecondary", this.getPatternSecondaryColour().toString());
 			}
-			if(this.getPatternTertiaryColour()!=AbstractClothingType.DEFAULT_COLOUR_VALUE) {
+			if(this.getPatternTertiaryColour()!=this.clothingType.getDefaultTertiaryColour()) {
 				CharacterUtils.addAttribute(doc, element, "patternColourTertiary", this.getPatternTertiaryColour().toString());
 			}
 			CharacterUtils.addAttribute(doc, element, "pattern", this.getPattern());

--- a/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
+++ b/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
@@ -3005,4 +3005,16 @@ public abstract class AbstractClothingType extends AbstractCoreType {
 		}
 		return orificeOtherModifiers;
 	}
+
+	public Colour getDefaultSecondaryColour() {
+		return availableSecondaryColours.size() == 1
+				? availableSecondaryColours.get(0)
+				: DEFAULT_COLOUR_VALUE;
+	}
+
+	public Colour getDefaultTertiaryColour() {
+		return availableTertiaryColours.size() == 1
+				? availableTertiaryColours.get(0)
+				: DEFAULT_COLOUR_VALUE;
+	}
 }


### PR DESCRIPTION
- What is the purpose of the pull request?
Fixes a bug that was introduced with the latest update when saving a game would not save an xml property for the colour `CLOTHING_BLACK`, but when loading the game would instead apply a default color from the collection of `availableSecondaryColours` or `availableTertiaryColours`, leading to incorrect data being loaded.

- Give a brief description of what you changed or added.
Added two methods to retrieve a default secondary or tertiary color that take `availableColours` collections into account and changed xml saving method accordingly. That had a nice little side effect of _very slightly_ reducing the size of the resulting xml file, since a few in-game items have their effective default color set to something other than black (like roses and metal bits on a few items).

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Tested in 3.6.9

- So we have a better idea of who you are, what is your Discord Handle?
Rist
