### PR TITLE
Reduce length of offspring list.

### DIFF
--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -3764,7 +3764,14 @@ public class Game implements XMLSaving {
 	public boolean banishNPC(NPC npc) {
 		Main.game.getPlayer().removeCompanion(npc);
 		npc.deleteAllEquippedClothing(true); // To cut down on save size and return unique items to the player.
-		
+
+		//If the NPC to be removed is related to the player, remove it from the NPCmap and increase childrenRemoved
+		if(npc.isRelatedTo(player))
+		{
+			NPCMap.remove(npc.getId(),npc);
+			player.incrementChildrenRemoved(1);
+		}
+
 		if(Main.game.getPlayer().getSexPartners().containsKey(npc.getId())
 				|| npc.getPregnantLitter()!=null
 				|| npc.getLastLitterBirthed()!=null

--- a/src/com/lilithsthrone/game/character/PlayerCharacter.java
+++ b/src/com/lilithsthrone/game/character/PlayerCharacter.java
@@ -99,6 +99,10 @@ public class PlayerCharacter extends GameCharacter implements XMLSaving {
 	private Set<Subspecies> racesDiscoveredFromBook;
 	
 	protected List<String> friendlyOccupants;
+
+	//Variable for tracking how many children were removed after encountering them
+	//Needed for correct calculation of percentage of already met children
+	private int childrenRemoved = 0;
 	
 	// Trader buy-back:
 	private SizedStack<ShopTransaction> buybackStack;
@@ -174,7 +178,9 @@ public class PlayerCharacter extends GameCharacter implements XMLSaving {
 		for(String id : charactersEncountered) {
 			CharacterUtils.createXMLElementWithValue(doc, charactersEncounteredElement, "id", id);
 		}
-		
+
+		CharacterUtils.createXMLElementWithValue(doc,playerSpecific,"childrenRemoved",String.valueOf(this.getChildrenRemoved()));
+
 		innerElement = doc.createElement("questMap");
 		playerSpecific.appendChild(innerElement);
 		for(Entry<QuestLine, List<Quest>> entry : quests.entrySet()) {
@@ -300,7 +306,11 @@ public class PlayerCharacter extends GameCharacter implements XMLSaving {
 						character.addCharacterEncountered(id);
 					}
 				}
-				
+
+				if(playerSpecificElement.getElementsByTagName("childrenRemoved").getLength()!=0) {
+					character.incrementChildrenRemoved(Integer.valueOf(Integer.valueOf(((Element) playerSpecificElement.getElementsByTagName("childrenRemoved").item(0)).getAttribute("value"))));
+				}
+
 				Element questMapElement = (Element) playerSpecificElement.getElementsByTagName("questMap").item(0);
 				if(questMapElement!=null) {
 					NodeList questMapEntries = questMapElement.getElementsByTagName("entry");
@@ -1299,6 +1309,10 @@ public class PlayerCharacter extends GameCharacter implements XMLSaving {
 	public boolean removeFriendlyOccupant(GameCharacter occupant) {
 		return friendlyOccupants.remove(occupant.getId());
 	}
+
+	public int getChildrenRemoved() {return childrenRemoved;}
+
+	public void incrementChildrenRemoved(int childrenRemovedIncrement){childrenRemoved+=childrenRemovedIncrement;}
 
 	public Set<WorldType> getWorldsVisited() {
 		return worldsVisited;

--- a/src/com/lilithsthrone/game/dialogue/utils/PhoneDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/PhoneDialogue.java
@@ -1483,7 +1483,8 @@ public class PhoneDialogue {
 				childrenMet += ChildMet(npc) ? 1 : 0;
 			}
 			int totalChildren = (sonsBirthed+daughtersBirthed+sonsFathered+daughtersFathered);
-			int percentageMet = totalChildren == 0 ? 100 : (100 * childrenMet / totalChildren);
+			//childrenMet is decreased every time a child is removed, therefore number of already removed children is added to get correct values
+			int percentageMet = totalChildren == 0 ? 100 : (100 * (childrenMet+Main.game.getPlayer().getChildrenRemoved()) / totalChildren);
 
 			UtilText.nodeContentSB.append(
 					"<div class='subTitle'>Total offspring: "+ totalChildren+" (Children met: "+ percentageMet +"%)</div>"


### PR DESCRIPTION
- What is the purpose of the pull request?
Shortening the offspring list under pregnancy stats by removing the children which were removed from the game after attacking them.

- Give a brief description of what you changed or added.
PlayerCharacter.java:
   Added new variable to store the number of removed children
   Added getter and increment function for new variable
   Updated save and load function to include the new variable
PhoneDialogue.java:
   Updated calculation method for percentage of already met children
Game.java:
   Added a bit of code to the function for removing NPCs, that removes the NPC, if related to the player, from NPCmap and increases the new variable by 1.

- Are any new graphical assets required?
No.

- Has this change been tested? If so, mention the version number that the test was based on.
I tested it briefly with 0.3.6.9 Alpha.