### PR TITLE
No enchanting in trade

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/places/dominion/nightlife/NightlifeDistrict.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/nightlife/NightlifeDistrict.java
@@ -23,6 +23,7 @@ import com.lilithsthrone.game.character.npc.dominion.Kruger;
 import com.lilithsthrone.game.character.npc.misc.GenericSexualPartner;
 import com.lilithsthrone.game.character.persona.PersonalityTrait;
 import com.lilithsthrone.game.character.persona.SexualOrientation;
+import com.lilithsthrone.game.character.race.Race;
 import com.lilithsthrone.game.character.race.Subspecies;
 import com.lilithsthrone.game.dialogue.DialogueFlagValue;
 import com.lilithsthrone.game.dialogue.DialogueNode;
@@ -941,23 +942,25 @@ public class NightlifeDistrict {
 			}
 			int count = 1;
 			for(Gender gender : Gender.values()) {
-				if((responseTab==0 && gender.getType()==PronounType.FEMININE)
-						|| (responseTab==1 && gender.getType()==PronounType.MASCULINE)
-						|| (responseTab==2 && gender.getType()==PronounType.NEUTRAL)) {
-					if(count==index) {
-						return new Response(Util.capitaliseSentence(gender.getName()),
-								"Look for "+UtilText.generateSingularDeterminer(gender.getName())+" "+gender.getName()+" in amongst the crowds of revellers."
-									+ " ("+(gender.getGenderName().isHasBreasts()?"[style.colourGood(Breasts)]":"[style.colourBad(Breasts)]")+", "
-										+(gender.getGenderName().isHasPenis()?"[style.colourGood(Penis)]":"[style.colourBad(Penis)]")+", "
-										+(gender.getGenderName().isHasVagina()?"[style.colourGood(Vagina)]":"[style.colourBad(Vagina)]")+")",
-								WATERING_HOLE_SEARCH_RACE) {
-							@Override
-							public void effects() {
-								clubberGender = gender;
-							}
-						};
+				if (Main.getProperties().genderPreferencesMap.get(gender)>0) {
+					if((responseTab==0 && gender.getType()==PronounType.FEMININE)
+							|| (responseTab==1 && gender.getType()==PronounType.MASCULINE)
+							|| (responseTab==2 && gender.getType()==PronounType.NEUTRAL)) {
+						if (count == index) {
+							return new Response(Util.capitaliseSentence(gender.getName()),
+									"Look for " + UtilText.generateSingularDeterminer(gender.getName()) + " " + gender.getName() + " in amongst the crowds of revellers."
+											+ " (" + (gender.getGenderName().isHasBreasts() ? "[style.colourGood(Breasts)]" : "[style.colourBad(Breasts)]") + ", "
+											+ (gender.getGenderName().isHasPenis() ? "[style.colourGood(Penis)]" : "[style.colourBad(Penis)]") + ", "
+											+ (gender.getGenderName().isHasVagina() ? "[style.colourGood(Vagina)]" : "[style.colourBad(Vagina)]") + ")",
+									WATERING_HOLE_SEARCH_RACE) {
+								@Override
+								public void effects() {
+									clubberGender = gender;
+								}
+							};
+						}
+						count++;
 					}
-					count++;
 				}
 			}
 			
@@ -990,19 +993,24 @@ public class NightlifeDistrict {
 			}
 			if(!subspeciesSet.isEmpty()) {
 				for(Subspecies subspecies : subspeciesSet) {
-					if(count==index) {
-						return new Response(Util.capitaliseSentence(subspecies.getName(null)),
-								"Look for "+UtilText.generateSingularDeterminer(subspecies.getName(null))+" "+subspecies.getName(null)+" in amongst the crowds of revellers.",
-								(isSearchingForASub
-										?WATERING_HOLE_SEARCH_GENERATE
-										:WATERING_HOLE_SEARCH_GENERATE_DOM)) {
-							@Override
-							public void effects() {
-								clubberSubspecies = subspecies;
-								spawnClubbers(isSearchingForASub);
-							}
-						};
-					}
+                    if ((clubberGender.getType() == PronounType.MASCULINE && Main.getProperties().getSubspeciesMasculinePreferencesMap().get(subspecies).getValue() > 0 ) ||
+                        (clubberGender.getType() == PronounType.NEUTRAL && Main.getProperties().getSubspeciesFemininePreferencesMap().get(subspecies).getValue() > 0 ) ||
+                        (clubberGender.getType() == PronounType.FEMININE && Main.getProperties().getSubspeciesFemininePreferencesMap().get(subspecies).getValue() > 0 ) ||
+                        (subspecies.getRace() == Race.HUMAN) ) {
+                        if(count==index) {
+                            return new Response(Util.capitaliseSentence(subspecies.getName(null)),
+                                    "Look for "+UtilText.generateSingularDeterminer(subspecies.getName(null))+" "+subspecies.getName(null)+" in amongst the crowds of revellers.",
+                                    (isSearchingForASub
+                                            ?WATERING_HOLE_SEARCH_GENERATE
+                                            :WATERING_HOLE_SEARCH_GENERATE_DOM)) {
+                                @Override
+                                public void effects() {
+                                    clubberSubspecies = subspecies;
+                                    spawnClubbers(isSearchingForASub);
+                                }
+                            };
+                        }
+                    }
 					count++;
 				}
 			}

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/nightlife/NightlifeDistrict.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/nightlife/NightlifeDistrict.java
@@ -23,7 +23,6 @@ import com.lilithsthrone.game.character.npc.dominion.Kruger;
 import com.lilithsthrone.game.character.npc.misc.GenericSexualPartner;
 import com.lilithsthrone.game.character.persona.PersonalityTrait;
 import com.lilithsthrone.game.character.persona.SexualOrientation;
-import com.lilithsthrone.game.character.race.Race;
 import com.lilithsthrone.game.character.race.Subspecies;
 import com.lilithsthrone.game.dialogue.DialogueFlagValue;
 import com.lilithsthrone.game.dialogue.DialogueNode;
@@ -942,25 +941,23 @@ public class NightlifeDistrict {
 			}
 			int count = 1;
 			for(Gender gender : Gender.values()) {
-				if (Main.getProperties().genderPreferencesMap.get(gender)>0) {
-					if((responseTab==0 && gender.getType()==PronounType.FEMININE)
-							|| (responseTab==1 && gender.getType()==PronounType.MASCULINE)
-							|| (responseTab==2 && gender.getType()==PronounType.NEUTRAL)) {
-						if (count == index) {
-							return new Response(Util.capitaliseSentence(gender.getName()),
-									"Look for " + UtilText.generateSingularDeterminer(gender.getName()) + " " + gender.getName() + " in amongst the crowds of revellers."
-											+ " (" + (gender.getGenderName().isHasBreasts() ? "[style.colourGood(Breasts)]" : "[style.colourBad(Breasts)]") + ", "
-											+ (gender.getGenderName().isHasPenis() ? "[style.colourGood(Penis)]" : "[style.colourBad(Penis)]") + ", "
-											+ (gender.getGenderName().isHasVagina() ? "[style.colourGood(Vagina)]" : "[style.colourBad(Vagina)]") + ")",
-									WATERING_HOLE_SEARCH_RACE) {
-								@Override
-								public void effects() {
-									clubberGender = gender;
-								}
-							};
-						}
-						count++;
+				if((responseTab==0 && gender.getType()==PronounType.FEMININE)
+						|| (responseTab==1 && gender.getType()==PronounType.MASCULINE)
+						|| (responseTab==2 && gender.getType()==PronounType.NEUTRAL)) {
+					if(count==index) {
+						return new Response(Util.capitaliseSentence(gender.getName()),
+								"Look for "+UtilText.generateSingularDeterminer(gender.getName())+" "+gender.getName()+" in amongst the crowds of revellers."
+									+ " ("+(gender.getGenderName().isHasBreasts()?"[style.colourGood(Breasts)]":"[style.colourBad(Breasts)]")+", "
+										+(gender.getGenderName().isHasPenis()?"[style.colourGood(Penis)]":"[style.colourBad(Penis)]")+", "
+										+(gender.getGenderName().isHasVagina()?"[style.colourGood(Vagina)]":"[style.colourBad(Vagina)]")+")",
+								WATERING_HOLE_SEARCH_RACE) {
+							@Override
+							public void effects() {
+								clubberGender = gender;
+							}
+						};
 					}
+					count++;
 				}
 			}
 			
@@ -993,25 +990,20 @@ public class NightlifeDistrict {
 			}
 			if(!subspeciesSet.isEmpty()) {
 				for(Subspecies subspecies : subspeciesSet) {
-                    if ((clubberGender.getType() == PronounType.MASCULINE && Main.getProperties().getSubspeciesMasculinePreferencesMap().get(subspecies).getValue() > 0 ) ||
-                        (clubberGender.getType() == PronounType.NEUTRAL && Main.getProperties().getSubspeciesFemininePreferencesMap().get(subspecies).getValue() > 0 ) ||
-                        (clubberGender.getType() == PronounType.FEMININE && Main.getProperties().getSubspeciesFemininePreferencesMap().get(subspecies).getValue() > 0 ) ||
-                        (subspecies.getRace() == Race.HUMAN) ) {
-                        if(count==index) {
-                            return new Response(Util.capitaliseSentence(subspecies.getName(null)),
-                                    "Look for "+UtilText.generateSingularDeterminer(subspecies.getName(null))+" "+subspecies.getName(null)+" in amongst the crowds of revellers.",
-                                    (isSearchingForASub
-                                            ?WATERING_HOLE_SEARCH_GENERATE
-                                            :WATERING_HOLE_SEARCH_GENERATE_DOM)) {
-                                @Override
-                                public void effects() {
-                                    clubberSubspecies = subspecies;
-                                    spawnClubbers(isSearchingForASub);
-                                }
-                            };
-                        }
-						count++;
-                    }
+					if(count==index) {
+						return new Response(Util.capitaliseSentence(subspecies.getName(null)),
+								"Look for "+UtilText.generateSingularDeterminer(subspecies.getName(null))+" "+subspecies.getName(null)+" in amongst the crowds of revellers.",
+								(isSearchingForASub
+										?WATERING_HOLE_SEARCH_GENERATE
+										:WATERING_HOLE_SEARCH_GENERATE_DOM)) {
+							@Override
+							public void effects() {
+								clubberSubspecies = subspecies;
+								spawnClubbers(isSearchingForASub);
+							}
+						};
+					}
+					count++;
 				}
 			}
 			return null;

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/nightlife/NightlifeDistrict.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/nightlife/NightlifeDistrict.java
@@ -1010,8 +1010,8 @@ public class NightlifeDistrict {
                                 }
                             };
                         }
+						count++;
                     }
-					count++;
 				}
 			}
 			return null;

