### PR TITLE
Added check for fertility pills, including broodmother

### DIFF
--- a/res/txt/encounters/dominion/generic.xml
+++ b/res/txt/encounters/dominion/generic.xml
@@ -100,7 +100,7 @@
 		As you walk down Dominion's wide boulevard, an exceptionally happy-looking [#SPECIAL_PARSE_0] bounces up in front of you, blocking your way. After taking note of the fact that she looks to be having the time of her life, you observe that she has a large, rounded tummy, and is quite clearly heavily pregnant. Before you can ask her to move aside, she exclaims, in a voice just as bubbly and enthusiastic as you'd imagine, [genericFemale.speech(Isn't Mother's week just the most wonderful time of year?! I'm already expecting [#SPECIAL_PARSE_1]! I couldn't be happier!)]
 	</p>
 	<p>
-		With this unsolicited information now having been delivered to you, the [#SPECIAL_PARSE_0] reaches into the wicker basket which she's carrying, before grabbing a handful of little pink pills and forcefully thrusting them into your [pc.hands].
+		With this unsolicited information now having been delivered to you, the [#SPECIAL_PARSE_0] reaches into the wicker basket which she's carrying, before grabbing a handful of little purple pills and forcefully thrusting them into your [pc.hands].
 		#IF(pc.isFeminine())
 			#IF(pc.isVisiblyPregnant())
 			 [genericFemale.speech(Already got a bun or two in the oven, I see! Well, once you've got them popped out, you can use these pills to make sure that you'll quickly get knocked up again!)]
@@ -125,7 +125,7 @@
 		As you walk down Dominion's wide boulevard, a tall, handsome [#SPECIAL_PARSE_0] suddenly steps up in front of you, blocking your way. Before you can ask him to step aside, he grins, and in a deep, booming voice, declares, [genericMale.speech(Father's week is the best time of year, isn't it?! I've already knocked up a dozen or so mothers-to-be!)]
 	</p>
 	<p>
