### PR TITLE
Fix nullpointer with strapon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target/
 
 # Ignore all generic character images
 res/images/characters/generic/
+/tail.txt

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ target/
 
 # Ignore all generic character images
 res/images/characters/generic/
-/tail.txt

--- a/src/com/lilithsthrone/game/sex/Sex.java
+++ b/src/com/lilithsthrone/game/sex/Sex.java
@@ -782,9 +782,12 @@ public class Sex {
 				for(AbstractClothing c : equippedClothing) {
 					AbstractClothing clean = new AbstractClothing(c) {};
 					clean.setDirty(null, false);
-					if(!entry.getValue().get(c.getSlotEquippedTo()).keySet().contains(c) && !entry.getValue().get(c.getSlotEquippedTo()).keySet().contains(clean)) {
+					if(entry.getValue().get(c.getSlotEquippedTo())!=null && !entry.getValue().get(c.getSlotEquippedTo()).keySet().contains(c) && !entry.getValue().get(c.getSlotEquippedTo()).keySet().contains(clean)) {
 						character.forceUnequipClothingIntoVoid(character, c);
 						character.getCell().getInventory().addClothing(c);
+					}
+					else {
+						character.unequipClothingIntoInventory(c, true, character);
 					}
 				}
 			}


### PR DESCRIPTION
- What is the purpose of the pull request?
Fix a Nullpointer exception after equipping a unique NPC with a strapon. When sex ends, looping over all equipped clothing will throw a Nullpointer because there is no entry for the item in the penis slot in the original map. (Issue #1337).

- Give a brief description of what you changed or added.
Added a check to prevent a Nullpointer when equipped clothing is in a slot that wasn't equipped before. In this case, the new equipment is put back into the inventory.

- Are any new graphical assets required?
No.

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, version 0.3.7.3

- So we have a better idea of who you are, what is your Discord Handle?
Acexp