--- a/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
@@ -3025,7 +3025,7 @@ public class InventoryDialogue {
 								}
 								
 							} else if(index == 5) {
-								return new Response("Enchant", "You can't enchant items while trading with someone!", null);
+								return new Response("Enchant", "You can't enchant weapons while trading with someone!", null);
 
 							} else if(index == 6) {
 								return new Response("Equip Main (Self)", "Equip the " + weapon.getName() + " as your main weapon.", INVENTORY_MENU){
@@ -4362,7 +4362,7 @@ public class InventoryDialogue {
 															+ " or go to a vendor and pay "+IDENTIFICATION_PRICE+" flames to have them do it for you.", null);
 										}
 									}
-									return new Response("Enchant", "You can't enchant items while trading with someone!", null);
+									return new Response("Enchant", "You can't enchant clothing while trading with someone!", null);
 									
 								} else {
 									return new Response("Enchant", "You have not discovered how to enchant clothing yet...", null);

--- a/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
@@ -1721,22 +1721,8 @@ public class InventoryDialogue {
 								}
 								
 							} else if(index == 5) {
-								if(item.getEnchantmentItemType(null)==null) {
-									return new Response("Enchant", "This item cannot be enchanted!", null);
-									
-								} else if(Main.game.isDebugMode()
-										|| (Main.game.getPlayer().hasQuest(QuestLine.SIDE_ENCHANTMENT_DISCOVERY) && Main.game.getPlayer().isQuestCompleted(QuestLine.SIDE_ENCHANTMENT_DISCOVERY))) {
-									return new Response("Enchant", "Enchant this item.", EnchantmentDialogue.ENCHANTMENT_MENU) {
-										@Override
-										public DialogueNode getNextDialogue() {
-											return EnchantmentDialogue.getEnchantmentMenu(item);
-										}
-									};
-									
-								} else {
-									return new Response("Enchant", "You have not discovered how to enchant items yet...", null);
-								}
-								
+								return new Response("Enchant", "You can't enchant items while trading with someone!", null);
+
 							} else if(index == 6) {
 								if (!item.isAbleToBeUsedFromInventory()) {
 									return new Response(Util.capitaliseSentence(item.getItemType().getUseName())+" (Self)", item.getUnableToBeUsedFromInventoryDescription(), null);
@@ -3039,22 +3025,8 @@ public class InventoryDialogue {
 								}
 								
 							} else if(index == 5) {
-								if(weapon.getEnchantmentItemType(null)==null) {
-									return new Response("Enchant", "This weapon cannot be enchanted!", null);
-									
-								} else if(Main.game.isDebugMode()
-										|| (Main.game.getPlayer().hasQuest(QuestLine.SIDE_ENCHANTMENT_DISCOVERY) && Main.game.getPlayer().isQuestCompleted(QuestLine.SIDE_ENCHANTMENT_DISCOVERY))) {
-									return new Response("Enchant", "Enchant this weapon.", EnchantmentDialogue.ENCHANTMENT_MENU) {
-										@Override
-										public DialogueNode getNextDialogue() {
-											return EnchantmentDialogue.getEnchantmentMenu(weapon);
-										}
-									};
-									
-								} else {
-									return new Response("Enchant", "You have not discovered how to enchant weapons yet...", null);
-								}
-								
+								return new Response("Enchant", "You can't enchant items while trading with someone!", null);
+
 							} else if(index == 6) {
 								return new Response("Equip Main (Self)", "Equip the " + weapon.getName() + " as your main weapon.", INVENTORY_MENU){
 									@Override
@@ -4390,12 +4362,7 @@ public class InventoryDialogue {
 															+ " or go to a vendor and pay "+IDENTIFICATION_PRICE+" flames to have them do it for you.", null);
 										}
 									}
-									return new Response("Enchant", "Enchant this clothing.", EnchantmentDialogue.ENCHANTMENT_MENU) {
-										@Override
-										public DialogueNode getNextDialogue() {
-											return EnchantmentDialogue.getEnchantmentMenu(clothing);
-										}
-									};
+									return new Response("Enchant", "You can't enchant items while trading with someone!", null);
 									
 								} else {
 									return new Response("Enchant", "You have not discovered how to enchant clothing yet...", null);


### PR DESCRIPTION
What is the purpose of the pull request?

Fix the issue where returning from the Enchantment dialogue gives you control over the shopkeepers inventory (#1369)

Give a brief description of what you changed or added.

Disallow enchanting items while trading

Are any new graphical assets required?

No

Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested in 0.3.8.9

@Innoxia Made a new PR for this
