### PR TITLE
store result of getSubspeciesWeighting to improve performance

### DIFF
--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -614,11 +614,13 @@ public abstract class AbstractSubspecies {
 		AbstractSubspecies subspecies = null;
 		
 		int highestWeighting = 0;
+		int newWeighting;
 		for(AbstractSubspecies sub : Subspecies.getAllSubspecies()) {
-			if(sub.getSubspeciesWeighting(body, race)>highestWeighting
+			newWeighting = sub.getSubspeciesWeighting(body, race);
+			if(newWeighting>highestWeighting
 					&& (!body.isFeral() || sub.isFeralConfigurationAvailable())) {
 				subspecies = sub;
-				highestWeighting = sub.getSubspeciesWeighting(body, race);
+				highestWeighting = newWeighting;
 			}
 		}
 		if(subspecies==null) {

--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -1091,14 +1091,20 @@ public abstract class AbstractSubspecies {
 
 	public String getBasicDescription(GameCharacter character) {
 		if(this.isFromExternalFile()) {
-			return UtilText.parseFromXMLFile(new ArrayList<>(), bookIdFolderPath, "bookEntries", getBasicDescriptionId(), new ArrayList<>());
+			File file = new File(bookIdFolderPath+System.getProperty("file.separator")+"bookEntries.xml");
+			if (file.exists()) {
+				return UtilText.parseFromXMLFile(new ArrayList<>(), bookIdFolderPath, "bookEntries", getBasicDescriptionId(), new ArrayList<>());
+			}
 		}
 		return UtilText.parseFromXMLFile("characters/raceInfo", getBasicDescriptionId());
 	}
 
 	public String getAdvancedDescription(GameCharacter character) {
 		if(this.isFromExternalFile()) {
-			return UtilText.parseFromXMLFile(new ArrayList<>(), bookIdFolderPath, "bookEntries", getAdvancedDescriptionId(), new ArrayList<>());
+			File file = new File(bookIdFolderPath+System.getProperty("file.separator")+"bookEntries.xml");
+			if (file.exists()) {
+				return UtilText.parseFromXMLFile(new ArrayList<>(), bookIdFolderPath, "bookEntries", getAdvancedDescriptionId(), new ArrayList<>());
+			}
 		}
 		return UtilText.parseFromXMLFile("characters/raceInfo", getAdvancedDescriptionId());
 	}

--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -1090,21 +1090,17 @@ public abstract class AbstractSubspecies {
 	}
 
 	public String getBasicDescription(GameCharacter character) {
-		if(this.isFromExternalFile()) {
-			File file = new File(bookIdFolderPath+System.getProperty("file.separator")+"bookEntries.xml");
-			if (file.exists()) {
+		if(this.isFromExternalFile() &&
+		   new File(bookIdFolderPath+System.getProperty("file.separator")+"bookEntries.xml").exists()) {
 				return UtilText.parseFromXMLFile(new ArrayList<>(), bookIdFolderPath, "bookEntries", getBasicDescriptionId(), new ArrayList<>());
-			}
 		}
 		return UtilText.parseFromXMLFile("characters/raceInfo", getBasicDescriptionId());
 	}
 
 	public String getAdvancedDescription(GameCharacter character) {
-		if(this.isFromExternalFile()) {
-			File file = new File(bookIdFolderPath+System.getProperty("file.separator")+"bookEntries.xml");
-			if (file.exists()) {
+		if(this.isFromExternalFile() &&
+		   new File(bookIdFolderPath+System.getProperty("file.separator")+"bookEntries.xml").exists()) {
 				return UtilText.parseFromXMLFile(new ArrayList<>(), bookIdFolderPath, "bookEntries", getAdvancedDescriptionId(), new ArrayList<>());
-			}
 		}
 		return UtilText.parseFromXMLFile("characters/raceInfo", getAdvancedDescriptionId());
 	}

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -824,7 +824,7 @@ public class UtilText {
 				e.printStackTrace();
 			}
 		} else {
-			System.err.println("Error in UtilText.parseFromXMLFile(): File '"+(folderPath+pathName+".xml")+"' does not exist!");
+			System.err.println("Error in UtilText.parseFromXMLFile(): File '"+(folderPath+System.getProperty("file.separator")+pathName+".xml")+"' does not exist!");
 		}
 		
 		if(strings.isEmpty()) {


### PR DESCRIPTION
- What is the purpose of the pull request?

Improve performance by storing the result of getSubspeciesWeighting

Load race descriptions from characters/raceInfo if there is no bookEntries file (like the new Cougar subspecies)

- Give a brief description of what you changed or added.

Store the result of getSubspeciesWeighting and use this for the comparison and to assign it as a value

Only load from the bookEntries file if it exists, otherwise use the characters/raceInfo for parsing.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with 0.3.14

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930