### PR TITLE
Distinguish between bestial and non bestial fluids for addictions.

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -17629,7 +17629,7 @@ public abstract class GameCharacter implements XMLSaving {
 		for(Entry<SexAreaOrifice, List<FluidStored>> entry : this.fluidsStoredMap.entrySet()) {
 			for(FluidStored fs : entry.getValue()) {
 				if(fs.getFluid().getFluidModifiers().contains(FluidModifier.ADDICTIVE)) {
-					addAddiction(new Addiction(fs.getFluid().getType(), Main.game.getMinutesPassed(), fs.getCharactersFluidID()));
+					addAddiction(new Addiction(fs.getFluid().getType(), Main.game.getMinutesPassed(), fs.getCharactersFluidID(), fs.isBestial()));
 				}
 				if(fs.getFluid().getFluidModifiers().contains(FluidModifier.HALLUCINOGENIC)) {
 					this.addStatusEffect(StatusEffect.PSYCHOACTIVE, 6*60*60);

--- a/src/com/lilithsthrone/game/character/body/valueEnums/FluidModifier.java
+++ b/src/com/lilithsthrone/game/character/body/valueEnums/FluidModifier.java
@@ -65,7 +65,7 @@ public enum FluidModifier {
 		public String applyEffects(GameCharacter target, GameCharacter fluidProvider, float millilitres, FluidInterface fluid) {
 			boolean curedWithdrawal = target.getAddiction(fluid.getType())!=null && Main.game.getMinutesPassed()-target.getAddiction(fluid.getType()).getLastTimeSatisfied()>=24*60;
 			boolean appendAddiction = !Main.game.isInSex() || curedWithdrawal;
-			if(target.addAddiction(new Addiction(fluid.getType(), Main.game.getMinutesPassed(), fluidProvider.getId()))) {
+			if(target.addAddiction(new Addiction(fluid.getType(), Main.game.getMinutesPassed(), fluidProvider.getId(), fluid.isBestial(fluidProvider)))) {
 				return UtilText.parse(target,
 						"<p style='padding:0; margin:0; text-align:center;'>"
 							+ "Due to the addictive properties of "+(fluidProvider==null?"":(fluidProvider.equals(target)?"[npc.her]":UtilText.parse(fluidProvider, "[npc.namePos]")))+" "+fluid.getName(fluidProvider)

--- a/src/com/lilithsthrone/game/character/effects/Addiction.java
+++ b/src/com/lilithsthrone/game/character/effects/Addiction.java
@@ -12,6 +12,8 @@ import com.lilithsthrone.game.character.body.abstractTypes.AbstractFluidType;
 import com.lilithsthrone.game.character.body.types.FluidType;
 import com.lilithsthrone.utils.XMLSaving;
 
+import static java.lang.Boolean.valueOf;
+
 /**
  * @since 0.2.0
  * @version 0.3.8.2
@@ -22,24 +24,27 @@ public class Addiction implements XMLSaving {
 	private AbstractFluidType fluid;
 	private long lastTimeSatisfied;
 	private Set<String> providerIDs;
-	
+	private boolean isBestial;
+
 	public Addiction(AbstractFluidType fluid, long lastTimeSatisfied) {
 		this.fluid = fluid;
 		this.lastTimeSatisfied = lastTimeSatisfied;
 		this.providerIDs = new HashSet<>();
 	}
 	
-	public Addiction(AbstractFluidType fluid, long lastTimeSatisfied, String providerID) {
+	public Addiction(AbstractFluidType fluid, long lastTimeSatisfied, String providerID, boolean isBestial) {
 		this.fluid = fluid;
 		this.lastTimeSatisfied = lastTimeSatisfied;
 		this.providerIDs = new HashSet<>();
 		this.providerIDs.add(providerID);
+		this.isBestial = isBestial;
 	}
 	
-	public Addiction(AbstractFluidType fluid, long lastTimeSatisfied, Set<String> providerIDs) {
+	public Addiction(AbstractFluidType fluid, long lastTimeSatisfied, Set<String> providerIDs, boolean isBestial) {
 		this.fluid = fluid;
 		this.lastTimeSatisfied = lastTimeSatisfied;
 		this.providerIDs = providerIDs;
+		this.isBestial = isBestial;
 	}
 
 	@Override
@@ -48,7 +53,8 @@ public class Addiction implements XMLSaving {
 			return (o instanceof Addiction)
 					&& ((Addiction)o).getFluid().equals(this.getFluid())
 					&& ((Addiction)o).getLastTimeSatisfied() == this.getLastTimeSatisfied()
-					&& ((Addiction)o).getProviderIDs().equals(this.getProviderIDs());
+					&& ((Addiction)o).getProviderIDs().equals(this.getProviderIDs())
+					&& ((Addiction)o).isBestial() == (this.isBestial());
 		} else {
 			return false;
 		}
@@ -70,7 +76,7 @@ public class Addiction implements XMLSaving {
 
 		CharacterUtils.addAttribute(doc, element, "fluid", FluidType.getIdFromFluidType(this.getFluid()));
 		CharacterUtils.addAttribute(doc, element, "lastTimeSatisfied", String.valueOf(this.getLastTimeSatisfied()));
-		
+
 		Element innerElement = doc.createElement("providerIDs");
 		element.appendChild(innerElement);
 		for(String id : this.getProviderIDs()) {
@@ -78,7 +84,8 @@ public class Addiction implements XMLSaving {
 			innerElement.appendChild(idElement);
 			CharacterUtils.addAttribute(doc, idElement, "value", id);
 		}
-		
+		CharacterUtils.addAttribute(doc, element, "bestial", String.valueOf(this.isBestial()));
+
 		return element;
 	}
 
@@ -90,8 +97,8 @@ public class Addiction implements XMLSaving {
 		}
 		
 		return new Addiction(FluidType.getFluidTypeFromId(parentElement.getAttribute("fluid")),
-				Long.valueOf(parentElement.getAttribute("lastTimeSatisfied")),
-				IDs);
+				Long.parseLong(parentElement.getAttribute("lastTimeSatisfied")),
+				IDs, Boolean.parseBoolean(parentElement.getAttribute("bestial")));
 	}
 	
 	public AbstractFluidType getFluid() {
@@ -116,5 +123,13 @@ public class Addiction implements XMLSaving {
 	
 	public void addProviderID(String providerID) {
 		getProviderIDs().add(providerID);
+	}
+
+	public boolean isBestial() {
+		return isBestial;
+	}
+
+	public void setBestial(boolean bestial) {
+		isBestial = bestial;
 	}
 }

--- a/src/com/lilithsthrone/game/character/effects/StatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/StatusEffect.java
@@ -2844,7 +2844,7 @@ public class StatusEffect {
 				long timeLeft = oneDayLater - now;
 				long hoursLeft = timeLeft / 60;
 				long minutesLeft = timeLeft % 60;
-				extraEffects.add("<b style='color:"+addiction.getFluid().getRace().getColour().toWebHexString()+";'>"+Util.capitaliseSentence(addiction.getFluid().getRace().getName(true))+" "+addiction.getFluid().getBaseType().getNames().get(0)+"</b>: "
+				extraEffects.add("<b style='color:"+addiction.getFluid().getRace().getColour().toWebHexString()+";'>"+Util.capitaliseSentence(addiction.getFluid().getRace().getName(addiction.isBestial()))+" "+addiction.getFluid().getBaseType().getNames().get(0)+"</b>: "
 						+ (timeLeft > 0
 								?" [style.colourGood("+hoursLeft+":"+String.format("%02d", minutesLeft)+")]"
 								:" [style.boldArcane(Withdrawal!)]"));


### PR DESCRIPTION
- What is the purpose of the pull request?

Determine if an addictive fluid is from a bestial or a non bestial source, and store this information.

- Give a brief description of what you changed or added.

Add a new property to addictions, save it to xml, load it from xml and initialize it from the fluid that is causing the addiction. And finally show the proper name in the addiction status effect.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with version 0.3.9.2

- So we have a better idea of who you are, what is your Discord Handle?

AceXp#0930

Closes #1364 
