### PR TITLE
Elasticity affect depth

### DIFF
--- a/src/com/lilithsthrone/controller/MainControllerInitMethod.java
+++ b/src/com/lilithsthrone/controller/MainControllerInitMethod.java
@@ -6286,6 +6286,7 @@ public class MainControllerInitMethod {
 					new Value<>("ANAL", PropertyValue.analContent),
 					new Value<>("GAPE", PropertyValue.gapeContent),
 					new Value<>("PENETRATION_LIMITATION", PropertyValue.penetrationLimitations),
+					new Value<>("PENETRATION_LIMITATION_DYNAMIC", PropertyValue.elasticityAffectDepth),
 					new Value<>("FOOT", PropertyValue.footContent),
 					new Value<>("FUTA_BALLS", PropertyValue.futanariTesticles),
 					new Value<>("CLOACA", PropertyValue.bipedalCloaca),

--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -4362,6 +4362,10 @@ public class Game implements XMLSaving {
 		return Main.getProperties().hasValue(PropertyValue.penetrationLimitations);
 	}
 	
+	public boolean isElasticityAffectDepthEnabled() {
+		return Main.getProperties().hasValue(PropertyValue.elasticityAffectDepth);
+	}
+	
 	public boolean isFootContentEnabled() {
 		return Main.getProperties().hasValue(PropertyValue.footContent);
 	}

--- a/src/com/lilithsthrone/game/PropertyValue.java
+++ b/src/com/lilithsthrone/game/PropertyValue.java
@@ -63,6 +63,8 @@ public enum PropertyValue {
 	
 	cumRegenerationContent(true),
 	penetrationLimitations(true),
+	//ElasticityAffectDepth was modded in so i set the default value to false 
+	elasticityAffectDepth(false),
 	
 	futanariTesticles(true),
 	bipedalCloaca(true),

--- a/src/com/lilithsthrone/game/character/body/OrificeAnus.java
+++ b/src/com/lilithsthrone/game/character/body/OrificeAnus.java
@@ -13,6 +13,7 @@ import com.lilithsthrone.game.character.body.valueEnums.OrificeModifier;
 import com.lilithsthrone.game.character.body.valueEnums.OrificePlasticity;
 import com.lilithsthrone.game.character.body.valueEnums.Wetness;
 import com.lilithsthrone.game.dialogue.utils.UtilText;
+import com.lilithsthrone.main.Main;
 
 /**
  * @since 0.1.?
@@ -153,7 +154,17 @@ public class OrificeAnus implements OrificeInterface {
 	
 	@Override
 	public int getMaximumPenetrationDepthUncomfortable(GameCharacter owner, OrificeDepth depth) {
+		if( Main.game.isElasticityAffectDepthEnabled()) {
+			if(elasticity<=3 ) {		
+				//Default original value
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 2);			
+			}
+			else {
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * (float)elasticity/1.5f);
+			}
+		} else {
 		return getMaximumPenetrationDepthComfortable(owner, depth) * 2;
+		}
 	}
 	
 	@Override

--- a/src/com/lilithsthrone/game/character/body/OrificeMouth.java
+++ b/src/com/lilithsthrone/game/character/body/OrificeMouth.java
@@ -13,6 +13,7 @@ import com.lilithsthrone.game.character.body.valueEnums.OrificeModifier;
 import com.lilithsthrone.game.character.body.valueEnums.OrificePlasticity;
 import com.lilithsthrone.game.character.body.valueEnums.Wetness;
 import com.lilithsthrone.game.dialogue.utils.UtilText;
+import com.lilithsthrone.main.Main;
 
 /**
  * @since 0.1.?
@@ -151,7 +152,16 @@ public class OrificeMouth implements OrificeInterface {
 	
 	@Override
 	public int getMaximumPenetrationDepthUncomfortable(GameCharacter owner, OrificeDepth depth) {
-		return getMaximumPenetrationDepthComfortable(owner, depth) * 2;
+		if( Main.game.isElasticityAffectDepthEnabled()) {
+			if(elasticity<=3 ) {		
+				//Default original value
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 2);			
+			} else {
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * (float)elasticity/1.5f);
+			}
+		} else {
+			return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 2);
+		}		
 	}
 	
 	@Override

--- a/src/com/lilithsthrone/game/character/body/OrificeNipples.java
+++ b/src/com/lilithsthrone/game/character/body/OrificeNipples.java
@@ -13,6 +13,7 @@ import com.lilithsthrone.game.character.body.valueEnums.OrificeModifier;
 import com.lilithsthrone.game.character.body.valueEnums.OrificePlasticity;
 import com.lilithsthrone.game.character.body.valueEnums.Wetness;
 import com.lilithsthrone.game.dialogue.utils.UtilText;
+import com.lilithsthrone.main.Main;
 
 /**
  * @since 0.1.?
@@ -148,7 +149,16 @@ public class OrificeNipples implements OrificeInterface {
 	
 	@Override
 	public int getMaximumPenetrationDepthUncomfortable(GameCharacter owner, OrificeDepth depth) {
-		return getMaximumPenetrationDepthComfortable(owner, depth) * 2;
+		if( Main.game.isElasticityAffectDepthEnabled()) {
+			if(elasticity<=3 ) {		
+				//Default original value
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 2);			
+			} else {
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * (float)elasticity/1.5f);
+			}
+		} else {
+			return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 2);
+		}		
 	}
 	
 	@Override

--- a/src/com/lilithsthrone/game/character/body/OrificePenisUrethra.java
+++ b/src/com/lilithsthrone/game/character/body/OrificePenisUrethra.java
@@ -13,6 +13,7 @@ import com.lilithsthrone.game.character.body.valueEnums.OrificeModifier;
 import com.lilithsthrone.game.character.body.valueEnums.OrificePlasticity;
 import com.lilithsthrone.game.character.body.valueEnums.Wetness;
 import com.lilithsthrone.game.dialogue.utils.UtilText;
+import com.lilithsthrone.main.Main;
 
 /**
  * @since 0.1.?
@@ -154,7 +155,16 @@ public class OrificePenisUrethra implements OrificeInterface {
 	
 	@Override
 	public int getMaximumPenetrationDepthUncomfortable(GameCharacter owner, OrificeDepth depth) {
-		return getMaximumPenetrationDepthComfortable(owner, depth) * 2;
+		if( Main.game.isElasticityAffectDepthEnabled()) {
+			if(elasticity<=3 ) {		
+				//Default original value
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 2);			
+			} else {
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * (float)elasticity/1.5f);
+			}
+		} else {
+			return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 2);
+		}
 	}
 
 	@Override

--- a/src/com/lilithsthrone/game/character/body/OrificeVagina.java
+++ b/src/com/lilithsthrone/game/character/body/OrificeVagina.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.lilithsthrone.game.PropertyValue;
 import com.lilithsthrone.game.character.GameCharacter;
 import com.lilithsthrone.game.character.body.types.OrificeInterface;
 import com.lilithsthrone.game.character.body.valueEnums.Capacity;
@@ -13,6 +14,7 @@ import com.lilithsthrone.game.character.body.valueEnums.OrificeModifier;
 import com.lilithsthrone.game.character.body.valueEnums.OrificePlasticity;
 import com.lilithsthrone.game.character.body.valueEnums.Wetness;
 import com.lilithsthrone.game.dialogue.utils.UtilText;
+import com.lilithsthrone.main.Main;
 
 /**
  * @since 0.1.?
@@ -189,7 +191,16 @@ public class OrificeVagina implements OrificeInterface {
 	
 	@Override
 	public int getMaximumPenetrationDepthUncomfortable(GameCharacter owner, OrificeDepth depth) {
-		return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 1.5f);
+		if( Main.game.isElasticityAffectDepthEnabled()) {
+			if(elasticity<=3 ) {		
+				//Default original value
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 1.5f);			
+			} else {
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * (float)elasticity/1.8f);
+			}
+		} else {
+			return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 1.5f);
+		}
 	}
 
 	@Override

--- a/src/com/lilithsthrone/game/character/body/OrificeVaginaUrethra.java
+++ b/src/com/lilithsthrone/game/character/body/OrificeVaginaUrethra.java
@@ -13,6 +13,7 @@ import com.lilithsthrone.game.character.body.valueEnums.OrificeModifier;
 import com.lilithsthrone.game.character.body.valueEnums.OrificePlasticity;
 import com.lilithsthrone.game.character.body.valueEnums.Wetness;
 import com.lilithsthrone.game.dialogue.utils.UtilText;
+import com.lilithsthrone.main.Main;
 
 /**
  * @since 0.1.?
@@ -151,7 +152,16 @@ public class OrificeVaginaUrethra implements OrificeInterface {
 	
 	@Override
 	public int getMaximumPenetrationDepthUncomfortable(GameCharacter owner, OrificeDepth depth) {
-		return getMaximumPenetrationDepthComfortable(owner, depth) * 2;
+		if( Main.game.isElasticityAffectDepthEnabled()) {
+			if(elasticity<=3 ) {		
+				//Default original value
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 2);			
+			} else {
+				return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * (float)elasticity/1.5f);
+			}
+		} else {
+			return (int) (getMaximumPenetrationDepthComfortable(owner, depth) * 2);
+		}
 	}
 
 	@Override

--- a/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
@@ -2145,6 +2145,13 @@ public class OptionsDialogue {
 							Main.getProperties().hasValue(PropertyValue.penetrationLimitations)));
 			
 			UtilText.nodeContentSB.append(getContentPreferenceDiv(ContentOptionsPage.SEX,
+							"PENETRATION_LIMITATION_DYNAMIC",
+							PresetColour.BASE_PINK_DEEP,
+							"Elasticity Affect Depth",
+							"When enabled, the elasticity of an orifice will affect it's depth so that you can accommodate longuer sizes.(Require Penetrative size-difference)",
+							Main.getProperties().hasValue(PropertyValue.elasticityAffectDepth)));
+			
+			UtilText.nodeContentSB.append(getContentPreferenceDiv(ContentOptionsPage.SEX,
 							"FOOT",
 							PresetColour.BASE_TAN,
 							"Foot Content",


### PR DESCRIPTION
### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
I didn't like that you had to have a cavernous pussy(or other orifices) in order to accommodate a longer dick so I attached all the orifice to elasticity since I felt that it could make sense that an elastic orifice can accommodate not only larger but longer penetrative object

- Give a brief description of what you changed or added.
1. Added an ON/OFF setting to enable the feature(default off)
1. Change all the orifice uncomfortable value to return different depth depending on the elasticity with a minimum value of the default value, also set the modifier value to something that I felt was not overly exaggerated

- Are any new graphical assets required?
none

- Has this change been tested? If so, mention the version number that the test was based on.
Tested in 0.3.9.9

- So we have a better idea of who you are, what is your Discord Handle?
LightCanadian

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
