### PR TITLE
Add new option for sex action bypass

### DIFF
--- a/src/com/lilithsthrone/controller/MainControllerInitMethod.java
+++ b/src/com/lilithsthrone/controller/MainControllerInitMethod.java
@@ -6179,6 +6179,14 @@ public class MainControllerInitMethod {
 					setAutosavePreference(id, i);
 				}
 			}
+
+			// bypass sex action options:
+			for(int i=0; i<3; i++) {
+				id = "BYPASS_SEX_ACTIONS_"+i;
+				if (((EventTarget) MainController.document.getElementById(id)) != null) {
+					setBypassSexActionsPreference(id, i);
+				}
+			}
 			
 			Map<String, PropertyValue> settingsMap = Util.newHashMapOfValues(
 					new Value<>("ENCHANTMENT_LIMITS", PropertyValue.enchantmentLimits),
@@ -6218,7 +6226,6 @@ public class MainControllerInitMethod {
 					new Value<>("INFLATION_CONTENT", PropertyValue.inflationContent),
 					new Value<>("SPITTING_ENABLED", PropertyValue.spittingEnabled),
 					new Value<>("OPPORTUNISTIC_ATTACKERS", PropertyValue.opportunisticAttackers),
-					new Value<>("BYPASS_SEX_ACTIONS", PropertyValue.bypassSexActions),
 					new Value<>("SHARED_ENCYCLOPEDIA", PropertyValue.sharedEncyclopedia)
 					);
 			
@@ -7097,7 +7104,19 @@ public class MainControllerInitMethod {
 		TooltipInformationEventListener el = new TooltipInformationEventListener().setInformation(Properties.autoSaveLabels[i], Properties.autoSaveDescriptions[i]);
 		MainController.addEventListener(MainController.document, id, "mouseenter", el, false);
 	}
-	
+
+	static void setBypassSexActionsPreference(String id, int i) {
+		((EventTarget) MainController.document.getElementById(id)).addEventListener("click", e -> {
+			Main.getProperties().bypassSexActions=i;
+			Main.saveProperties();
+			Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
+		}, false);
+
+		MainController.addEventListener(MainController.document, id, "mousemove", MainController.moveTooltipListener, false);
+		MainController.addEventListener(MainController.document, id, "mouseleave", MainController.hideTooltipListener, false);
+		TooltipInformationEventListener el = new TooltipInformationEventListener().setInformation(Properties.bypassSexActionsLabels[i], Properties.getBypassSexActionsDescriptions[i]);
+		MainController.addEventListener(MainController.document, id, "mouseenter", el, false);
+	}
 	
 	
 	private static void fluidHandler(MilkingRoom room, FluidStored fluid) {

--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -2338,16 +2338,15 @@ public class Game implements XMLSaving {
 		
 		if (response != null) {
 			String corruptionGains = "";
+			if(response.isActionCorrupting() && !response.isAvailableFromFetishes()) {
+				Main.game.getPlayer().incrementAttribute(Attribute.MAJOR_CORRUPTION, response.getCorruptionNeeded().getCorruptionBypass());
+				corruptionGains = ("<p style='text-align:center;'>"
+						+ "<b>You have gained +"+response.getCorruptionNeeded().getCorruptionBypass()+"</b> <b style='color:"+Attribute.MAJOR_CORRUPTION.getColour().toWebHexString()+";'>corruption</b><b>!</b>"
+						+ "</p>");
+			};
 
-			if(!response.isAvailable()) {
-				if(!response.isAbleToBypass()) {
-					return;
-				} else {
-					Main.game.getPlayer().incrementAttribute(Attribute.MAJOR_CORRUPTION, response.getCorruptionNeeded().getCorruptionBypass());
-					corruptionGains = ("<p style='text-align:center;'>"
-							+ "<b>You have gained +"+response.getCorruptionNeeded().getCorruptionBypass()+"</b> <b style='color:"+Attribute.MAJOR_CORRUPTION.getColour().toWebHexString()+";'>corruption</b><b>!</b>"
-							+ "</p>");
-				}
+			if(!response.isAvailable() && !response.isAbleToBypass()) {
+				return;
 			}
 			
 			String chosenResponse = response.getTitle();

--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -2338,7 +2338,7 @@ public class Game implements XMLSaving {
 		
 		if (response != null) {
 			String corruptionGains = "";
-			
+
 			if(!response.isAvailable()) {
 				if(!response.isAbleToBypass()) {
 					return;
@@ -3108,7 +3108,7 @@ public class Game implements XMLSaving {
 		if(response.disabledOnNullDialogue() && response.getNextDialogue()==null) {
 			responseDisabled = true;
 			
-		} else if (response.isAbleToBypass()) {
+		} else if (response.isActionCorrupting()) {
 			iconLeftBottom = "<div class='response-icon-leftBottom'>"+SVGImages.SVG_IMAGE_PROVIDER.getResponseCorruptionBypass()+"</div>";
 		}
 		else if(response.hasRequirements()) {
@@ -4465,8 +4465,8 @@ public class Game implements XMLSaving {
 		return Main.getProperties().hasValue(PropertyValue.opportunisticAttackers);
 	}
 	
-	public boolean isBypassSexActions() {
-		return Main.getProperties().hasValue(PropertyValue.bypassSexActions);
+	public boolean isBypassSexActionsEnabled() {
+		return Main.getProperties().bypassSexActions!=0;
 	}
 	
 	public boolean isBraxMainQuestComplete() {

--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -114,6 +114,13 @@ public class Properties {
 			"The game will autosave every time you transition to a new map.",
 			"The game will autosave when you transition to a new map, at a maximum rate of once per in-game day.",
 			"The game will autosave when you transition to a new map, at a maximum rate of once per in-game week."};
+
+	public int bypassSexActions = 2;
+	public static String[] bypassSexActionsLabels = new String[] {"None", "Limited", "Full"};
+	public static String[] getBypassSexActionsDescriptions = new String[] {
+			"There will be no options to bypass sex action corruption requirements, you are limited in your actions based on your corruption and fetishes.",
+			"Sex action corruption requirements may be bypassed if your corruption level is one level below the required corruption level of the action, but you will gain corruption if you do so.",
+			"All sex action corruption requirements may be bypassed, but you will gain corruption if you do so."};
 	
 	public int forcedTFPercentage = 40;
 	public int forcedFetishPercentage = 0;
@@ -300,6 +307,7 @@ public class Properties {
 			createXMLElementWithValue(doc, settings, "multiBreasts", String.valueOf(multiBreasts));
 			createXMLElementWithValue(doc, settings, "udders", String.valueOf(udders));
 			createXMLElementWithValue(doc, settings, "autoSaveFrequency", String.valueOf(autoSaveFrequency));
+			createXMLElementWithValue(doc, settings, "bypassSexActions", String.valueOf(bypassSexActions));
 			createXMLElementWithValue(doc, settings, "forcedTFPercentage", String.valueOf(forcedTFPercentage));
 			createXMLElementWithValue(doc, settings, "randomRacePercentage", String.valueOf(randomRacePercentage)); 
 
@@ -792,13 +800,19 @@ public class Properties {
 				} else {
 					udders = 1;
 				}
-				
+
 				if(element.getElementsByTagName("autoSaveFrequency").item(0)!=null) {
 					autoSaveFrequency = Integer.valueOf(((Element)element.getElementsByTagName("autoSaveFrequency").item(0)).getAttribute("value"));
 				} else {
 					autoSaveFrequency = 0;
 				}
-				
+
+				if(element.getElementsByTagName("bypassSexActions").item(0)!=null) {
+					bypassSexActions = Integer.valueOf(((Element)element.getElementsByTagName("bypassSexActions").item(0)).getAttribute("value"));
+				} else {
+					bypassSexActions = 2;
+				}
+
 				if(element.getElementsByTagName("forcedTFPercentage").item(0)!=null) {
 					forcedTFPercentage = Integer.valueOf(((Element)element.getElementsByTagName("forcedTFPercentage").item(0)).getAttribute("value"));
 				}
@@ -1150,6 +1164,7 @@ public class Properties {
 	
 	public void resetContentOptions() {
 		autoSaveFrequency = 0;
+		bypassSexActions = 2;
 		multiBreasts = 1;
 		udders = 1;
 		forcedTFPercentage = 40;

--- a/src/com/lilithsthrone/game/PropertyValue.java
+++ b/src/com/lilithsthrone/game/PropertyValue.java
@@ -72,7 +72,6 @@ public enum PropertyValue {
 
 	spittingEnabled(true),
 	opportunisticAttackers(false),
-	bypassSexActions(true),
 
 	levelUpHightlight(false),
 	sharedEncyclopedia(false),

--- a/src/com/lilithsthrone/game/dialogue/responses/Response.java
+++ b/src/com/lilithsthrone/game/dialogue/responses/Response.java
@@ -273,7 +273,7 @@ public class Response {
 		if(!hasRequirements()) {
 			return true;
 		}
-		if(sexActionType!=null && !Main.game.isBypassSexActions() && !isCorruptionWithinRange() && !isAvailableFromFetishes()) {
+		if(sexActionType!=null && !Main.game.isBypassSexActionsEnabled() && !isCorruptionWithinRange() && !isAvailableFromFetishes()) {
 			return false;
 		}
 		
@@ -301,7 +301,7 @@ public class Response {
 	 */
 	public boolean isAbleToBypass(){
 		if(!isAvailable()
-				&& (!Main.game.isInSex() || Main.game.isBypassSexActions())
+				&& (!Main.game.isInSex() || Main.game.isBypassSexActionsEnabled())
 				&& !isBlockedFromPerks()
 				&& isFemininityInRange()
 				&& isRequiredRace()
@@ -310,7 +310,9 @@ public class Response {
 			if(!Main.game.isInSex() && corruptionBypass==null) { // Do not allow bypass out of sex if there is no corruption bypassing
 				return false;
 			}
-			return !isCorruptionWithinRange();
+			return ((Main.getProperties().bypassSexActions==2 && !isCorruptionWithinRange()) ||
+					(Main.getProperties().bypassSexActions==1 && Main.game.isInSex() && isCorruptionWithinRange() && isActionCorrupting()) ||
+					(Main.getProperties().bypassSexActions<=1 && !Main.game.isInSex()));
 		}
 		
 		return false;
@@ -321,7 +323,7 @@ public class Response {
 		SB = new StringBuilder();
 		
 		if(!isAvailable() && !isAbleToBypass()) {
-			if(!Main.game.isBypassSexActions() && !isCorruptionWithinRange()) {
+			if(!Main.game.isBypassSexActionsEnabled() && !isCorruptionWithinRange()) {
 				SB.append("This action is blocked as [style.colourTerrible(you are not corrupt enough)] to think of performing it.");
 				
 			} else {
@@ -335,7 +337,7 @@ public class Response {
 			}
 			
 			if(corruptionBypass != null) {
-				if(isCorruptionWithinRange()) {
+				if(!isActionCorrupting()) {
 					SB.append("Your <span style='color:"+Main.game.getPlayer().getCorruptionLevel().getColour().toWebHexString()+";'>"+Util.capitaliseSentence(Main.game.getPlayer().getCorruptionLevel().getName())+"</span>"
 							+ " [style.colourCorruption(corruption)] has unlocked this action!");
 				} else {
@@ -588,12 +590,14 @@ public class Response {
 			if(isCorruptionWithinRange()) {
 				SB.append("<br/>"
 						+"[style.colourCorruption(Associated Corruption)]"
-						+ " ([style.colourMinorGood(within range)]): "
+						+ (!isActionCorrupting()
+							?" ([style.colourMinorGood(within range)]): "
+							:" ([style.colourMinorBad(just out of range)]): ")
 						+ Util.capitaliseSentence(corruptionBypass.getName()));
 			} else {
 				SB.append("<br/>"
 						+"[style.colourCorruption(Associated Corruption)]"
-						+ (!Main.game.isBypassSexActions()
+						+ (!Main.game.isBypassSexActionsEnabled()
 								?" ([style.colourTerrible(out of range)]): "
 								:" ([style.colourMinorBad(out of range)]): ")
 						+ Util.capitaliseSentence(corruptionBypass.getName()));
@@ -640,7 +644,16 @@ public class Response {
 	}
 
 	public boolean isCorruptionWithinRange() {
-		return corruptionBypass!=null && corruptionBypass.getMinimumValue() <= Main.game.getPlayer().getAttributeValue(Attribute.MAJOR_CORRUPTION);
+		if (Main.getProperties().bypassSexActions==1) {
+			return corruptionBypass!=null && Main.game.getPlayer().getCorruptionLevel().isAbleToPerformCorruptiveAction(corruptionBypass);
+		}
+		else {
+			return corruptionBypass!=null && corruptionBypass.getMinimumValue() <= Main.game.getPlayer().getAttributeValue(Attribute.MAJOR_CORRUPTION);
+		}
+	}
+
+	public boolean isActionCorrupting() {
+		return corruptionBypass!=null && corruptionBypass.getMinimumValue() > Main.game.getPlayer().getAttributeValue(Attribute.MAJOR_CORRUPTION);
 	}
 	
 	public boolean isAvailableFromFetishes() {

--- a/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
@@ -2064,13 +2064,18 @@ public class OptionsDialogue {
 							"This makes random attacks more likely when you're high on lust, low on health, covered in fluids, exposed, or drunk.",
 							Main.game.isOpportunisticAttackersEnabled()));
 			
-			UtilText.nodeContentSB.append(getContentPreferenceDiv(ContentOptionsPage.GAMEPLAY,
-							"BYPASS_SEX_ACTIONS",
-							PresetColour.BASE_PINK,
-							"Sex action bypass",
-							"If disabled, action requirements during sex may no longer be bypassed. (i.e. All 'Corruptive' actions will be unavailable.)",
-							Main.getProperties().hasValue(PropertyValue.bypassSexActions)));
-			
+			if(contentOptionsPage==ContentOptionsPage.GAMEPLAY) {
+				UtilText.nodeContentSB.append(getCustomContentPreferenceDivStart(PresetColour.BASE_PINK, "Sex action bypass", "If this is enabled, sex action corruption requirements may be bypassed."));
+				for (int i=2; i>=0; i--) {
+					UtilText.nodeContentSB.append("<div id='BYPASS_SEX_ACTIONS_" + i + "' class='normal-button" + (Main.getProperties().bypassSexActions == i ? " selected" : "") + "' style='width:calc(33% - 8px); margin-right:8px; text-align:center; float:right;'>"
+							+ (Main.getProperties().bypassSexActions == i
+							? "[style.boldGood("
+							: "[style.colourDisabled(")
+							+ com.lilithsthrone.game.Properties.bypassSexActionsLabels[i] + ")]</div>");
+				}
+				UtilText.nodeContentSB.append("</div></div>");
+			}
+
 			UtilText.nodeContentSB.append(getContentPreferenceDiv(ContentOptionsPage.SEX,
 							"VOLUNTARY_NTR",
 							PresetColour.GENERIC_MINOR_BAD,

--- a/src/com/lilithsthrone/game/sex/sexActions/SexActionInterface.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/SexActionInterface.java
@@ -1244,7 +1244,7 @@ public interface SexActionInterface {
 				}
 				@Override
 				public boolean isAbleToBypass() {
-					if(!Main.game.isBypassSexActions()) {
+					if(!Main.game.isBypassSexActionsEnabled()) {
 						return false;
 					}
 					return super.isAbleToBypass();


### PR DESCRIPTION
- What is the purpose of the pull request?

Add a new option for the bypass sex action content setting.

- Give a brief description of what you changed or added.

Remove the boolean value, and add a property. There are three possible values: None, Limited and Full:

None: There will be no options to bypass sex action corruption requirements, you are limited in your actions based on your corruption and fetishes. This is the same as the old OFF

Limited: Sex action corruption requirements may be bypassed if your corruption level is one level below the required corruption level of the action, but you will gain corruption if you do so.

Full: All sex action corruption requirements may be bypassed, but you will gain corruption if you do so. This is the same as the old ON.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested in version 0.3.9.2

- So we have a better idea of who you are, what is your Discord Handle?

AceXp#0930

@CognitiveMist Any chance that you take a look at these changes? I did extensive testing, but in this case the 4 eye principle applies.

![Bypassoptions](https://user-images.githubusercontent.com/56754746/90182209-e50ce980-ddb1-11ea-8e46-b1c386943e4b.png)
