### PR TITLE
Made Milker Room affection bonus apply to Cum Stud fetish holders

### DIFF
--- a/src/com/lilithsthrone/game/occupantManagement/SlaveJob.java
+++ b/src/com/lilithsthrone/game/occupantManagement/SlaveJob.java
@@ -264,10 +264,11 @@ public enum SlaveJob {
 			return Main.game.getOccupancyUtil().getMilkingRooms().size()*8;
 		}
 		
+		// Gives affection bonus for those with a fetish for being milked while assigned to milking room. Either Lactation or cum stud fetishes.
 		@Override
 		public float getAffectionGain(int hour, GameCharacter slave) {
 			float aff = this.affectionGain;
-			if(slave.hasFetish(Fetish.FETISH_LACTATION_SELF)) {
+			if(slave.hasFetish(Fetish.FETISH_LACTATION_SELF) || slave.hasFetish(Fetish.FETISH_CUM_STUD)) {
 				aff = 2f;
 			}
 			Cell c = this.getWorkDestinationCell(hour, slave);


### PR DESCRIPTION
Milker Room affection bonus is added for characters having lactation or cum stud fetishes. The affection increase is the same for having one or both fetishes. Making the bonus compound for double the bonus with having both seemed too exploitable, I leave any balancing of specific values to you.


- What is the purpose of the pull request?
Making the milking room's affection bonus account for male milking

- Give a brief description of what you changed or added.
Added OR CUMSTUD to the IF LACTATION THEN affection = 2

- Has this change been tested? 
Yes, tested with current /dev 0.3.7.5 using JDK 1.8-172; slave without stud fetish cycled in the milker for a day has no affection gain, shows no gain. Gave cum stud fetish, shows affection bonus, gained the same affection per hour as another slave that has lactation and lactation+cumstud.

- Discord Handle?
Eliria