### PR TITLE
Enchantment recipes can now be applied to weapons that already have enchantments

### DIFF
--- a/src/com/lilithsthrone/controller/MainControllerInitMethod.java
+++ b/src/com/lilithsthrone/controller/MainControllerInitMethod.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.lilithsthrone.game.inventory.AbstractCoreItem;
 import org.w3c.dom.Document;
 import org.w3c.dom.events.EventTarget;
 
@@ -7024,8 +7025,12 @@ public class MainControllerInitMethod {
 							LoadedEnchantment lEnch = EnchantmentDialogue.loadEnchant(fileName);
 							
 							EnchantmentDialogue.resetNonTattooEnchantmentVariables();
-							EnchantmentDialogue.initModifiers(lEnch.getSuitableItem());
+							AbstractCoreItem abstractItem = lEnch.getSuitableItem();
+							EnchantmentDialogue.initModifiers(abstractItem);
 							EnchantmentDialogue.getEffects().clear();
+							for(ItemEffect ie : abstractItem.getEffects()) {
+								EnchantmentDialogue.addEffect(ie);
+							}
 							for(ItemEffect ie : lEnch.getEffects()) {
 								EnchantmentDialogue.addEffect(ie);
 							}

--- a/src/com/lilithsthrone/controller/MainControllerInitMethod.java
+++ b/src/com/lilithsthrone/controller/MainControllerInitMethod.java
@@ -6999,13 +6999,13 @@ public class MainControllerInitMethod {
 						if(!Main.getProperties().hasValue(PropertyValue.overwriteWarning) || EnchantmentDialogue.overwriteConfirmationName.equals(f.getName())) {
 							EnchantmentDialogue.overwriteConfirmationName = "";
 							EnchantmentDialogue.saveEnchant(fileName, true);
-							Main.game.setContent(new Response("Save/Load", "Open the save/load game window.", EnchantmentDialogue.ENCHANTMENT_SAVE_LOAD));
+							Main.game.setContent(new Response("Save/Load", "Open the save/load enchantment window.", EnchantmentDialogue.ENCHANTMENT_SAVE_LOAD));
 							
 						} else {
 							EnchantmentDialogue.overwriteConfirmationName = f.getName();
 							EnchantmentDialogue.loadConfirmationName = "";
 							EnchantmentDialogue.deleteConfirmationName = "";
-							Main.game.setContent(new Response("Save/Load", "Open the save/load game window.", EnchantmentDialogue.ENCHANTMENT_SAVE_LOAD));
+							Main.game.setContent(new Response("Save/Load", "Open the save/load enchantment window.", EnchantmentDialogue.ENCHANTMENT_SAVE_LOAD));
 						}
 						
 					}, false);
@@ -7030,13 +7030,13 @@ public class MainControllerInitMethod {
 								EnchantmentDialogue.addEffect(ie);
 							}
 							EnchantmentDialogue.setOutputName(lEnch.getName());
-							Main.game.setContent(new Response("Save/Load", "Open the save/load game window.", EnchantmentDialogue.ENCHANTMENT_MENU));
+							Main.game.setContent(new Response("Save/Load", "Open the save/load enchantment window.", EnchantmentDialogue.ENCHANTMENT_MENU));
 							
 						} else {
 							EnchantmentDialogue.overwriteConfirmationName = "";
 							EnchantmentDialogue.loadConfirmationName = f.getName();
 							EnchantmentDialogue.deleteConfirmationName = "";
-							Main.game.setContent(new Response("Save/Load", "Open the save/load game window.", EnchantmentDialogue.ENCHANTMENT_SAVE_LOAD));
+							Main.game.setContent(new Response("Save/Load", "Open the save/load enchantment window.", EnchantmentDialogue.ENCHANTMENT_SAVE_LOAD));
 						}
 						
 					}, false);

--- a/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
@@ -782,7 +782,7 @@ public class EnchantmentDialogue {
 		public Response getResponse(int responseTab, int index) {
 			if (index == 1) {
 				return new Response("Confirmations: ",
-						"Toggle confirmations being shown when you click to load, overwrite, or delete a saved game."
+						"Toggle confirmations being shown when you click to load, overwrite, or delete a saved enchantment."
 							+ " When turned on, it will take two clicks to apply any button press."
 							+ " When turned off, it will only take one click.",
 						ENCHANTMENT_SAVE_LOAD) {

--- a/src/com/lilithsthrone/game/inventory/enchanting/LoadedEnchantment.java
+++ b/src/com/lilithsthrone/game/inventory/enchanting/LoadedEnchantment.java
@@ -99,10 +99,18 @@ public class LoadedEnchantment {
 			}
 			
 		} else if(weaponType!=null) {
+			List<AbstractWeapon> weaponList = new ArrayList<>();
 			for(AbstractWeapon w :  Main.game.getPlayer().getAllWeaponsInInventory().keySet()) {
-				if(w.getWeaponType().equals(weaponType) && w.getEffects().isEmpty()) {
-					return w;
+				if(w.getWeaponType().equals(weaponType) ) {
+					if (w.getEffects().isEmpty()) {
+						return w;
+					} else {
+						weaponList.add(w);
+					}
 				}
+			}
+			if(!weaponList.isEmpty()) {
+				return weaponList.get(0);
 			}
 			
 		} else if(tattooType!=null) {

--- a/src/com/lilithsthrone/game/inventory/enchanting/LoadedEnchantment.java
+++ b/src/com/lilithsthrone/game/inventory/enchanting/LoadedEnchantment.java
@@ -85,7 +85,7 @@ public class LoadedEnchantment {
 			
 		} else if(clothingType!=null) {
 			List<AbstractClothing> clothingList = new ArrayList<>();
-			for(AbstractClothing c :  Main.game.getPlayer().getAllClothingInInventory().keySet()) {
+			for(AbstractClothing c : Main.game.getPlayer().getAllClothingInInventory().keySet()) {
 				if(c.getClothingType().equals(clothingType) && c.isEnchantmentKnown()) {
 					if(c.getEffects().isEmpty()) {
 						return c;
@@ -100,7 +100,7 @@ public class LoadedEnchantment {
 			
 		} else if(weaponType!=null) {
 			List<AbstractWeapon> weaponList = new ArrayList<>();
-			for(AbstractWeapon w :  Main.game.getPlayer().getAllWeaponsInInventory().keySet()) {
+			for(AbstractWeapon w : Main.game.getPlayer().getAllWeaponsInInventory().keySet()) {
 				if(w.getWeaponType().equals(weaponType) ) {
 					if (w.getEffects().isEmpty()) {
 						return w;


### PR DESCRIPTION
- What is the purpose of the pull request?

Make it possible to apply recipes (stored enchantment lists) to weapons that already have an enchantment

- Give a brief description of what you changed or added.

Choose a weapon with no enchantment to apply the recipe to, and if none are available choose the first one that has (one or more) enchantments. In all cases, the weapon must be the same type as the one the recipe was made for.

Also, when loading a recipe, add the effects on the item that is to be enchanted to the list of effects in the enchantment dialogue, and not just the list of effects that were in the recipe.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with 3.9.9

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930