### PR TITLE
Fixed time bug in Angel's Kiss Sub scene

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/places/dominion/RedLightDistrict.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/RedLightDistrict.java
@@ -502,7 +502,7 @@ public class RedLightDistrict {
 
 		@Override
 		public int getSecondsPassed() {
-			return 5*60;
+			return 25*60;
 		}
 
 		@Override


### PR DESCRIPTION
Not a large pull request, but I can include these things.

- What is the purpose of the pull request?

Fixes a balance/continuity issue when acting as a submissive partner in the Angel's Kiss

- Give a brief description of what you changed or added.

Dialogue states that the client enters "Around twenty-five minutes later", but the ANGELS_KISS_SELL_SELF_SUB DialogueNode only progresses time by 5 minutes. This has been fixed to make the node take 25 minutes instead.

- Are any new graphical assets required?

No.

- Has this change been tested? If so, mention the version number that the test was based on.

Only so far as to ensure that the fix works, on version 0.3.9.7