### PR TITLE
Fix anus description of elementals

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -20455,7 +20455,7 @@ public abstract class GameCharacter implements XMLSaving {
 		clothing.onUnequipApplyEffects(this, characterRemovingClothing, false);
 		inventory.forceUnequipClothingIntoVoid(this, characterRemovingClothing, clothing);
 	}
-	
+
 	public String unequipClothingIntoVoid(AbstractClothing clothing, boolean automaticClothingManagement, GameCharacter characterClothingUnequipper) { // TODO it's saying "added to inventory"
 		boolean unknownPenis = !this.isAreaKnownByCharacter(CoverableArea.PENIS, Main.game.getPlayer()) && !this.isCoverableAreaVisible(CoverableArea.PENIS);
 		boolean unknownBreasts = !this.isAreaKnownByCharacter(CoverableArea.BREASTS, Main.game.getPlayer()) && !this.isCoverableAreaVisible(CoverableArea.BREASTS);
@@ -25905,16 +25905,25 @@ public abstract class GameCharacter implements XMLSaving {
 				if(bodyCoveringType==BodyCoveringType.HAIR_DEMON) {
 					return body.getCoverings().get(BodyCoveringType.AIR_HAIR);
 				}
-				return body.getCoverings().get(BodyCoveringType.AIR);
+                if(bodyCoveringType==BodyCoveringType.ANUS) {
+                    return body.getCoverings().get(BodyCoveringType.AIR_ANUS);
+                }
+                return body.getCoverings().get(BodyCoveringType.AIR);
 			case ARCANE:
 				if(bodyCoveringType==BodyCoveringType.HAIR_DEMON) {
 					return body.getCoverings().get(BodyCoveringType.ARCANE_HAIR);
 				}
-				return body.getCoverings().get(BodyCoveringType.ARCANE);
+                if(bodyCoveringType==BodyCoveringType.ANUS) {
+                    return body.getCoverings().get(BodyCoveringType.ARCANE_ANUS);
+                }
+                return body.getCoverings().get(BodyCoveringType.ARCANE);
 			case FIRE:
 				if(bodyCoveringType==BodyCoveringType.HAIR_DEMON) {
 					return body.getCoverings().get(BodyCoveringType.FIRE_HAIR);
 				}
+                if(bodyCoveringType==BodyCoveringType.ANUS) {
+                    return body.getCoverings().get(BodyCoveringType.FIRE_ANUS);
+                }
 				return body.getCoverings().get(BodyCoveringType.FIRE);
 			case FLESH:
 				break;
@@ -25922,24 +25931,36 @@ public abstract class GameCharacter implements XMLSaving {
 				if(bodyCoveringType==BodyCoveringType.HAIR_DEMON) {
 					return body.getCoverings().get(BodyCoveringType.ICE_HAIR);
 				}
+                if(bodyCoveringType==BodyCoveringType.ANUS) {
+                    return body.getCoverings().get(BodyCoveringType.ICE_ANUS);
+                }
 				return body.getCoverings().get(BodyCoveringType.ICE);
 			case RUBBER:
 				if(bodyCoveringType==BodyCoveringType.HAIR_DEMON) {
 					return body.getCoverings().get(BodyCoveringType.RUBBER_HAIR);
 				}
-				return body.getCoverings().get(BodyCoveringType.RUBBER);
+                if(bodyCoveringType==BodyCoveringType.ANUS) {
+                    return body.getCoverings().get(BodyCoveringType.RUBBER_ANUS);
+                }
+                return body.getCoverings().get(BodyCoveringType.RUBBER);
 			case SLIME:
 				break;
 			case STONE:
 				if(bodyCoveringType==BodyCoveringType.HAIR_DEMON) {
 					return body.getCoverings().get(BodyCoveringType.STONE_HAIR);
 				}
-				return body.getCoverings().get(BodyCoveringType.STONE);
+                if(bodyCoveringType==BodyCoveringType.ANUS) {
+                    return body.getCoverings().get(BodyCoveringType.STONE_ANUS);
+                }
+                return body.getCoverings().get(BodyCoveringType.STONE);
 			case WATER:
 				if(bodyCoveringType==BodyCoveringType.HAIR_DEMON) {
 					return body.getCoverings().get(BodyCoveringType.WATER_HAIR);
 				}
-				return body.getCoverings().get(BodyCoveringType.WATER);
+                if(bodyCoveringType==BodyCoveringType.ANUS) {
+                    return body.getCoverings().get(BodyCoveringType.WATER_ANUS);
+                }
+                return body.getCoverings().get(BodyCoveringType.WATER);
 		}
 		
 		if(this.getBodyMaterial()==BodyMaterial.SLIME) {

--- a/src/com/lilithsthrone/game/character/body/types/BodyCoveringTemplateFactory.java
+++ b/src/com/lilithsthrone/game/character/body/types/BodyCoveringTemplateFactory.java
@@ -105,22 +105,24 @@ public class BodyCoveringTemplateFactory {
 	public static BodyCoveringTemplate createBodyHair(CoveringModifier modifier) {
 		return createHairWithoutPatterns("a layer of", "hair", modifier);
 	}
-	
-	public static BodyCoveringTemplate createElemental(String name, CoveringModifier modifier, Colour... naturalHairColours) {
+
+	public static BodyCoveringTemplate createElemental(String name, CoveringPattern pattern, CoveringModifier modifier, Colour... naturalHairColours) {
 		return new BodyCoveringTemplate("",
 				false,
 				name,
 				name,
 				Util.newArrayListOfValues(modifier),
 				null,
-				Util.newHashMapOfValues(new Value<>(CoveringPattern.NONE, 1)),
+				pattern==null
+					?Util.newHashMapOfValues(new Value<>(CoveringPattern.NONE, 1))
+					:Util.newHashMapOfValues(new Value<>(pattern, 1)),
 				null,
 				Arrays.asList(naturalHairColours),
 				null,
 				null,
 				null);
 	}
-	
+
 	public static BodyCoveringTemplate createOrificeSkin(CoveringPattern pattern) {
 		return new BodyCoveringTemplate("a layer of",
 				false,

--- a/src/com/lilithsthrone/game/character/body/types/BodyCoveringType.java
+++ b/src/com/lilithsthrone/game/character/body/types/BodyCoveringType.java
@@ -200,43 +200,97 @@ public enum BodyCoveringType {
 	VAGINA(BodyCoveringTemplateFactory.createOrificeSkin(CoveringPattern.ORIFICE_VAGINA)),
 	
 
-	FIRE(BodyCoveringTemplateFactory.createElemental("flames", CoveringModifier.BLAZING, 
-					PresetColour.COVERING_ORANGE,
-					PresetColour.COVERING_BLUE_LIGHT)),
-	
-	FIRE_HAIR(BodyCoveringTemplateFactory.createElemental("flames", CoveringModifier.BLAZING, 
+	FIRE(BodyCoveringTemplateFactory.createElemental("flames", null,
+			CoveringModifier.BLAZING,
 			PresetColour.COVERING_ORANGE,
 			PresetColour.COVERING_BLUE_LIGHT)),
 	
-	WATER(BodyCoveringTemplateFactory.createElemental("water", CoveringModifier.SHIMMERING, 
-			PresetColour.COVERING_BLUE,
-			PresetColour.COVERING_BLUE_LIGHT)),
-	
-	WATER_HAIR(BodyCoveringTemplateFactory.createElemental("water", CoveringModifier.SHIMMERING, 
-			PresetColour.COVERING_BLUE,
+	FIRE_HAIR(BodyCoveringTemplateFactory.createElemental("flames", null,
+			CoveringModifier.BLAZING,
+			PresetColour.COVERING_ORANGE,
 			PresetColour.COVERING_BLUE_LIGHT)),
 
-	ICE(BodyCoveringTemplateFactory.createElemental("ice", CoveringModifier.SHIMMERING, PresetColour.COVERING_BLUE_LIGHT)),
+	FIRE_ANUS(BodyCoveringTemplateFactory.createElemental("flames", CoveringPattern.ORIFICE_ANUS,
+			CoveringModifier.BLAZING,
+			PresetColour.COVERING_ORANGE,
+			PresetColour.COVERING_BLUE_LIGHT)),
 	
-	ICE_HAIR(BodyCoveringTemplateFactory.createElemental("ice", CoveringModifier.SHIMMERING, PresetColour.COVERING_BLUE_LIGHT)),
+	WATER(BodyCoveringTemplateFactory.createElemental("water", null,
+			CoveringModifier.SHIMMERING,
+			PresetColour.COVERING_BLUE,
+			PresetColour.COVERING_BLUE_LIGHT)),
 
-	AIR(BodyCoveringTemplateFactory.createElemental("vapours", CoveringModifier.SWIRLING, PresetColour.COVERING_BLUE_LIGHT)),
-	
-	AIR_HAIR(BodyCoveringTemplateFactory.createElemental("vapours", CoveringModifier.SWIRLING, PresetColour.COVERING_BLUE_LIGHT)),
+	WATER_HAIR(BodyCoveringTemplateFactory.createElemental("water", null,
+			CoveringModifier.SHIMMERING,
+			PresetColour.COVERING_BLUE,
+			PresetColour.COVERING_BLUE_LIGHT)),
 
-	STONE(BodyCoveringTemplateFactory.createElemental("stone", CoveringModifier.MATTE, PresetColour.COVERING_GREY)),
-	
-	STONE_HAIR(BodyCoveringTemplateFactory.createElemental("stone", CoveringModifier.MATTE, PresetColour.COVERING_GREY)),
+	WATER_ANUS(BodyCoveringTemplateFactory.createElemental("water", CoveringPattern.ORIFICE_ANUS,
+			CoveringModifier.SHIMMERING,
+			PresetColour.COVERING_BLUE,
+			PresetColour.COVERING_BLUE_LIGHT)),
 
-	RUBBER(BodyCoveringTemplateFactory.createElemental("rubber", CoveringModifier.GLOSSY, PresetColour.COVERING_BLACK)),
-	
-	RUBBER_HAIR(BodyCoveringTemplateFactory.createElemental("rubber", CoveringModifier.GLOSSY, PresetColour.COVERING_BLACK)),
+	ICE(BodyCoveringTemplateFactory.createElemental("ice", null,
+			CoveringModifier.GLITTERING,
+			PresetColour.COVERING_BLUE_LIGHT)),
 
-	ARCANE(BodyCoveringTemplateFactory.createElemental("energy", CoveringModifier.SWIRLING, PresetColour.COVERING_PINK)),
-	
-	ARCANE_HAIR(BodyCoveringTemplateFactory.createElemental("energy", CoveringModifier.SWIRLING, PresetColour.COVERING_PINK)),
-	
-	
+	ICE_HAIR(BodyCoveringTemplateFactory.createElemental("ice", null,
+			CoveringModifier.GLITTERING,
+			PresetColour.COVERING_BLUE_LIGHT)),
+
+	ICE_ANUS(BodyCoveringTemplateFactory.createElemental("ice", CoveringPattern.ORIFICE_ANUS,
+			CoveringModifier.GLITTERING,
+			PresetColour.COVERING_BLUE_LIGHT)),
+
+	AIR(BodyCoveringTemplateFactory.createElemental("vapours", null,
+			CoveringModifier.SWIRLING,
+			PresetColour.COVERING_BLUE_LIGHT)),
+
+	AIR_HAIR(BodyCoveringTemplateFactory.createElemental("vapours", null,
+			CoveringModifier.SWIRLING,
+			PresetColour.COVERING_BLUE_LIGHT)),
+
+	AIR_ANUS(BodyCoveringTemplateFactory.createElemental("vapours", CoveringPattern.ORIFICE_ANUS,
+			CoveringModifier.SWIRLING,
+			PresetColour.COVERING_BLUE_LIGHT)),
+
+	STONE(BodyCoveringTemplateFactory.createElemental("stone", null,
+			CoveringModifier.MATTE,
+			PresetColour.COVERING_GREY)),
+
+	STONE_HAIR(BodyCoveringTemplateFactory.createElemental("stone", null,
+			CoveringModifier.MATTE,
+			PresetColour.COVERING_GREY)),
+
+	STONE_ANUS(BodyCoveringTemplateFactory.createElemental("stone", CoveringPattern.ORIFICE_ANUS,
+			CoveringModifier.MATTE,
+			PresetColour.COVERING_GREY)),
+
+	RUBBER(BodyCoveringTemplateFactory.createElemental("rubber", null,
+			CoveringModifier.GLOSSY,
+			PresetColour.COVERING_BLACK)),
+
+	RUBBER_HAIR(BodyCoveringTemplateFactory.createElemental("rubber", null,
+			CoveringModifier.GLOSSY,
+			PresetColour.COVERING_BLACK)),
+
+	RUBBER_ANUS(BodyCoveringTemplateFactory.createElemental("rubber", CoveringPattern.ORIFICE_ANUS,
+			CoveringModifier.GLOSSY,
+			PresetColour.COVERING_BLACK)),
+
+	ARCANE(BodyCoveringTemplateFactory.createElemental("energy", null,
+			CoveringModifier.SWIRLING,
+			PresetColour.COVERING_PINK)),
+
+	ARCANE_HAIR(BodyCoveringTemplateFactory.createElemental("energy", null,
+			CoveringModifier.SWIRLING,
+			PresetColour.COVERING_PINK)),
+
+	ARCANE_ANUS(BodyCoveringTemplateFactory.createElemental("energy", CoveringPattern.ORIFICE_ANUS,
+			CoveringModifier.SWIRLING,
+			PresetColour.COVERING_PINK)),
+
+
 	SLIME(BodyCoveringTemplateFactory.createSlime(CoveringPattern.NONE, CoveringPattern.allStandardCoveringPatterns)),
 
 	SLIME_EYE(BodyCoveringTemplateFactory.createSlime(CoveringPattern.EYE_IRISES,

--- a/src/com/lilithsthrone/game/character/body/valueEnums/CoveringModifier.java
+++ b/src/com/lilithsthrone/game/character/body/valueEnums/CoveringModifier.java
@@ -19,6 +19,7 @@ public enum CoveringModifier {
 
 	BLAZING("blazing"),
 	SHIMMERING("shimmering"),
+	GLITTERING("glittering"),
 	SWIRLING("swirling"),
 	
 	GOOEY("gooey") {


### PR DESCRIPTION
- What is the purpose of the pull request?

Fix the issue where the description of the anus of elementals is wrong

- Give a brief description of what you changed or added.

Added coverings for elementals that have the required pattern 'ORIFICE_ANUS', and create these with the CreateElemental BodyCoveringTemplateFactory. Also changed this method by adding a parameter 'pattern'. Then use these new patterns as needed in GameCharacter.getCovering. And changed the covering modifier to 'glittering' for ice, because I think it's cool...

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with version 0.3.9.8

- So we have a better idea of who you are, what is your Discord Handle?

AceXp#0930

Info screen before the fix:
![BeforeFireElemental](https://user-images.githubusercontent.com/56754746/93225000-06c30d00-f772-11ea-8c7a-e7e76d3376bc.png)

Info screen after the fix:
![AfterFireElemental](https://user-images.githubusercontent.com/56754746/93225099-23f7db80-f772-11ea-86dc-e84b39f97130.png)

The human/demonic description is based on what the elemental has, and is not affected by this fix.