### PR TITLE
Expand dye selection on test shirt, additional ignored filetypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ target/
 *.log
 *.iml
 *.jar
+desktop.ini
+nbactions.xml
 
 # Ignore all generic character images
 res/images/characters/generic/

--- a/res/clothing/innoxia/torso/tshirt_test_item.xml
+++ b/res/clothing/innoxia/torso/tshirt_test_item.xml
@@ -62,7 +62,7 @@
 		
 		<incompatibleSlots/> 
 		
-		<primaryColours values="ALL_WITH_METALS"/>
+		<primaryColours values="DEBUG_ALL"/>
 		<primaryColoursDye/>
 		<secondaryColours/>
 		<secondaryColoursDye/>

--- a/src/com/lilithsthrone/game/inventory/ColourReplacement.java
+++ b/src/com/lilithsthrone/game/inventory/ColourReplacement.java
@@ -55,7 +55,7 @@ public class ColourReplacement {
 		}
 
 		Set<Colour> colourSet = new HashSet<>();
-		this.allColours = new ArrayList<>(ColourListPresets.ALL_WITH_METALS);
+		this.allColours = new ArrayList<>(ColourListPresets.DEBUG_ALL);
 		if(defaultColours!=null) {
 			colourSet.addAll(defaultColours);
 		}

--- a/src/com/lilithsthrone/utils/colours/ColourListPresets.java
+++ b/src/com/lilithsthrone/utils/colours/ColourListPresets.java
@@ -299,14 +299,73 @@ public class ColourListPresets {
 			PresetColour.CLOTHING_PINK_HOT,
 			PresetColour.CLOTHING_PINK_DARK);
 	
-	public static ArrayList<Colour> NOT_WHITE = new ArrayList<>(ALL);
+        public static ArrayList<Colour> NOT_WHITE = new ArrayList<>(ALL);
 	
 	public static ArrayList<Colour> NOT_BLACK = new ArrayList<>(ALL);
 	
+        //Speshul debug color list with added damage and BaseColours
+        //Modders don't use this in your items rrrrreeeeee
+        public static ArrayList<Colour> DEBUG_ALL = Util.newArrayListOfValues(
+                PresetColour.BASE_WHITE,
+                PresetColour.BASE_GREY_LIGHT,
+                PresetColour.BASE_GREY,
+                PresetColour.BASE_GREY_DARK,
+                PresetColour.BASE_ROSE,
+                PresetColour.BASE_LILAC,
+                PresetColour.BASE_LILAC_LIGHT,
+                PresetColour.BASE_INDIGO,
+                PresetColour.BASE_PURPLE_DARK,
+                PresetColour.BASE_PURPLE,
+                PresetColour.BASE_PURPLE_LIGHT,
+                PresetColour.BASE_PINK_DEEP,
+                PresetColour.BASE_PINK_SALMON,
+                PresetColour.BASE_PINK,
+                PresetColour.BASE_PINK_LIGHT,
+                PresetColour.BASE_MAGENTA,
+                PresetColour.BASE_CRIMSON,
+                PresetColour.BASE_RED_DARK,
+                PresetColour.BASE_RED,
+                PresetColour.BASE_RED_LIGHT,
+                PresetColour.BASE_TAN,
+                PresetColour.BASE_BROWN,
+                PresetColour.BASE_BROWN_DARK,
+                PresetColour.BASE_COPPER,
+                PresetColour.BASE_ORANGE,
+                PresetColour.BASE_GINGER,
+                PresetColour.BASE_GOLD,
+                PresetColour.BASE_YELLOW,
+                PresetColour.BASE_YELLOW_LIGHT,
+                PresetColour.BASE_GREEN_LIME,
+                PresetColour.BASE_GREEN_LIGHT,
+                PresetColour.BASE_GREEN,
+                PresetColour.BASE_GREEN_DARK,
+                PresetColour.BASE_AQUA,
+                PresetColour.BASE_TEAL,
+                PresetColour.BASE_PERIWINKLE,
+                PresetColour.BASE_BLUE_DARK,
+                PresetColour.BASE_BLUE_LIGHT,
+                PresetColour.BASE_BLUE,
+                PresetColour.BASE_BLUE_STEEL,
+                PresetColour.BASE_BLACK,
+                PresetColour.BASE_PITCH_BLACK,
+                PresetColour.DAMAGE_TYPE_UNARMED,
+                PresetColour.DAMAGE_TYPE_MELEE,
+                PresetColour.DAMAGE_TYPE_RANGED,
+                PresetColour.DAMAGE_TYPE_PHYSICAL,
+                PresetColour.DAMAGE_TYPE_MANA,
+                PresetColour.DAMAGE_TYPE_LUST,
+                PresetColour.DAMAGE_TYPE_SPELL,
+                PresetColour.DAMAGE_TYPE_FIRE,
+                PresetColour.DAMAGE_TYPE_COLD,
+                PresetColour.DAMAGE_TYPE_POISON,
+                PresetColour.DAMAGE_TYPE_PURE
+                );
+        
 	static {
 		NOT_WHITE.remove(PresetColour.CLOTHING_WHITE);
 		NOT_BLACK.remove(PresetColour.CLOTHING_BLACK);
 		NOT_BLACK.remove(PresetColour.CLOTHING_BLACK_JET);
+                DEBUG_ALL.addAll(ALL_WITH_METALS);
 	}
 
 	private static Map<String, ArrayList<Colour>> idToColourListMap = new HashMap<>();


### PR DESCRIPTION
**- What is the purpose of the pull request?**
Expand the available dye selection on the debug shirt
Add NetBeans and Windows generated filetypes
**- Give a brief description of what you changed or added.**
Added 2 new entries to .gitignore
Added BaseColour and damage colors to a new color ArrayList, changed the starting ArrayList for dyes to this new list
Only the debug shirt should ever use this
**- Has this change been tested? If so, mention the version number that the test was based on.**
Tested on 0.3.9
**- So we have a better idea of who you are, what is your Discord Handle?**
dsg#4931
