### PR TITLE
Search in Watering Hole based on preferences

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/places/dominion/nightlife/NightlifeDistrict.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/nightlife/NightlifeDistrict.java
@@ -23,6 +23,7 @@ import com.lilithsthrone.game.character.npc.dominion.Kruger;
 import com.lilithsthrone.game.character.npc.misc.GenericSexualPartner;
 import com.lilithsthrone.game.character.persona.PersonalityTrait;
 import com.lilithsthrone.game.character.persona.SexualOrientation;
+import com.lilithsthrone.game.character.race.Race;
 import com.lilithsthrone.game.character.race.Subspecies;
 import com.lilithsthrone.game.dialogue.DialogueFlagValue;
 import com.lilithsthrone.game.dialogue.DialogueNode;
@@ -941,23 +942,25 @@ public class NightlifeDistrict {
 			}
 			int count = 1;
 			for(Gender gender : Gender.values()) {
-				if((responseTab==0 && gender.getType()==PronounType.FEMININE)
-						|| (responseTab==1 && gender.getType()==PronounType.MASCULINE)
-						|| (responseTab==2 && gender.getType()==PronounType.NEUTRAL)) {
-					if(count==index) {
-						return new Response(Util.capitaliseSentence(gender.getName()),
-								"Look for "+UtilText.generateSingularDeterminer(gender.getName())+" "+gender.getName()+" in amongst the crowds of revellers."
-									+ " ("+(gender.getGenderName().isHasBreasts()?"[style.colourGood(Breasts)]":"[style.colourBad(Breasts)]")+", "
-										+(gender.getGenderName().isHasPenis()?"[style.colourGood(Penis)]":"[style.colourBad(Penis)]")+", "
-										+(gender.getGenderName().isHasVagina()?"[style.colourGood(Vagina)]":"[style.colourBad(Vagina)]")+")",
-								WATERING_HOLE_SEARCH_RACE) {
-							@Override
-							public void effects() {
-								clubberGender = gender;
-							}
-						};
+				if (Main.getProperties().genderPreferencesMap.get(gender)>0) {
+					if((responseTab==0 && gender.getType()==PronounType.FEMININE)
+							|| (responseTab==1 && gender.getType()==PronounType.MASCULINE)
+							|| (responseTab==2 && gender.getType()==PronounType.NEUTRAL)) {
+						if (count == index) {
+							return new Response(Util.capitaliseSentence(gender.getName()),
+									"Look for " + UtilText.generateSingularDeterminer(gender.getName()) + " " + gender.getName() + " in amongst the crowds of revellers."
+											+ " (" + (gender.getGenderName().isHasBreasts() ? "[style.colourGood(Breasts)]" : "[style.colourBad(Breasts)]") + ", "
+											+ (gender.getGenderName().isHasPenis() ? "[style.colourGood(Penis)]" : "[style.colourBad(Penis)]") + ", "
+											+ (gender.getGenderName().isHasVagina() ? "[style.colourGood(Vagina)]" : "[style.colourBad(Vagina)]") + ")",
+									WATERING_HOLE_SEARCH_RACE) {
+								@Override
+								public void effects() {
+									clubberGender = gender;
+								}
+							};
+						}
+						count++;
 					}
-					count++;
 				}
 			}
 			
@@ -990,19 +993,24 @@ public class NightlifeDistrict {
 			}
 			if(!subspeciesSet.isEmpty()) {
 				for(Subspecies subspecies : subspeciesSet) {
-					if(count==index) {
-						return new Response(Util.capitaliseSentence(subspecies.getName(null)),
-								"Look for "+UtilText.generateSingularDeterminer(subspecies.getName(null))+" "+subspecies.getName(null)+" in amongst the crowds of revellers.",
-								(isSearchingForASub
-										?WATERING_HOLE_SEARCH_GENERATE
-										:WATERING_HOLE_SEARCH_GENERATE_DOM)) {
-							@Override
-							public void effects() {
-								clubberSubspecies = subspecies;
-								spawnClubbers(isSearchingForASub);
-							}
-						};
-					}
+                    if ((clubberGender.getType() == PronounType.MASCULINE && Main.getProperties().getSubspeciesMasculinePreferencesMap().get(subspecies).getValue() > 0 ) ||
+                        (clubberGender.getType() == PronounType.NEUTRAL && Main.getProperties().getSubspeciesFemininePreferencesMap().get(subspecies).getValue() > 0 ) ||
+                        (clubberGender.getType() == PronounType.FEMININE && Main.getProperties().getSubspeciesFemininePreferencesMap().get(subspecies).getValue() > 0 ) ||
+                        (subspecies.getRace() == Race.HUMAN) ) {
+                        if(count==index) {
+                            return new Response(Util.capitaliseSentence(subspecies.getName(null)),
+                                    "Look for "+UtilText.generateSingularDeterminer(subspecies.getName(null))+" "+subspecies.getName(null)+" in amongst the crowds of revellers.",
+                                    (isSearchingForASub
+                                            ?WATERING_HOLE_SEARCH_GENERATE
+                                            :WATERING_HOLE_SEARCH_GENERATE_DOM)) {
+                                @Override
+                                public void effects() {
+                                    clubberSubspecies = subspecies;
+                                    spawnClubbers(isSearchingForASub);
+                                }
+                            };
+                        }
+                    }
 					count++;
 				}
 			}

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/nightlife/NightlifeDistrict.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/nightlife/NightlifeDistrict.java
@@ -1010,8 +1010,8 @@ public class NightlifeDistrict {
                                 }
                             };
                         }
+						count++;
                     }
-					count++;
 				}
 			}
 			return null;


### PR DESCRIPTION
- What is the purpose of the pull request?

Searching for a partner in the Watering Hole will no longer show genders or subspecies that cannot normally be spawned (based on the gender/subspecies preferences).

- Give a brief description of what you changed or added.

Added checks to see if the GenderPreference or Subspecies(Masculine or Feminine)Preference is greater than zero. If it isn't these genders and subspecies will not be selectable anymore. Note: Humans are always selectable, since there is no SubspeciesPreference for Humans.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Tested in 0.3.8.9