### PR TITLE
Add option for mute slaves in custom slave shop

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/places/dominion/slaverAlley/ScarlettsShop.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/slaverAlley/ScarlettsShop.java
@@ -2956,7 +2956,7 @@ public class ScarlettsShop {
 			sb.append("<div class='cosmetics-container' style='background:transparent;'>"
 						+ CharacterModificationUtils.getAgeChoiceDiv()
 						+ CharacterModificationUtils.getOrientationChoiceDiv()
-						+ CharacterModificationUtils.getPersonalityChoiceDiv()
+						+ CharacterModificationUtils.getPersonalityChoiceDiv(true)
 						+ CharacterModificationUtils.getObedienceChoiceDiv()
 						+ CharacterModificationUtils.getAffectionChoiceDiv()
 						+ CharacterModificationUtils.getFetishChoiceDiv()

--- a/src/com/lilithsthrone/game/dialogue/story/CharacterCreation.java
+++ b/src/com/lilithsthrone/game/dialogue/story/CharacterCreation.java
@@ -690,7 +690,7 @@ public class CharacterCreation {
 						
 						+ CharacterModificationUtils.getOrientationChoiceDiv()
 						
-						+ CharacterModificationUtils.getPersonalityChoiceDiv()
+						+ CharacterModificationUtils.getPersonalityChoiceDiv(false)
 						
 					+"</div>";
 		}

--- a/src/com/lilithsthrone/game/dialogue/utils/BodyChanging.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/BodyChanging.java
@@ -879,12 +879,6 @@ public class BodyChanging {
 						
 						+ CharacterModificationUtils.getSelfDivHairStyles("Hair Style", UtilText.parse(BodyChanging.getTarget(), "Change [npc.namePos] hair style."))
 						
-						+ CharacterModificationUtils.getKatesDivCoveringsNew(false, BodyChanging.getTarget().getCovering(BodyCoveringType.TONGUE).getType(), "Tongue colour",
-								(BodyChanging.getTarget().isPlayer()
-										?"The colour of your tongue."
-										:UtilText.parse(BodyChanging.getTarget(), "The colour of [npc.namePos] tongue.")),
-								true, true)
-						
 						+ CharacterModificationUtils.getKatesDivCoveringsNew(false, BodyChanging.getTarget().getCovering(BodyChanging.getTarget().getHairCovering()).getType(), "Hair colour",
 								(BodyChanging.getTarget().isPlayer()
 										?"Change the colour of your hair."

--- a/src/com/lilithsthrone/game/dialogue/utils/CharacterModificationUtils.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/CharacterModificationUtils.java
@@ -320,7 +320,7 @@ public class CharacterModificationUtils {
 		return contentSB.toString();
 	}
 	
-	public static String getPersonalityChoiceDiv() {
+	public static String getPersonalityChoiceDiv(boolean allowSpecials) {
 		contentSB.setLength(0);
 		
 		contentSB.append("<div class='container-full-width' style='text-align:center;'>");
@@ -335,7 +335,7 @@ public class CharacterModificationUtils {
 				}
 				
 				for(PersonalityTrait trait : PersonalityTrait.values()) {
-					if(!trait.isSpecialRequirements()) {
+					if(allowSpecials || !trait.isSpecialRequirements()) {
 						if(BodyChanging.getTarget().hasPersonalityTrait(trait)) {
 							contentSB.append(
 									"<div id='PERSONALITY_TRAIT_"+trait+"' class='cosmetics-button active'>"


### PR DESCRIPTION
- What is the purpose of the pull request?

Add the option for a slave to be mute to Helena's custom slave shop.

fix #1349

- Give a brief description of what you changed or added.

Added a boolean to allow specials in getPersonalityChoiceDiv. Currently only Mute is a special.

Also removed the option to change tongue colour in the Hair options tab (probably a copy/paste error).

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested in 3.9.9.9. Slaves can now be mute, the main character cannot be mute.

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930

After merging this PR issue #1349 Customise Slave can be closed.