### PR TITLE
Allow multiple vagina and penis types per race

### DIFF
--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractPenisType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractPenisType.java
@@ -146,6 +146,7 @@ public abstract class AbstractPenisType implements BodyPartTypeInterface {
 				this.fromExternalFile = true;
 				
 				this.race = Race.getRaceFromId(coreElement.getMandatoryFirstOf("race").getTextContent());
+				this.transformationName = coreElement.getMandatoryFirstOf("transformationName").getTextContent();
 				this.coveringType = BodyCoveringType.getBodyCoveringTypeFromId(coreElement.getMandatoryFirstOf("coveringType").getTextContent());
 
 				this.transformationName = coreElement.getMandatoryFirstOf("transformationName").getTextContent();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractVaginaType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractVaginaType.java
@@ -155,6 +155,7 @@ public abstract class AbstractVaginaType implements BodyPartTypeInterface {
 				this.fromExternalFile = true;
 				
 				this.race = Race.getRaceFromId(coreElement.getMandatoryFirstOf("race").getTextContent());
+				this.transformationName = coreElement.getMandatoryFirstOf("transformationName").getTextContent();
 				this.coveringType = BodyCoveringType.getBodyCoveringTypeFromId(coreElement.getMandatoryFirstOf("coveringType").getTextContent());
 				
 				this.fluidType = FluidType.getFluidTypeFromId(coreElement.getMandatoryFirstOf("fluidType").getTextContent());

--- a/src/com/lilithsthrone/game/inventory/enchanting/AbstractItemEffectType.java
+++ b/src/com/lilithsthrone/game/inventory/enchanting/AbstractItemEffectType.java
@@ -2389,7 +2389,9 @@ public abstract class AbstractItemEffectType {
 				break;
 				
 			case TF_PENIS:
-				secondaryModPotencyMap.put(TFModifier.TF_TYPE_1, Util.newArrayListOfValues(TFPotency.MINOR_BOOST));
+				for(int i=0; i< PenisType.getPenisTypes(race).size();i++) {
+					secondaryModPotencyMap.put(TFModifier.valueOf("TF_TYPE_"+(i+1)), Util.newArrayListOfValues(TFPotency.MINOR_BOOST));
+				}
 				secondaryModPotencyMap.put(TFModifier.REMOVAL, Util.newArrayListOfValues(TFPotency.MINOR_BOOST));
 				
 				secondaryModPotencyMap.put(TFModifier.TF_MOD_SIZE, TFPotency.getAllPotencies());
@@ -2471,7 +2473,9 @@ public abstract class AbstractItemEffectType {
 				break;
 				
 			case TF_VAGINA:
-				secondaryModPotencyMap.put(TFModifier.TF_TYPE_1, Util.newArrayListOfValues(TFPotency.MINOR_BOOST));
+				for(int i=0; i< VaginaType.getVaginaTypes(race).size();i++) {
+					secondaryModPotencyMap.put(TFModifier.valueOf("TF_TYPE_"+(i+1)), Util.newArrayListOfValues(TFPotency.MINOR_BOOST));
+				}
 				secondaryModPotencyMap.put(TFModifier.REMOVAL, Util.newArrayListOfValues(TFPotency.MINOR_BOOST));
 				
 				secondaryModPotencyMap.put(TFModifier.TF_MOD_SIZE, TFPotency.getAllPotencies());


### PR DESCRIPTION
- What is the purpose of the pull request?
  Multiple vagina and penis types weren't handled correctly in `vagina.xml` and `penis.xml` files and only the first vagina and penis type was handled in enchanting.

- Give a brief description of what you changed or added.
  `<transformationName>` wasn't parsed for vags 'n cocks and TF_TYPE_1 was hardcoded there. Fixed that.

- Are any new graphical assets required?
  No.

- Has this change been tested? If so, mention the version number that the test was based on.
  Yes, 0.3.13 Alpha

- So we have a better idea of who you are, what is your Discord Handle?
  `@Stadler#3007`