### PR TITLE
Return to correct dialogue when leaving inventory management in an apartment

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/companions/OccupantDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/companions/OccupantDialogue.java
@@ -12,6 +12,7 @@ import com.lilithsthrone.game.character.fetishes.Fetish;
 import com.lilithsthrone.game.character.npc.NPC;
 import com.lilithsthrone.game.character.npc.NPCFlagValue;
 import com.lilithsthrone.game.character.persona.Occupation;
+import com.lilithsthrone.game.dialogue.DialogueFlags;
 import com.lilithsthrone.game.dialogue.DialogueNode;
 import com.lilithsthrone.game.dialogue.DialogueNodeType;
 import com.lilithsthrone.game.dialogue.places.dominion.lilayashome.RoomPlayer;
@@ -53,6 +54,9 @@ public class OccupantDialogue {
 		}
 		if(!isApartment || targetedOccupant.isAtHome()) {
 			CompanionManagement.initManagement(OCCUPANT_START, 2, targetedOccupant);
+		}
+		if(isApartment) {
+			CompanionManagement.initManagement(OCCUPANT_APARTMENT, 2, targetedOccupant);
 		}
 		occupant = targetedOccupant;
 		characterForSex = targetedOccupant;
@@ -1196,6 +1200,7 @@ public class OccupantDialogue {
 						occupant().setRandomUnoccupiedLocation(WorldType.DOMINION, true, PlaceType.DOMINION_STREET, PlaceType.DOMINION_STREET_HARPY_NESTS, PlaceType.DOMINION_BOULEVARD);
 						occupant().setHomeLocation();
 						OccupantDialogue.isApartment = true;
+						Main.game.getDialogueFlags().setManagementCompanion(occupant());
 						Main.game.getPlayer().setLocation(occupant().getWorldLocation(), occupant().getLocation(), false);
 					}
 				};


### PR DESCRIPTION
- What is the purpose of the pull request?

Fix issue #1356 'Moved Out; still getting lodging options'

- Give a brief description of what you changed or added.

Set the companionManagement (inventory and so on) to return to the OCCUPANT_APARTMENT dialogue if starting from an apartment. Also, when first visiting, set the npc as the managementCompanion so the dialogue recognizes the npc as present.

This is in the to_do list as 
"my daughters that have already moved out seem to be treated as though they haven't. All the dialogue options are reverted back as if they're still living with me. (Can ask what they think about my slaves, ask them to move out, etc.)" ca. line 496

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with 0.3.9.3

- So we have a better idea of who you are, what is your Discord Handle?

AceXp#0930

Closes #1356 