### PR TITLE
Increase lust when the partner of a noncon fetishist is resisting

### DIFF
--- a/src/com/lilithsthrone/game/sex/Sex.java
+++ b/src/com/lilithsthrone/game/sex/Sex.java
@@ -2366,18 +2366,26 @@ public class Sex {
 		if(Main.sex.getSexPace(activeCharacter)==SexPace.SUB_RESISTING && !activeCharacter.getFetishDesire(Fetish.FETISH_NON_CON_SUB).isPositive()) {
 			lustIncrements.put(activeCharacter, -2.5f);
 		} else {
-			lustIncrements.put(activeCharacter, Math.min(2.5f, Math.max(-2.5f, sexAction.getArousalGainSelf().getArousalIncreaseValue())));
+			if (activeCharacter.getFetishDesire(Fetish.FETISH_NON_CON_DOM).isPositive() && Main.sex.getSexPace(targetCharacter) == SexPace.SUB_RESISTING) {
+				lustIncrements.put(activeCharacter, 2.5f);
+			} else {
+				lustIncrements.put(activeCharacter, Math.min(2.5f, Math.max(-2.5f, sexAction.getArousalGainSelf().getArousalIncreaseValue())));
+			}
 		}
 		lustIncrements.put(activeCharacter, lustIncrements.get(activeCharacter) + (activeCharacter.getAffection(targetCharacter)/40)); //+-2.5
 		
 		if(Main.sex.getSexPace(targetCharacter)==SexPace.SUB_RESISTING && !targetCharacter.getFetishDesire(Fetish.FETISH_NON_CON_SUB).isPositive()) {
 			lustIncrements.put(targetCharacter, -2.5f);
 		} else {
-			lustIncrements.put(targetCharacter, Math.min(2.5f, Math.max(-2.5f, sexAction.getArousalGainTarget().getArousalIncreaseValue())));
+			if (targetCharacter.getFetishDesire(Fetish.FETISH_NON_CON_DOM).isPositive() && Main.sex.getSexPace(activeCharacter) == SexPace.SUB_RESISTING) {
+				lustIncrements.put(targetCharacter, 2.5f);
+			} else {
+				lustIncrements.put(targetCharacter, Math.min(2.5f, Math.max(-2.5f, sexAction.getArousalGainTarget().getArousalIncreaseValue())));
+			}
 		}
 		lustIncrements.put(targetCharacter, lustIncrements.get(targetCharacter) + (targetCharacter.getAffection(activeCharacter)/40)); //+-2.5
 
-		
+
 		// Arousal increments for related status effects:
 		for(AbstractStatusEffect se : activeCharacter.getStatusEffects()) {
 			if(se.isSexEffect()) {


### PR DESCRIPTION
- What is the purpose of the pull request?

Characters with the NON_CON_DOM fetish will gain lust when having sex with someone that is resisting.

fix #1347

- Give a brief description of what you changed or added.

Add a positive lust gain in this situation. 

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with version 3.9.9.9 (with the save file attached to issue #1347 Non-consent bug)

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930

After this PR is merged, issue #1347 Non-consent bug can be closed.