-		With this unsolicited information now having been delivered to you, the [#SPECIAL_PARSE_0] reaches into the bum bag which he's got strapped around his waist, before grabbing a handful of little pink pills and forcefully thrusting them into your [pc.hands].
+		With this unsolicited information now having been delivered to you, the [#SPECIAL_PARSE_0] reaches into the bum bag which he's got strapped around his waist, before grabbing a handful of little purple pills and forcefully thrusting them into your [pc.hands].
 		#IF(pc.isFeminine())
 			#IF(pc.isCoverableAreaExposed(CA_PENIS) && pc.hasPenisIgnoreDildo())
 			 [genericMale.speech(Here you go, babe! I see you're packing, so just pop one of these before you give your next fuck a nice big creampie, and you're sure to become a father!)]

--- a/res/txt/places/dominion/slaverAlley/genericDialogue.xml
+++ b/res/txt/places/dominion/slaverAlley/genericDialogue.xml
@@ -1164,7 +1164,7 @@
 		[sean.speech(You're a really kinky [pc.girl], you know that, right?)] the [sean.race] asks as he hears your suggestion. Asking him if he's willing to do it or not, you can't help but grin as he replies, [sean.speech(Of course I'll do it! If you're looking to get bred, though, then you're going to be wanting to take a [#ITEM_innoxia_pills_fertility.getName(false)]; it'll make your womb nice and fertile.)]
 	</p>
 	<p>
-		Producing a small pink pill from out of one of his pockets, [sean.name] pops it out of its protective wrapper and holds it up to your mouth. Leaning forwards and opening your mouth, you allow the [sean.race] to place it onto your outstretched tongue, and with a quick smile, you gulp it down.
+		Producing a small purple pill from out of one of his pockets, [sean.name] pops it out of its protective wrapper and holds it up to your mouth. Leaning forwards and opening your mouth, you allow the [sean.race] to place it onto your outstretched tongue, and with a quick smile, you gulp it down.
 	</p>
 	<p>
 		[sean.speech(Good [pc.girl]! Now, let's have you put on a show for the public!)] [sean.name] exclaims, before helping you to strip out of your clothes. Leading you over to the nearest set of stocks, the [sean.race] quickly locks you in, before stepping around behind you and teasing, [sean.speech(Mmm, that's one fine-looking pussy!)]
@@ -1238,7 +1238,7 @@
 		[sean.speech(You're a really kinky [pc.girl], you know that, right?)] the [sean.race] asks as he hears your suggestion. Asking him if he's willing to do it or not, you can't help but grin as he replies, [sean.speech(Of course I'll do it! If you're looking to get bred, though, then you're both going to want to take a [#ITEM_innoxia_pills_fertility.getName(false)]; it'll make your wombs nice and fertile.)]
 	</p>
 	<p>
-		Producing two small pink pills from out of one of his pockets, [sean.name] pops them out of their protective wrappers and holds them up to you and [com.name]. Leaning forwards and opening your mouth, you allow the [sean.race] to place one of them onto your outstretched tongue, and with a quick smile, you gulp it down. Following your lead, your [com.companion] does the same thing, and lets out an exited [com.moan] as [com.she] swallows down the fertility-enhancing pill.
+		Producing two small purple pills from out of one of his pockets, [sean.name] pops them out of their protective wrappers and holds them up to you and [com.name]. Leaning forwards and opening your mouth, you allow the [sean.race] to place one of them onto your outstretched tongue, and with a quick smile, you gulp it down. Following your lead, your [com.companion] does the same thing, and lets out an exited [com.moan] as [com.she] swallows down the fertility-enhancing pill.
 	</p>
 	#IF(com.equals(brax))
 		<p>
@@ -2135,7 +2135,7 @@
 		Walking around in front of you and [com.name], [sean.name] grins and says, [sean.speech(Now, I was thinking of giving the two of you a choice as to what happens to you. I can always mark you both as being available for public use, or, if you'd like, I could spare you that and keep you all to myself instead.)]
 	</p>
 	<p>
-		Fishing around in his pocket, the [sean.race] produces a pair of small pink pills, and holds them up in front of you and [com.name] as he explains, [sean.speech(Of course, if you want me to keep the public away from you, you'll have to swallow these [#ITEM_innoxia_pills_fertility.getNamePlural(false)] and beg for me to breed you. You'd like me to pound your pussies and fill you with my virile seed, wouldn't you?)]
+		Fishing around in his pocket, the [sean.race] produces a pair of small purple pills, and holds them up in front of you and [com.name] as he explains, [sean.speech(Of course, if you want me to keep the public away from you, you'll have to swallow these [#ITEM_innoxia_pills_fertility.getNamePlural(false)] and beg for me to breed you. You'd like me to pound your pussies and fill you with my virile seed, wouldn't you?)]
 	</p>
 	#IF(game.getDialogueFlags().hasFlag(FLAG_slaverAlleyCompanionAcceptedDeal))
 		#IF(com.equals(brax))
@@ -2155,7 +2155,7 @@
 				#ENDIF
 			</p>
 			<p>
-				Doing as [com.she] asks, [sean.name] pops one of the pink pills out of its protective wrapper, before placing it on [com.namePos] outstretched tongue and then teasing, [sean.speech(Go on then, [com.name], beg for me to breed you!)]
+				Doing as [com.she] asks, [sean.name] pops one of the purple pills out of its protective wrapper, before placing it on [com.namePos] outstretched tongue and then teasing, [sean.speech(Go on then, [com.name], beg for me to breed you!)]
 			</p>
 			<p>
 				Quickly swallowing down the fertility-enhancing pill, your [com.companion] obediently whines,
@@ -2172,7 +2172,7 @@
 				Quick to reply, [com.name] shuffles about a little in [com.her] stocks and admits, [com.speech(Yes, I'd like that... Please, give me the pill and then breed me!)]
 			</p>
 			<p>
-				Doing as [com.she] asks, [sean.name] pops one of the pink pills out of its protective wrapper, before placing it on [com.namePos] outstretched tongue. Quickly swallowing it down, your [com.companion] whines, [com.speech(Please, I need your cock! Just breed me already!)]
+				Doing as [com.she] asks, [sean.name] pops one of the purple pills out of its protective wrapper, before placing it on [com.namePos] outstretched tongue. Quickly swallowing it down, your [com.companion] whines, [com.speech(Please, I need your cock! Just breed me already!)]
 			</p>
 		#ENDIF
 		<p>
@@ -2198,7 +2198,7 @@
 		Walking around in front of you, [sean.name] grins and says, [sean.speech(Now, I was thinking of giving you a choice as to what happens to you. I can always mark you as being available for public use, or, if you'd like, I could spare you that and keep you all to myself instead.)]
 	</p>
 	<p>
-		Fishing around in his pocket, the [sean.race] produces a small pink pill, and holds it up in front of you as he explains, [sean.speech(Of course, if you want me to keep the public away from you, you'll have to swallow this [#ITEM_innoxia_pills_fertility.getName(false)] and beg for me to breed you. You'd like me to pound your pussy and knock you up, wouldn't you?)]
+		Fishing around in his pocket, the [sean.race] produces a small purple pill, and holds it up in front of you as he explains, [sean.speech(Of course, if you want me to keep the public away from you, you'll have to swallow this [#ITEM_innoxia_pills_fertility.getName(false)] and beg for me to breed you. You'd like me to pound your pussy and knock you up, wouldn't you?)]
 	</p>
 	]]>
 	</htmlContent>
@@ -2208,7 +2208,7 @@
 		Walking around in front of [com.name], [sean.name] grins and says, [sean.speech(Now, I was thinking of giving you a choice as to what happens to you. I can always mark you as being available for public use, or, if you'd like, I could spare you that and keep you all to myself instead.)]
 	</p>
 	<p>
-		Fishing around in his pocket, the [sean.race] produces a small pink pill, and holds it up in front of your [com.companion] he explains, [sean.speech(Of course, if you want me to keep the public away from you, you'll have to swallow this [#ITEM_innoxia_pills_fertility.getName(false)] and beg for me to breed you. You'd like me to pound your pussy and knock you up, wouldn't you?)]
+		Fishing around in his pocket, the [sean.race] produces a small purple pill, and holds it up in front of your [com.companion] he explains, [sean.speech(Of course, if you want me to keep the public away from you, you'll have to swallow this [#ITEM_innoxia_pills_fertility.getName(false)] and beg for me to breed you. You'd like me to pound your pussy and knock you up, wouldn't you?)]
 	</p>
 	#IF(game.getDialogueFlags().hasFlag(FLAG_slaverAlleyCompanionAcceptedDeal))
 		#IF(com.equals(brax))
@@ -2228,7 +2228,7 @@
 				#ENDIF
 			</p>
 			<p>
-				Doing as [com.she] asks, [sean.name] pops one of the pink pills out of its protective wrapper, before placing it on [com.namePos] outstretched tongue and then teasing, [sean.speech(Go on then, [com.name], beg for me to breed you!)]
+				Doing as [com.she] asks, [sean.name] pops one of the purple pills out of its protective wrapper, before placing it on [com.namePos] outstretched tongue and then teasing, [sean.speech(Go on then, [com.name], beg for me to breed you!)]
 			</p>
 			<p>
 				Quickly swallowing down the fertility-enhancing pill, your [com.companion] obediently whines,
@@ -2245,7 +2245,7 @@
 				Quick to reply, [com.name] shuffles about a little in [com.her] stocks and admits, [com.speech(Yes, I'd like that... Please, give me the pill and then breed me!)]
 			</p>
 			<p>
-				Doing as [com.she] asks, [sean.name] pops one of the pink pills out of its protective wrapper, before placing it on [com.namePos] outstretched tongue. Quickly swallowing it down, your [com.companion] whines, [com.speech(Please, I need your cock! Just breed me already!)]
+				Doing as [com.she] asks, [sean.name] pops one of the purple pills out of its protective wrapper, before placing it on [com.namePos] outstretched tongue. Quickly swallowing it down, your [com.companion] whines, [com.speech(Please, I need your cock! Just breed me already!)]
 			</p>
 			<p>
 		#ENDIF
@@ -2288,7 +2288,7 @@
 	
 	<htmlContent tag="PUBLIC_STOCKS_LOCKED_UP_ACCEPTED_DEAL"><![CDATA[
 	<p>
-		Deciding that it would be preferable to get bred by [sean.name] rather than having an unknown number of strangers fuck you, you tell the [sean.race] that you accept his deal. Opening your mouth, you allow him to slide the pink pill past your [pc.lips], before gulping it down and opening wide to show him that you've swallowed it.
+		Deciding that it would be preferable to get bred by [sean.name] rather than having an unknown number of strangers fuck you, you tell the [sean.race] that you accept his deal. Opening your mouth, you allow him to slide the purple pill past your [pc.lips], before gulping it down and opening wide to show him that you've swallowed it.
 	</p>
 	<p>
 		[sean.speech(Now, tell me that you want me to breed you,)] [sean.name] says, reminding you of the other part of his deal.

--- a/res/txt/places/submission/gamblingDen/pregnancyRoulette.xml
+++ b/res/txt/places/submission/gamblingDen/pregnancyRoulette.xml
@@ -249,7 +249,7 @@
 		While these horse-girls are getting the breeders warmed up, Epona opens the door beside you and steps forwards into the small room. [epona.speech(Heya! Look at all those cocks lined up just for you! So, which one do you think's gonna be the one to knock you up? Remember, after you've chosen, I'll roll dice to see in what order they get to use your pussy. Oh, and I almost forgot! You need to take a [#ITEM_innoxia_pills_fertility.getName(false)]!)]
 	</p>
 	<p>
-		Epona hands you a little pink pill, which you quickly swallow. You then turn to look over the six futas before you, and after Epona's pointed out each one and told you her name, you decide upon the futa that you think will be the father of your kids...
+		Epona hands you a little purple pill, which you quickly swallow. You then turn to look over the six futas before you, and after Epona's pointed out each one and told you her name, you decide upon the futa that you think will be the father of your kids...
 	</p>
 	]]>
 	</htmlContent>
@@ -293,7 +293,7 @@
 		While these horse-girls are getting the breeders warmed up, Epona opens the door beside you and steps forwards into the small room. [epona.speech(Heya! Look at all those cocks lined up just for you! So, which one do you think's gonna be the one to knock you up? Remember, after you've chosen, I'll roll dice to see in what order they get to use your pussy. Oh, and I almost forgot! You need to take a [#ITEM_innoxia_pills_fertility.getName(false)]!)]
 	</p>
 	<p>
-		Epona hands you a little pink pill, which you quickly swallow. You then turn to look over the six guys before you, and after Epona's pointed out each one and told you his name, you decide upon the guy that you think will be the father of your kids...
+		Epona hands you a little purple pill, which you quickly swallow. You then turn to look over the six guys before you, and after Epona's pointed out each one and told you his name, you decide upon the guy that you think will be the father of your kids...
 	</p>
 	]]>
 	</htmlContent>

--- a/src/com/lilithsthrone/game/character/CharacterUtils.java
+++ b/src/com/lilithsthrone/game/character/CharacterUtils.java
@@ -2231,9 +2231,13 @@ public class CharacterUtils {
 		
 		if(character.getFetishDesire(Fetish.FETISH_PREGNANCY).isPositive() && !character.isPregnant() && character.hasVagina()) {
 			character.addItem(Main.game.getItemGen().generateItem("innoxia_pills_fertility"), 2+Util.random.nextInt(4), false, false);
+			if(Math.random()<0.2f) {
+				character.addItem(Main.game.getItemGen().generateItem("innoxia_pills_broodmother"), 1+Util.random.nextInt(2), false, false);}
 		}
 		if(character.getFetishDesire(Fetish.FETISH_IMPREGNATION).isPositive() && character.hasPenisIgnoreDildo()) {
 			character.addItem(Main.game.getItemGen().generateItem("innoxia_pills_fertility"), 2+Util.random.nextInt(4), false, false);
+			if(Math.random()<0.2f) {
+				character.addItem(Main.game.getItemGen().generateItem("innoxia_pills_broodmother"), 1+Util.random.nextInt(2), false, false);}
 		}
 
 		if(character.getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative() && !character.isPregnant() && character.hasVagina()) {

--- a/src/com/lilithsthrone/game/character/npc/dominion/Cultist.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Cultist.java
@@ -307,7 +307,7 @@ public class Cultist extends NPC {
 							+ "</p>");
 				}
 					
-			} else if(item.isFertilityPill()) {
+			} else if(item.isTypeOneOf("innoxia_pills_fertility", "innoxia_pills_broodmother")) {
 				Main.game.getPlayer().useItem(item, target, false);
 				if(Main.sex.isDom(Main.game.getPlayer())) {
 					return new Value<>(true,

--- a/src/com/lilithsthrone/game/character/npc/dominion/Cultist.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Cultist.java
@@ -307,14 +307,14 @@ public class Cultist extends NPC {
 							+ "</p>");
 				}
 					
-			} else if(item.getItemType().equals(ItemType.getItemTypeFromId("innoxia_pills_fertility"))) {
+			} else if(item.isFertilityPill()) {
 				Main.game.getPlayer().useItem(item, target, false);
 				if(Main.sex.isDom(Main.game.getPlayer())) {
 					return new Value<>(true,
 							"<p>"
 								+ UtilText.parse(user, target,
-									"Holding out a '[#ITEM_innoxia_pills_fertility.getName(false)]' to [npc2.name], you tell [npc2.herHim] to swallow it."
-									+ " [npc2.She] lets out a delighted cry, and eagerly swallows the little pink pill,"
+									"Holding out a "+item.getName(false, false)+" to [npc2.name], you tell [npc2.herHim] to swallow it."
+									+ " [npc2.She] lets out a delighted cry, and eagerly swallows the little "+item.getColour(0).getName()+" pill,"
 									+ " [npc2.speech(Thank you! Being as fertile as possible is one of the best ways in which to worship Lilith!)]")
 							+ "</p>");
 					
@@ -322,8 +322,8 @@ public class Cultist extends NPC {
 					return new Value<>(true,
 							"<p>"
 								+ UtilText.parse(user, target,
-									"Holding out a '[#ITEM_innoxia_pills_fertility.getName(false)]' to [npc2.name], you ask [npc2.herHim] to swallow it."
-									+ " [npc2.She] lets out a delighted cry, and eagerly swallows the little pink pill,"
+									"Holding out a "+item.getName(false, false)+" to [npc2.name], you ask [npc2.herHim] to swallow it."
+									+ " [npc2.She] lets out a delighted cry, and eagerly swallows the little "+item.getColour(0).getName()+" pill,"
 									+ " [npc2.speech(Good toy! Being as fertile as possible is one of the best ways in which to worship Lilith!)]")
 							+ "</p>");
 				}

--- a/src/com/lilithsthrone/game/character/npc/dominion/Elle.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Elle.java
@@ -378,10 +378,10 @@ public class Elle extends NPC {
 	@Override
 	public Value<Boolean, String> getItemUseEffects(AbstractItem item,  GameCharacter itemOwner, GameCharacter user, GameCharacter target) {
 		if(user.isPlayer() && !target.isPlayer()) {
-			if(item.getItemType().equals(ItemType.getItemTypeFromId("innoxia_pills_fertility")) || item.getItemType().equals(ItemType.getItemTypeFromId("innoxia_pills_broodmother"))) {
+			if(item.isFertilityPill()) {
 				return new Value<>(true,
 						"<p>"
-							+ "Producing "+item.getName(true, false)+" from your inventory, you prepare to offer it to Elle, but before you can even get that far, the [elle.race] sees what it is you're holding and declares,"
+							+ "Producing a "+item.getName(false, false)+" from your inventory, you prepare to offer it to Elle, but before you can even get that far, the [elle.race] sees what it is you're holding and declares,"
 							+ " [elle.speechNoEffects(There's no way I'm taking that! I have absolutely zero intention of ever getting pregnant, thank you very much!)]"
 						+ "</p>"
 						+ "<p>"

--- a/src/com/lilithsthrone/game/character/npc/dominion/Elle.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Elle.java
@@ -378,7 +378,7 @@ public class Elle extends NPC {
 	@Override
 	public Value<Boolean, String> getItemUseEffects(AbstractItem item,  GameCharacter itemOwner, GameCharacter user, GameCharacter target) {
 		if(user.isPlayer() && !target.isPlayer()) {
-			if(item.isFertilityPill()) {
+			if(item.isTypeOneOf("innoxia_pills_fertility", "innoxia_pills_broodmother")) {
 				return new Value<>(true,
 						"<p>"
 							+ "Producing a "+item.getName(false, false)+" from your inventory, you prepare to offer it to Elle, but before you can even get that far, the [elle.race] sees what it is you're holding and declares,"

--- a/src/com/lilithsthrone/game/character/npc/dominion/Kate.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Kate.java
@@ -487,12 +487,12 @@ public class Kate extends NPC {
 	@Override
 	public Value<Boolean, String> getItemUseEffects(AbstractItem item,  GameCharacter itemOwner, GameCharacter user, GameCharacter target) {
 		if(user.isPlayer() && !target.isPlayer()) {
-			if(item.getItemType().equals(ItemType.getItemTypeFromId("innoxia_pills_fertility"))) {
+			if(item.isFertilityPill()) {
 				itemOwner.useItem(item, target, false);
 				return new Value<>(true,
 						"<p>"
-							+ "Producing a '[#ITEM_innoxia_pills_fertility.getName(false)]' from your inventory, you pop it out of its plastic wrapper before pushing it into Kate's mouth."
-							+ " She giggles as she happily swallows the little pink pill, knowing that it's going to make her womb far more fertile."
+							+ "Producing a "+item.getName(false, false)+" from your inventory, you pop it out of its plastic wrapper before pushing it into Kate's mouth."
+							+ " She giggles as she happily swallows the little "+item.getColour(0).getName()+" pill, knowing that it's going to make her womb far more fertile."
 						+ "</p>");
 			} else {
 				return new Value<>(false,

--- a/src/com/lilithsthrone/game/character/npc/dominion/Kate.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Kate.java
@@ -487,7 +487,7 @@ public class Kate extends NPC {
 	@Override
 	public Value<Boolean, String> getItemUseEffects(AbstractItem item,  GameCharacter itemOwner, GameCharacter user, GameCharacter target) {
 		if(user.isPlayer() && !target.isPlayer()) {
-			if(item.isFertilityPill()) {
+			if(item.isTypeOneOf("innoxia_pills_fertility", "innoxia_pills_broodmother")) {
 				itemOwner.useItem(item, target, false);
 				return new Value<>(true,
 						"<p>"

--- a/src/com/lilithsthrone/game/character/npc/dominion/Lilaya.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Lilaya.java
@@ -445,12 +445,12 @@ public class Lilaya extends NPC {
 	
 	@Override
 	public Value<Boolean, String> getItemUseEffects(AbstractItem item, GameCharacter itemOwner, GameCharacter user, GameCharacter target) {
-		if(user.isPlayer() && !target.isPlayer() && item.getItemType().equals(ItemType.getItemTypeFromId("innoxia_pills_fertility"))) {
+		if(user.isPlayer() && !target.isPlayer() && item.isFertilityPill()) {
 			if(this.getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()) {
-				itemOwner.removeItemByType(ItemType.getItemTypeFromId("innoxia_pills_fertility"));
+				itemOwner.removeItem(item);
 				return new Value<>(false,
 						"<p>"
-							+ "Producing a '[#ITEM_innoxia_pills_fertility.getName(false)]' from your inventory, you pop it out of its plastic wrapper before bringing it up to Lilaya's mouth."
+							+ "Producing a "+item.getColour(0).getName()+" "+item.getName(false, false)+" from your inventory, you pop it out of its plastic wrapper before bringing it up to Lilaya's mouth."
 							+ " Seeing what it is you're trying to get her to swallow, she furrows her eyebrows and smacks the pill out of your [pc.hand], sending it flying off under one of the lab tables."
 							+ " In a sharp tone, she admonishes you, "
 							+ (this.hasPenis()
@@ -462,8 +462,8 @@ public class Lilaya extends NPC {
 				itemOwner.useItem(item, this, false);
 				return new Value<>(true,
 						"<p>"
-							+ "Producing a '[#ITEM_innoxia_pills_fertility.getName(false)]' from your inventory, you pop it out of its plastic wrapper before pushing it into Lilaya's mouth."
-							+ " She lets out a delighted moan as she happily swallows the little pink pill, [lilaya.speechNoEffects(~Mmm!~ That's right, make my demonic womb nice and fertile! I don't hate getting pregnant anymore...)]"
+							+ "Producing a "+item.getName(false, false)+" from your inventory, you pop it out of its plastic wrapper before pushing it into Lilaya's mouth."
+							+ " She lets out a delighted moan as she happily swallows the little "+ item.getColour(0).getName() +" pill, [lilaya.speechNoEffects(~Mmm!~ That's right, make my demonic womb nice and fertile! I don't hate getting pregnant anymore...)]"
 						+ "</p>");
 			}
 		}

--- a/src/com/lilithsthrone/game/character/npc/dominion/Lilaya.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Lilaya.java
@@ -445,7 +445,7 @@ public class Lilaya extends NPC {
 	
 	@Override
 	public Value<Boolean, String> getItemUseEffects(AbstractItem item, GameCharacter itemOwner, GameCharacter user, GameCharacter target) {
-		if(user.isPlayer() && !target.isPlayer() && item.isFertilityPill()) {
+		if(user.isPlayer() && !target.isPlayer() && item.isTypeOneOf("innoxia_pills_fertility", "innoxia_pills_broodmother")) {
 			if(this.getFetishDesire(Fetish.FETISH_PREGNANCY).isNegative()) {
 				itemOwner.removeItem(item);
 				return new Value<>(false,

--- a/src/com/lilithsthrone/game/character/npc/dominion/Ralph.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Ralph.java
@@ -530,13 +530,13 @@ public class Ralph extends NPC {
 	@Override
 	public Value<Boolean, String> getItemUseEffects(AbstractItem item, GameCharacter itemOwner, GameCharacter user, GameCharacter target) {
 		if(user.isPlayer() && !target.isPlayer()) {
-			if(item.getItemType().equals(ItemType.getItemTypeFromId("innoxia_pills_fertility"))) {
+			if(item.isFertilityPill()) {
 				itemOwner.useItem(item, target, false);
 				
 				if(Main.sex.getOngoingSexAreas(Main.game.getPlayer(), SexAreaOrifice.MOUTH, Main.game.getNpc(Ralph.class)).contains(SexAreaPenetration.PENIS)) {
 					return new Value<>(true,
 							"<p>"
-								+ "You pull out a '[#ITEM_innoxia_pills_fertility.getName(false)]' from your inventory, and, making a muffled questioning sound, hold it up to Ralph."
+								+ "You pull out a "+item.getName(false, false)+" from your inventory, and, making a muffled questioning sound, hold it up to Ralph."
 								+ " He looks down at you, letting out a little laugh and shrugging his shoulders as he sees what you're trying to give him."
 								+ " Quickly popping the pill out of its plastic container, he swallows it, and you let out a happy, although somewhat muffled, giggle, knowing that his sperm just got a lot more potent."
 							+ "</p>");
@@ -544,7 +544,7 @@ public class Ralph extends NPC {
 				} else if(Main.sex.getOngoingSexAreas(Main.game.getPlayer(), SexAreaOrifice.VAGINA, Main.game.getNpc(Ralph.class)).contains(SexAreaPenetration.PENIS)) {
 					return new Value<>(true,
 							"<p>"
-								+ "As Ralph carries on slamming his huge cock in and out of your pussy, you fumble around in your inventory and produce a '[#ITEM_innoxia_pills_fertility.getName(false)]'."
+								+ "As Ralph carries on slamming his huge cock in and out of your pussy, you fumble around in your inventory and produce a "+item.getName(false, false)+"."
 								+ " Suppressing your moans, you turn back, holding out your hand as you ask him to swallow it."
 								+ " He lets out a little laugh as he sees what you're giving him, and, quickly popping the pill out of its plastic container and swallowing it,"
 								+ " he takes a moment to say a few words before continuing to fuck you, "
@@ -558,7 +558,7 @@ public class Ralph extends NPC {
 				} else if(Main.sex.getOngoingSexAreas(Main.game.getPlayer(), SexAreaOrifice.ANUS, Main.game.getNpc(Ralph.class)).contains(SexAreaPenetration.PENIS)) {
 					return new Value<>(true,
 								"<p>"
-									+ "As Ralph carries on slamming his huge cock in and out of your ass, you fumble around in your inventory and produce a '[#ITEM_innoxia_pills_fertility.getName(false)]'."
+									+ "As Ralph carries on slamming his huge cock in and out of your ass, you fumble around in your inventory and produce a "+item.getName(false, false)+"."
 									+ " Suppressing your groans, you turn back, holding out your hand as you ask him to swallow it."
 									+ " He lets out a little laugh as he sees what you're giving him, and, quickly popping the pill out of its plastic container and swallowing it,"
 									+ " he takes a moment to say a few words before continuing to fuck you, "
@@ -568,7 +568,7 @@ public class Ralph extends NPC {
 				} else {
 					return new Value<>(true,
 							"<p>"
-								+ "Producing a '[#ITEM_innoxia_pills_fertility.getName(false)]' from your inventory, you lean forwards, looking up at Ralph and asking him to swallow it as you hold it up to him."
+								+ "Producing a "+item.getName(false, false)+" from your inventory, you lean forwards, looking up at Ralph and asking him to swallow it as you hold it up to him."
 									+ " He looks down at you, letting out a little laugh and shrugging his shoulders as he sees what you're trying to give him."
 									+ " Quickly popping the pill out of its plastic container, he swallows it, and you let out a happy giggle, knowing that his sperm just got a lot more potent."
 							+ "</p>");

--- a/src/com/lilithsthrone/game/character/npc/dominion/Ralph.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Ralph.java
@@ -530,7 +530,7 @@ public class Ralph extends NPC {
 	@Override
 	public Value<Boolean, String> getItemUseEffects(AbstractItem item, GameCharacter itemOwner, GameCharacter user, GameCharacter target) {
 		if(user.isPlayer() && !target.isPlayer()) {
-			if(item.isFertilityPill()) {
+			if(item.isTypeOneOf("innoxia_pills_fertility", "innoxia_pills_broodmother")) {
 				itemOwner.useItem(item, target, false);
 				
 				if(Main.sex.getOngoingSexAreas(Main.game.getPlayer(), SexAreaOrifice.MOUTH, Main.game.getNpc(Ralph.class)).contains(SexAreaPenetration.PENIS)) {

--- a/src/com/lilithsthrone/game/character/npc/submission/Roxy.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/Roxy.java
@@ -81,6 +81,7 @@ public class Roxy extends NPC {
 			ItemType.FETISH_UNREFINED,
 			ItemType.MOO_MILKER_EMPTY,
 			ItemType.getItemTypeFromId("innoxia_pills_fertility"),
+			ItemType.getItemTypeFromId("innoxia_pills_broodmother"),
 			ItemType.getItemTypeFromId("innoxia_pills_sterility"),
 			ItemType.MOTHERS_MILK,
 			ItemType.PREGNANCY_TEST);

--- a/src/com/lilithsthrone/game/inventory/enchanting/ItemEffectType.java
+++ b/src/com/lilithsthrone/game/inventory/enchanting/ItemEffectType.java
@@ -335,7 +335,7 @@ public class ItemEffectType {
 //			target.addStatusEffect(StatusEffect.VIXENS_VIRILITY, 60*24*60);
 //			return UtilText.parse(target,
 //					"<p style='margin-bottom:0; padding-bottom:0;'>"
-//						+ "The little pink pill easily slides down [npc.her] throat, and within moments [npc.she] [npc.verb(feel)] "
+//						+ "The little purple pill easily slides down [npc.her] throat, and within moments [npc.she] [npc.verb(feel)] "
 //						+ ( target.hasVagina()
 //								? "a soothing, warm glow spreading out from [npc.her] ovaries into [npc.her] lower torso."
 //									+ " [npc.Her] mind fogs over with an overwhelming desire to feel potent sperm spurting deep into [npc.her] "+(target.isVisiblyPregnant()?"pussy":"womb")

--- a/src/com/lilithsthrone/game/inventory/item/AbstractItem.java
+++ b/src/com/lilithsthrone/game/inventory/item/AbstractItem.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
-import com.lilithsthrone.game.inventory.enchanting.TFModifier;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -283,9 +283,8 @@ public abstract class AbstractItem extends AbstractCoreItem implements XMLSaving
 		return itemType.isGift();
 	}
 
-	public boolean isFertilityPill() {
-		return this.getItemType().equals(ItemType.getItemTypeFromId("innoxia_pills_fertility"))
-				|| this.getItemType().equals(ItemType.getItemTypeFromId("innoxia_pills_broodmother"));
+	public boolean isTypeOneOf(String ... itemType) {
+		return Stream.of(itemType).anyMatch(it -> (this.getItemType().equals(ItemType.getItemTypeFromId(it))));
 	}
 
 	@Override

--- a/src/com/lilithsthrone/game/inventory/item/AbstractItem.java
+++ b/src/com/lilithsthrone/game/inventory/item/AbstractItem.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.lilithsthrone.game.inventory.enchanting.TFModifier;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -280,6 +281,11 @@ public abstract class AbstractItem extends AbstractCoreItem implements XMLSaving
 	
 	public boolean isGift() {
 		return itemType.isGift();
+	}
+
+	public boolean isFertilityPill() {
+		return this.getItemType().equals(ItemType.getItemTypeFromId("innoxia_pills_fertility"))
+				|| this.getItemType().equals(ItemType.getItemTypeFromId("innoxia_pills_broodmother"));
 	}
 
 	@Override

--- a/src/com/lilithsthrone/game/inventory/item/ItemType.java
+++ b/src/com/lilithsthrone/game/inventory/item/ItemType.java
@@ -3290,7 +3290,7 @@ public class ItemType {
 //			false,
 //			"breeder pill",
 //			"breeder pills",
-//			"A small, pink pill, individually packaged in a foil and plastic wrapper."
+//			"A small, purple pill, individually packaged in a foil and plastic wrapper."
 //				+ " While the text printed on the foil identifies this pill as an 'Orally-Administered Reproduction Enhancer', it's colloquially known as a 'breeder pill', and temporarily boosts both fertility and virility when ingested.",
 //			"pill",
 //			PresetColour.CLOTHING_PINK,
@@ -3311,8 +3311,8 @@ public class ItemType {
 //		@Override
 //		public String getUseDescription(GameCharacter user, GameCharacter target) {
 //			return getGenericUseDescription(user, target,
-//					"Popping the little pink pill out of its foil wrapper, you quickly put it in your mouth and swallow it down.",
-//					"Popping the little pink pill out of its foil wrapper, you bring it up to [npc.namePos] [npc.lips], before forcing it into [npc.her] mouth and making sure that [npc.she] swallows it down.",
+//					"Popping the little purple pill out of its foil wrapper, you quickly put it in your mouth and swallow it down.",
+//					"Popping the little purple pill out of its foil wrapper, you bring it up to [npc.namePos] [npc.lips], before forcing it into [npc.her] mouth and making sure that [npc.she] swallows it down.",
 //					"[npc.Name] pops a breeder pill out of its little foil wrapper, before quickly placing it in [npc.her] mouth and swallowing it down.",
 //					"[npc.Name] pops a breeder pill out of its little foil wrapper, before bringing it up to your [pc.lips], forcing it into your mouth, and making sure that you swallow it down.");
 //		}


### PR DESCRIPTION
- What is the purpose of the pull request?

Special NPC's (like Lilaya and Kate) should treat brood mother pills much the same as other fertility pills.

- Give a brief description of what you changed or added.

Added a isTypeOneOf method to AbstractItem, and use this when determining if a special reaction is needed.

Also, Roxy now sells brood mother pills, and there is a chance random NPC's will have them as well.

And several scenes still mention the Breeder pills as pink, but they have been purple for some time. Those occurances have been changed.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with 3.9.9

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930