### PR TITLE
Player Selfie uses custom description if available

### DIFF
--- a/src/com/lilithsthrone/game/character/PlayerCharacter.java
+++ b/src/com/lilithsthrone/game/character/PlayerCharacter.java
@@ -731,9 +731,11 @@ public class PlayerCharacter extends GameCharacter implements XMLSaving {
 		if(!Main.game.isInNewWorld()) {
 			return ""; // This isn't displayed anywhere before the game starts for real.
 		} else {
-			return "Having been pulled into an enchanted mirror in your aunt Lily's museum, you woke up to find yourself in another world."
+			if(description=="") {
+				return "Having been pulled into an enchanted mirror in your aunt Lily's museum, you woke up to find yourself in another world."
 					+ " By a stroke of good fortune, one of the first people you met was Lilaya; this world's version of your aunt."
 					+ " Having convinced her that your story is true, you're now working towards finding a way to get back to your old world.";
+			} else {return UtilText.parse(this, description);}
 		}
 	}
 	


### PR DESCRIPTION
The player's description always shows the default description ("Having been pulled into an enchanted mirror..."), even if changed with save editing. This change makes it use the default description if there's no custom description.

Tested with 3 new characters, 1 character with custom description, and 1 pre-existing character, on 0.3.9.8.
