### PR TITLE
Enable loading patterns from res/mods folder

### DIFF
--- a/src/com/lilithsthrone/rendering/Pattern.java
+++ b/src/com/lilithsthrone/rendering/Pattern.java
@@ -12,6 +12,7 @@ import java.util.TreeMap;
 import com.lilithsthrone.controller.xmlParsing.Element;
 import com.lilithsthrone.controller.xmlParsing.XMLLoadException;
 import com.lilithsthrone.controller.xmlParsing.XMLMissingTagException;
+import com.lilithsthrone.game.character.markings.AbstractTattooType;
 import com.lilithsthrone.game.inventory.ColourReplacement;
 import com.lilithsthrone.utils.SvgUtil;
 import com.lilithsthrone.utils.colours.Colour;
@@ -35,21 +36,50 @@ public class Pattern {
 	static {
 		allPatterns = new TreeMap<>();
 		defaultPatterns = new TreeMap<>();
-		
-		File dir = new File("res/patterns");
-		
-		allPatterns.put("none", new Pattern("none")); // Adding empty pattern
-		defaultPatterns.put("none", new Pattern("none"));
+
+		allPatterns.put("none", new Pattern("none", null)); // Adding empty pattern
+		defaultPatterns.put("none", new Pattern("none", null));
+
+		File dir = new File("res/mods");
+
+		if (dir.exists() && dir.isDirectory()) {
+			File[] modDirectoryListing = dir.listFiles();
+			if (modDirectoryListing != null) {
+				for (File modAuthorDirectory : modDirectoryListing) {
+					File modAuthorPatternDirectory = new File(modAuthorDirectory.getAbsolutePath()+"/items/patterns");
+					FilenameFilter textFilter = (dir1, name) -> {
+						String lowercaseName = name.toLowerCase();
+						if (lowercaseName.endsWith(".xml")) {
+							return true;
+						} else {
+							return false;
+						}
+					};
+					File[] patternFilesListing = modAuthorPatternDirectory.listFiles(textFilter);
+					if (patternFilesListing != null) {
+						for (File patternFile : patternFilesListing) {
+							try {
+								if(patternFile.exists()) {
+									loadFromFile(patternFile);
+								}
+							} catch(Exception ex) {
+								System.err.println("Loading modded pattern failed in 'mod folder patterns'. File path: "+patternFile.getAbsolutePath());
+							}
+						}
+					}
+				}
+			}
+		}
+
+		dir = new File("res/patterns");
 		
 		if(dir.exists()) {
-			FilenameFilter textFilter = new FilenameFilter() {
-				public boolean accept(File dir, String name) {
-					String lowercaseName = name.toLowerCase();
-					if (lowercaseName.endsWith(".xml")) {
-						return true;
-					} else {
-						return false;
-					}
+			FilenameFilter textFilter = (dir1, name) -> {
+				String lowercaseName = name.toLowerCase();
+				if (lowercaseName.endsWith(".xml")) {
+					return true;
+				} else {
+					return false;
 				}
 			};
 			
@@ -61,14 +91,15 @@ public class Pattern {
 		}
 	}
 	
-	public Pattern(String name) {
+	public Pattern(String name, File xmlFile) {
 		this.name = name;
 		SVGStringMap = new HashMap<>();
 		
 		baseSVGString = "";
 		if(!name.equals("none")) {
 			try {
-				File patternFile = new File(System.getProperty("user.dir")+"/res/patterns/" + this.getName().toLowerCase() + ".svg");
+				String fileName = xmlFile.getPath().replaceAll("xml","svg");
+				File patternFile = new File(fileName);
 				List<String> lines = Files.readAllLines(patternFile.toPath());
 				StringBuilder sb = new StringBuilder();
 				for(String line : lines) {
@@ -89,7 +120,7 @@ public class Pattern {
 			boolean loadedDefaultPattern = Boolean.valueOf(patternElement.getMandatoryFirstOf("defaultPattern").getTextContent());
 			String loadedPatternName = patternElement.getMandatoryFirstOf("patternName").getTextContent().replace(".svg", "");
 
-			Pattern pattern = new Pattern(loadedPatternName);
+			Pattern pattern = new Pattern(loadedPatternName, clothingXMLFile);
 			pattern.displayName = loadedDisplayName;
 			
 			allPatterns.put(loadedPatternName, pattern);


### PR DESCRIPTION
- What is the purpose of the pull request?

Enable loading patterns from the res/mods/[author]/items/pattern folder.

- Give a brief description of what you changed or added.

Determine if there are xml files in any res/mods/[author]/items/pattern folders, and try to load them (and the corresponding svg file). And then add this as a pattern.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested in 0.3.9.7 by putting all the polka dot files in a local res/mods folder

- So we have a better idea of who you are, what is your Discord Handle?

AceXp#0930