### PR TITLE
Tooltip animation is toggleable

### DIFF
--- a/src/com/lilithsthrone/controller/MainController.java
+++ b/src/com/lilithsthrone/controller/MainController.java
@@ -2329,6 +2329,9 @@ public class MainController implements Initializable {
 	}
 	
 	public void setTooltipContent(String content) {
+		if (Main.getProperties().hasValue(PropertyValue.fadeInText)) {
+			content = "<div class='tooltip-animation' style='width: 100%;'>" + content + "</div>";
+		}
 		if(useJavascriptToSetContent) {
 			setWebEngineContent(webEngineTooltip, content);
 		} else {

--- a/src/com/lilithsthrone/res/css/webViewTooltip_stylesheet.css
+++ b/src/com/lilithsthrone/res/css/webViewTooltip_stylesheet.css
@@ -12,8 +12,10 @@ html {
 body{
 	padding:0;
 	margin:0;
-	
-	 -webkit-animation-name: fadeIn;
+}
+
+.tooltip-animation {
+	-webkit-animation-name: fadeIn;
     -webkit-animation-iteration-count: 1;
     -webkit-animation-timing-function: ease-out;
     -webkit-animation-duration: 0.3s;

--- a/src/com/lilithsthrone/res/css/webViewTooltip_stylesheet_light.css
+++ b/src/com/lilithsthrone/res/css/webViewTooltip_stylesheet_light.css
@@ -12,8 +12,10 @@ html {
 body{
 	padding:0;
 	margin:0;
-	
-	 -webkit-animation-name: fadeIn;
+}
+
+.tooltip-animation {
+	-webkit-animation-name: fadeIn;
     -webkit-animation-iteration-count: 1;
     -webkit-animation-timing-function: ease-out;
     -webkit-animation-duration: 0.3s;


### PR DESCRIPTION
Tooltip fade-in animation is now toggleable via the existing 'Fade-In' game option.

Addresses #1444:
When using Java 8u271, there is a bug with animations in JavaFX WebView (https://bugs.openjdk.java.net/browse/JDK-8256138). In LT, this causes tooltips to appear blank for users with that version of Java.

This change addresses that bug by restricting tooltip animation to the game's 'Fade-In' option, which is disabled by default. Without the animation, tooltips render normally.

No new graphical assets required. Tested on 0.3.9.9.