### PR TITLE
Fixed Sean's fight scene

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/places/dominion/slaverAlley/SlaverAlleyDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/slaverAlley/SlaverAlleyDialogue.java
@@ -2408,11 +2408,10 @@ public class SlaverAlleyDialogue {
 						Main.game.getPlayer().setLocation(WorldType.SLAVER_ALLEY, PlaceType.SLAVER_ALLEY_DESERTED_ALLEYWAY);
 						Main.game.getNpc(Sean.class).setLocation(WorldType.SLAVER_ALLEY, PlaceType.SLAVER_ALLEY_DESERTED_ALLEYWAY);
 						
-						// Sean takes jacket, belt, tie, and hat off:
+						// Sean takes jacket, belt, and hat off:
 						NPC sean = Main.game.getNpc(Sean.class);
 						sean.unequipClothingIntoInventory(sean.getClothingInSlot(InventorySlot.TORSO_OVER), true, sean);
 						sean.unequipClothingIntoInventory(sean.getClothingInSlot(InventorySlot.HEAD), true, sean);
-						sean.unequipClothingIntoInventory(sean.getClothingInSlot(InventorySlot.NECK), true, sean);
 						sean.unequipClothingIntoInventory(sean.getClothingInSlot(InventorySlot.HIPS), true, sean);
 						
 						Main.game.getDialogueFlags().setFlag(DialogueFlagValue.slaverAlleyComplained, true);


### PR DESCRIPTION
- What is the purpose of the pull request?

Fixes an issue where Accepting Sean's challenge in the Slaver's alley wouldn't initiate a fight scene

- Give a brief description of what you changed or added.

In commit 3ec95aa, the NPC's base clothing was changed without changing the fight scene preparation, wherein Sean removes some equipment, including a tie that no longer exists. This lead to a NullPointerException in `GameCharacter.unequipClothingIntoInventory`, which prevented the scene from moving any further into the fight sequence.  
This PR changes the fight scene preparation.

- Are any new graphical assets required?

No.

- Has this change been tested? If so, mention the version number that the test was based on.

Tested in 0.3.9.7, only so far as to ensure that the fix works

- So we have a better idea of who you are, what is your Discord Handle?

Null#3561

-----

Being largely unfamiliar with the codebase, I am unaware of any other instances of this issue, but they are possible. To prevent this issue from affecting the game, a check can be made to return early in `GameCharacter.unequipClothingIntoInventory` if the clothing parameter is null.