### PR TITLE
Check all arms for 2-h weapons

### DIFF
--- a/src/com/lilithsthrone/game/combat/moves/CombatMove.java
+++ b/src/com/lilithsthrone/game/combat/moves/CombatMove.java
@@ -714,9 +714,10 @@ public class CombatMove {
         		}
         		for(int i=0; i<Math.min(source.getArmRows(), source.getOffhandWeaponArray().length); i++) {
             		AbstractWeapon weapon = source.getOffhandWeaponArray()[i];
+					AbstractWeapon primaryWeapon = source.getMainWeaponArray()[i];
         			if(weapon!=null) {
         				damages.add(getFormattedDamageRange(source, target, weapon.getDamageType(), Attack.OFFHAND, weapon, isCrit));
-        			} else {
+        			} else if(!primaryWeapon.getWeaponType().isTwoHanded()) {
         				damages.add(getFormattedDamageRange(source, target, DamageType.UNARMED.getParentDamageType(source, null), Attack.OFFHAND, null, isCrit));
         			}
         		}
@@ -735,9 +736,10 @@ public class CombatMove {
         		}
         		for(int i=0; i<Math.min(source.getArmRows(), source.getOffhandWeaponArray().length); i++) {
             		AbstractWeapon weapon = source.getOffhandWeaponArray()[i];
+					AbstractWeapon primaryWeapon = source.getMainWeaponArray()[i];
         			if(weapon!=null) {
         				damages.add(getFormattedDamage(weapon.getDamageType(), weapon.getWeaponType().getDamage(), target, damageHasBeenApplied, isTargetAtMaximumLust(target)));
-        			} else {
+        			} else if(!primaryWeapon.getWeaponType().isTwoHanded()) {
         				damages.add(getFormattedDamage(DamageType.UNARMED.getParentDamageType(source, null), source.getUnarmedDamage(), target, damageHasBeenApplied, isTargetAtMaximumLust(target)));
         			}
         		}
@@ -831,6 +833,7 @@ public class CombatMove {
 
         		for(int i=0; i<Math.min(source.getArmRows(), source.getOffhandWeaponArray().length); i++) {
         			AbstractWeapon weapon = source.getOffhandWeaponArray()[i];
+					AbstractWeapon primaryWeapon = source.getMainWeaponArray()[i];
         			if(weapon!=null) {
         				int damage = Attack.calculateDamage(source, target, Attack.OFFHAND, weapon, isCrit);
         				boolean maxLust = isTargetAtMaximumLust(target);
@@ -858,7 +861,7 @@ public class CombatMove {
         					}
         				}
                 		
-        			} else {
+        			} else if(!primaryWeapon.getWeaponType().isTwoHanded()) {
         				int damage = Attack.calculateDamage(source, target, Attack.OFFHAND, null, isCrit);
         				boolean maxLust = isTargetAtMaximumLust(target);
         				Value<String, Integer> damageValue = DamageType.UNARMED.getParentDamageType(source, null).damageTarget(source, target, damage);
@@ -929,14 +932,21 @@ public class CombatMove {
             
             @Override
             public String isUsable(GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies) {
-            	if(source.getArmRows()==1) {
-	            	if(source.getMainWeapon(0)!=null && source.getMainWeapon(0).getWeaponType().isTwoHanded()) {
-	            		return "You are using a two-handed weapon, so have no free hand with which to use an all-out strike!";
-	            	}
-	            	if(source.getOffhandWeapon(0)!=null && source.getOffhandWeapon(0).getWeaponType().isTwoHanded()) {
-	            		return "You are using a two-handed weapon, so have no free hand with which to use an all-out strike!";
+        		int freeSlots = source.getArmRows();
+        		for (int i=0; i<source.getArmRows(); i++) {
+            	   	if(source.getMainWeapon(i)!=null && source.getMainWeapon(i).getWeaponType().isTwoHanded() ||
+	            	  (source.getOffhandWeapon(i)!=null && source.getOffhandWeapon(i).getWeaponType().isTwoHanded())) {
+            	   		freeSlots--;
 	            	}
             	}
+        		if (freeSlots==0){
+        			if (source.getArmRows()> 1) {
+						return "You are using only two-handed weapons, so have no free hand with which to use an all-out strike!";
+					}
+        			else {
+						return "You are using a two-handed weapon, so have no free hand with which to use an all-out strike!";
+					}
+				}
         		int cost = getArcaneCost(source);
             	if(source.getEssenceCount()<cost) {
             		return "You don't have enough arcane essences to use your weapon! ("+Util.capitaliseSentence(Util.intToString(cost))+" "+(cost==1?"is":"are")+" required.)";


### PR DESCRIPTION
- What is the purpose of the pull request?

Fix a bug where having multiple arm pairs allows an all-out strike with a 2-handed weapon

- Give a brief description of what you changed or added.

Check all arm pairs for 2-handed weapons. Only if at least one pair is not using 2-h weapons is an all-out strike allowed. Also check if the main weapon is 2-handed, if so, do not apply any damage in the off-hand attack.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested in version 3.9.1 with various weapon combinations and arm pairs.

- So we have a better idea of who you are, what is your Discord Handle?

AceXp#0930
