### PR TITLE
fix bug with passive form of elementals

### DIFF
--- a/src/com/lilithsthrone/game/character/race/Subspecies.java
+++ b/src/com/lilithsthrone/game/character/race/Subspecies.java
@@ -4878,11 +4878,15 @@ public class Subspecies {
 									"<div style='width:100%;height:100%;position:absolute;left:0;bottom:0;'>"+SVGImages.SVG_IMAGE_PROVIDER.getRaceWisp()+"</div>");
 					return wispSVG;
 				}
+				AbstractSubspecies passiveForm = ((Elemental)character).getPassiveForm();
+				if (passiveForm.SVGString == null) {
+					passiveForm.initSVGStrings();
+				}
 				String raceSvg = SvgUtil.colourReplacement(Subspecies.getIdFromSubspecies(ELEMENTAL_FIRE),
 						this.getColour(character),
 						this.getColour(character),
 						this.getColour(character),
-						((Elemental)character).getPassiveForm().SVGStringUncoloured);
+						passiveForm.SVGStringUncoloured);
 				return getBipedBackground(raceSvg, character, this.getColour(character));
 			}
 			return super.getSVGString(character);
@@ -4952,11 +4956,15 @@ public class Subspecies {
 							"<div style='width:100%;height:100%;position:absolute;left:0;bottom:0;'>"+SVGImages.SVG_IMAGE_PROVIDER.getRaceWisp()+"</div>");
 					return wispSVG;
 				}
+				AbstractSubspecies passiveForm = ((Elemental)character).getPassiveForm();
+				if (passiveForm.SVGString == null) {
+					passiveForm.initSVGStrings();
+				}
 				String raceSvg = SvgUtil.colourReplacement(Subspecies.getIdFromSubspecies(ELEMENTAL_EARTH),
 						this.getColour(character),
 						this.getColour(character),
 						this.getColour(character),
-						((Elemental)character).getPassiveForm().SVGStringUncoloured);
+						passiveForm.SVGStringUncoloured);
 				return getBipedBackground(raceSvg, character, this.getColour(character));
 			}
 			return super.getSVGString(character);
@@ -5027,11 +5035,15 @@ public class Subspecies {
 									"<div style='width:100%;height:100%;position:absolute;left:0;bottom:0;'>"+SVGImages.SVG_IMAGE_PROVIDER.getRaceWisp()+"</div>");
 					return wispSVG;
 				}
+				AbstractSubspecies passiveForm = ((Elemental)character).getPassiveForm();
+				if (passiveForm.SVGString == null) {
+					passiveForm.initSVGStrings();
+				}
 				String raceSvg = SvgUtil.colourReplacement(Subspecies.getIdFromSubspecies(ELEMENTAL_WATER),
 						this.getColour(character),
 						this.getColour(character),
 						this.getColour(character),
-						((Elemental)character).getPassiveForm().SVGStringUncoloured);
+						passiveForm.SVGStringUncoloured);
 				return getBipedBackground(raceSvg, character, this.getColour(character));
 			}
 			return super.getSVGString(character);
@@ -5101,11 +5113,15 @@ public class Subspecies {
 									"<div style='width:100%;height:100%;position:absolute;left:0;bottom:0;'>"+SVGImages.SVG_IMAGE_PROVIDER.getRaceWisp()+"</div>");
 					return wispSVG;
 				}
+				AbstractSubspecies passiveForm = ((Elemental)character).getPassiveForm();
+				if (passiveForm.SVGString == null) {
+					passiveForm.initSVGStrings();
+				}
 				String raceSvg = SvgUtil.colourReplacement(Subspecies.getIdFromSubspecies(ELEMENTAL_AIR),
 						this.getColour(character),
 						this.getColour(character),
 						this.getColour(character),
-						((Elemental)character).getPassiveForm().SVGStringUncoloured);
+						passiveForm.SVGStringUncoloured);
 				return getBipedBackground(raceSvg, character, this.getColour(character));
 			}
 			return super.getSVGString(character);
@@ -5175,11 +5191,15 @@ public class Subspecies {
 									"<div style='width:100%;height:100%;position:absolute;left:0;bottom:0;'>"+SVGImages.SVG_IMAGE_PROVIDER.getRaceWisp()+"</div>");
 					return wispSVG;
 				}
+				AbstractSubspecies passiveForm = ((Elemental)character).getPassiveForm();
+				if (passiveForm.SVGString == null) {
+					passiveForm.initSVGStrings();
+				}
 				String raceSvg = SvgUtil.colourReplacement(Subspecies.getIdFromSubspecies(ELEMENTAL_ARCANE),
 						this.getColour(character),
 						this.getColour(character),
 						this.getColour(character),
-						((Elemental)character).getPassiveForm().SVGStringUncoloured);
+						passiveForm.SVGStringUncoloured);
 				return getBipedBackground(raceSvg, character, this.getColour(character));
 			}
 			return super.getSVGString(character);


### PR DESCRIPTION
- What is the purpose of the pull request?

Fix a bug where having an elemental in a feral form leaves the left and right sidebar blank

- Give a brief description of what you changed or added.

Check if the feral subspecies of the elemental has it's SVGstrings initialised before accessing them

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with version 3.11

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930