### PR TITLE
Fix using both patterns and gradients together

### DIFF
--- a/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
+++ b/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
@@ -2752,12 +2752,12 @@ public abstract class AbstractClothingType extends AbstractCoreType {
 		int defEndIndex;
 		if (defIndex > 0) {
 			// Replace defs
-			returnable = s.substring(0, defIndex) + "<defs>" + newClipMask;
 			defEndIndex = s.indexOf("</defs>");
+			returnable = s.substring(0, defEndIndex) + newClipMask;
 		} else {
 			// Insert defs
-			returnable = s.substring(0, s.indexOf('>')) + "><defs>" + newClipMask + "</defs>";
 			defEndIndex = s.indexOf('>') + 1;
+			returnable = s.substring(0, defEndIndex) + "<defs>" + newClipMask + "</defs>";
 		}
 		
 		// Loading pattern


### PR DESCRIPTION
When patterns are applied, it stomps on all existing definitions, including gradients.

Tested on my own build of the game, and also via manual inspection by dumping the svg strings to the console and looking at the differences in the results.