### PR TITLE
add javafx dependency to pom.xml (this time on the right branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,4 @@ This is the source code for Lilith's Throne.
 
 You must agree to the terms of the attached disclaimer and abide by the terms of the license if you wish to view this source code.
 
-Dev-note: This project is relying on JavaFX which isn't included in the Openjdk, which is often the common choice for Linux enthusiasts. If you're using Linux, please make sure to use the Oracle JDK to build this project or install OpenJFX.
-
 Copyright 2016 Innoxia (innoxia7@gmail.com) all rights reserved.

--- a/pom.xml
+++ b/pom.xml
@@ -55,12 +55,22 @@
 		<dependency>
 			<groupId>org.openjfx</groupId>
 			<artifactId>javafx-fxml</artifactId>
-		<version>15</version>
+			<version>15</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openjfx</groupId>
 			<artifactId>javafx-web</artifactId>
 			<version>15</version>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-base</artifactId>
+			<version>15</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-graphics</artifactId>
+			<version>15</version>
+		</dependency>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,4 +46,21 @@
 			</plugin>
 		</plugins>
 	</build>
+	<dependencies>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-controls</artifactId>
+			<version>15</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-fxml</artifactId>
+		<version>15</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjfx</groupId>
+			<artifactId>javafx-web</artifactId>
+			<version>15</version>
+		</dependency>
+	</dependencies>
 </project>


### PR DESCRIPTION
> What is the purpose of the pull request?

to fix #1435, allowing to build on modern versions of java

> Give a brief description of what you changed or added.

the dependencies in `pom.xml`

> Are any new graphical assets required?

no

> Has this change been tested? If so, mention the version number that the test was based on.

tested on my machine with openjdk11 and commit 9d9ec4d41583bdc508245d13c0b99f3f305814a7

> So we have a better idea of who you are, what is your Discord Handle?

`nonchip#2308`

> If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.

not sure how urgent you find that but many linux distros don't actually package the oracle-jdk anymore, and even on oracle-jdk javafx was finally [removed](https://blogs.oracle.com/java-platform-group/the-future-of-javafx-and-other-java-client-roadmap-updates) from "java internal" in Java 11, many people prefer openjdk anyway because it allows automated installation via package managers without signing weird eulas, and this fixes the only issue i ever had building it with openjdk-11.

this essentially solves the "dev note" you mention in the readme


sorry, in #1436 i set it against the master branch accidentally.