### PR TITLE
Disallow access to equipped items while enchanting

### DIFF
--- a/src/com/lilithsthrone/controller/eventListeners/InventorySelectedItemEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/InventorySelectedItemEventListener.java
@@ -1,5 +1,6 @@
 package com.lilithsthrone.controller.eventListeners;
 
+import com.lilithsthrone.game.dialogue.utils.EnchantmentDialogue;
 import org.w3c.dom.events.Event;
 import org.w3c.dom.events.EventListener;
 
@@ -41,10 +42,11 @@ public class InventorySelectedItemEventListener implements EventListener {
 //		if (Main.game.getCurrentDialogueNode().getDialogueNodeType() == DialogueNodeType.CHARACTERS_PRESENT
 //				|| Main.game.getCurrentDialogueNode().getDialogueNodeType() == DialogueNodeType.PHONE
 //				|| Main.game.getCurrentDialogueNode().getDialogueNodeType() == DialogueNodeType.OCCUPANT_MANAGEMENT) {
-		if(Main.game.getCurrentDialogueNode().getDialogueNodeType()!=DialogueNodeType.INVENTORY
+		if(Main.game.getCurrentDialogueNode()==EnchantmentDialogue.ENCHANTMENT_MENU
+			|| (Main.game.getCurrentDialogueNode().getDialogueNodeType()!=DialogueNodeType.INVENTORY
 				&& (!Main.game.isInSex() || Main.game.getCurrentDialogueNode().isInventoryDisabled())
 				&& !Main.game.isInCombat()
-				&& (clothingEquipped!=null || weaponEquipped!=null)) {
+				&& (clothingEquipped!=null || weaponEquipped!=null))) {
 			return;
 		}
 		


### PR DESCRIPTION
- What is the purpose of the pull request?

Fix the bug where clicking on an equipped item while enchanting during a trading session gives you full access to the inventory of the trader, allowing to take all their equipped items and the items in their inventory.

- Give a brief description of what you changed or added.

The InventorySelectedItemEventListener will do nothing when you are in the ENCHANTMENT_MENU. I.e. when you now click an equipped item while enchanting, nothing will happen.
Since you can never enchant equipped items, this action is not needed anyway.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with 3.9.9

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930