### PR TITLE
Use correct cutoff point for arcane impotence

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -5542,7 +5542,7 @@ public abstract class GameCharacter implements XMLSaving {
 		}
  		// Special case for mana:
 		if (attribute == Attribute.MANA_MAXIMUM) {
-			if(getAttributeValue(Attribute.MAJOR_ARCANE) < 15) {
+			if(getAttributeValue(Attribute.MAJOR_ARCANE) < 10) {
 				value = 5;
 			} else {
 				value = 5 + 2*getLevel() + 5*getAttributeValue(Attribute.MAJOR_ARCANE);


### PR DESCRIPTION
- What is the purpose of the pull request?

Arcane impotence should apply when arcane is lower than 10, but it is applied when arcane is lower than 15

- Give a brief description of what you changed or added.

Change the cutoff value to 10

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested in version 0.3.9.2

- So we have a better idea of who you are, what is your Discord Handle?

AceXp#0930

Closes #1374 