### PR TITLE
Save character list for each call when parsing

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -895,7 +895,9 @@ public class UtilText {
 	 * Parses supplied text.
 	 */
 	public static String parse(List<GameCharacter> specialNPC, String input, boolean xmlParsing, List<ParserTag> tags) {
+		List<GameCharacter> parsingCharactersForSpeechSaved;
 		parserTags = (tags);
+		parsingCharactersForSpeechSaved = parsingCharactersForSpeech;
 		parsingCharactersForSpeech = specialNPC;
 		
 		if(Main.game!=null && Main.game.getCurrentDialogueNode()==DebugDialogue.PARSER) {
@@ -1202,6 +1204,7 @@ public class UtilText {
 			
 			if (startIndex != 0) {
 				System.err.println("Error in parsing: StartIndex:"+startIndex+" ("+target+", "+command+") - "+input.substring(startIndex, Math.min(input.length()-1, startIndex+20)));
+				parsingCharactersForSpeech = parsingCharactersForSpeechSaved;
 				return input;
 			}
 			if (startedParsingSegmentAt < input.length()) {
@@ -1212,12 +1215,14 @@ public class UtilText {
 			
 			//TODO This really should be somewhere else or handled differently...
 			result = result.replaceAll("german", "German"); // This is needed as the subspecies 'german-shepherd-morph' needs to use a lowercase 'g' for generic name determiner detection.
-			
+
+			parsingCharactersForSpeech = parsingCharactersForSpeechSaved;
 			return result;
 			
 		} catch(Exception ex) {
 			System.err.println("Failed to parse: "+input);
 			ex.printStackTrace();
+			parsingCharactersForSpeech = parsingCharactersForSpeechSaved;
 			return "";
 		}
 	}


### PR DESCRIPTION
- What is the purpose of the pull request?

Fix the bug where characters get lost when parsing speech, leading to parserTarget.Character() not found! errors.

- Give a brief description of what you changed or added.

Save the current list of characters for parsing, and restore it when the parsing is done, so that calling parse recursively works properly

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with 3.9.9.9

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930