### PR TITLE
Change default permissions/job settings allocation

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -4599,22 +4599,24 @@ public abstract class GameCharacter implements XMLSaving {
 			}
 			slave.setOwner(this);
 			slave.setPendingClothingDressing(false);
-			
-			// Set up default permissions:
-			for(SlavePermission permission : SlavePermission.values()) {
-				for(SlavePermissionSetting setting : permission.getSettings()) {
-					if(Main.game.getOccupancyUtil().getEnabledByDefaultPermissionSettings().contains(setting)) {
-						slave.addSlavePermissionSetting(permission, setting);
-					}
-				}
-			}
-			
-			// Set up default job settings:
-			for(Entry<SlaveJob, List<SlaveJobSetting>> entry : Main.game.getOccupancyUtil().getEnabledByDefaultJobSettings().entrySet()) {
-				for(SlaveJobSetting setting : entry.getValue()) {
-					slave.addSlaveJobSettings(entry.getKey(), setting);
-				}
-			}
+
+			if(this.isPlayer()) {
+                // Set up default permissions:
+                for(SlavePermission permission : SlavePermission.values()) {
+                    for(SlavePermissionSetting setting : permission.getSettings()) {
+                        if(Main.game.getOccupancyUtil().getEnabledByDefaultPermissionSettings().contains(setting)) {
+                            slave.addSlavePermissionSetting(permission, setting);
+                        }
+                    }
+                }
+
+                // Set up default job settings:
+                for(Entry<SlaveJob, List<SlaveJobSetting>> entry : Main.game.getOccupancyUtil().getEnabledByDefaultJobSettings().entrySet()) {
+                    for(SlaveJobSetting setting : entry.getValue()) {
+                        slave.addSlaveJobSettings(entry.getKey(), setting);
+                    }
+                }
+            }
 		}
 		
 		return added;

--- a/src/com/lilithsthrone/game/character/npc/dominion/SlaveInStocks.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/SlaveInStocks.java
@@ -171,28 +171,6 @@ public class SlaveInStocks extends NPC {
 	}
 	
 	@Override
-	public String getDescription() {
-		if(this.getHistory()==Occupation.NPC_PROSTITUTE) {
-			if(this.isSlave()) {
-				return (UtilText.parse(this,
-						"[npc.NamePos] days of whoring [npc.herself] out in the back alleys of Dominion are now over. Having run afoul of the law, [npc.sheIs] now a slave, and is no more than [npc.her] owner's property."));
-			} else {
-				return (UtilText.parse(this,
-						"[npc.Name] is a prostitute who whores [npc.herself] out in the backalleys of Dominion."));
-			}
-			
-		} else {
-			if(this.isSlave()) {
-				return (UtilText.parse(this,
-						"[npc.NamePos] days of prowling the back alleys of Dominion and mugging innocent travellers are now over. Having run afoul of the law, [npc.sheIs] now a slave, and is no more than [npc.her] owner's property."));
-			} else {
-				return (UtilText.parse(this,
-						"[npc.Name] is a resident of Dominion, who prowls the back alleys in search of innocent travellers to mug and rape."));
-			}
-		}
-	}
-
-	@Override
 	public boolean isClothingStealable() {
 		return false;
 	}
@@ -239,7 +217,7 @@ public class SlaveInStocks extends NPC {
 					if(this.hasSlaveJobSetting(SlaveJob.PUBLIC_STOCKS, SlaveJobSetting.SEX_ANAL)) {
 						this.calculateGenericSexEffects(false, true, null, subspecies, halfDemonSubspecies, new SexType(SexParticipantType.NORMAL, SexAreaOrifice.ANUS, SexAreaPenetration.PENIS), GenericSexFlag.NO_DESCRIPTION_NEEDED);
 					}
-					if(this.hasSlaveJobSetting(SlaveJob.PUBLIC_STOCKS, SlaveJobSetting.SEX_VAGINAL)) {
+					if(this.hasSlaveJobSetting(SlaveJob.PUBLIC_STOCKS, SlaveJobSetting.SEX_VAGINAL) && this.hasVagina()) {
 						this.calculateGenericSexEffects(false, true, null, subspecies, halfDemonSubspecies, new SexType(SexParticipantType.NORMAL, SexAreaOrifice.VAGINA, SexAreaPenetration.PENIS), GenericSexFlag.NO_DESCRIPTION_NEEDED);
 					}
 				}

--- a/src/com/lilithsthrone/game/character/npc/dominion/SlaveInStocks.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/SlaveInStocks.java
@@ -96,7 +96,7 @@ public class SlaveInStocks extends NPC {
 			setSexualOrientation(RacialBody.valueOfRace(this.getRace()).getSexualOrientation(gender));
 	
 			setName(Name.getRandomTriplet(this.getRace()));
-			this.setPlayerKnowsName(false);
+			this.setPlayerKnowsName(true);
 			setDescription(UtilText.parse(this,
 					"[npc.Name] is a slave, who, for one reason or another, has been locked into the stocks for public use."));
 			
@@ -144,8 +144,6 @@ public class SlaveInStocks extends NPC {
 			this.removeSlavePermissionSetting(SlavePermission.CLEANLINESS, SlavePermissionSetting.CLEANLINESS_WASH_BODY);
 			this.removeSlavePermissionSetting(SlavePermission.CLEANLINESS, SlavePermissionSetting.CLEANLINESS_WASH_CLOTHES);
 			
-			this.setPlayerKnowsName(true);
-
 			initHealthAndManaToMax();
 		}
 	}


### PR DESCRIPTION
- What is the purpose of the pull request?

Prevent the job permissions of slaves in the stocks from being overruled

- Give a brief description of what you changed or added.

Allocating default permissions/job settings for slaves in the AddSlave method should only be done if the MC is the new owner of the slave. With this change, the settings for slaves in the stocks for Allow_oral, allow_anal and allow_vaginal stay the way they are when the slave is first generated.

Added a check to see if the slave has a vagina to the slaves in stocks to prevent any other male pregnancies in the future.

Also removed the getDescription for slaves in stocks, as this overrides the description as a 'slave in stocks' that they start with.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with 3.9.9

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930

![SlavesInStocks](https://user-images.githubusercontent.com/56754746/95013976-20a29200-0644-11eb-87cb-588ff2204fa2.png)

Male pregnancies:
![PregnantMale](https://user-images.githubusercontent.com/56754746/95312096-cc3f2280-088e-11eb-9f46-5f9c9b310594.png)

Description before change:
![before](https://user-images.githubusercontent.com/56754746/95313941-fc87c080-0890-11eb-8e91-5b6f6ac2214e.png)

Description after change:
![after](https://user-images.githubusercontent.com/56754746/95313986-08738280-0891-11eb-8ac5-2c080fa484a0.png)