### PR TITLE
Non-ferals shouldn't display the leg-description, when there are no legs

### DIFF
--- a/src/com/lilithsthrone/game/character/body/Body.java
+++ b/src/com/lilithsthrone/game/character/body/Body.java
@@ -2877,7 +2877,9 @@ public class Body implements XMLSaving {
 					sb.append("[npc.Her] [npc.legs], being part of [npc.her] [npc.legRace]'s body, are entirely [style.colourFeral(feral in nature)]. ");
 					break;
 			}
-			sb.append(leg.getType().getBodyDescription(owner));
+			if(owner.getLegConfiguration().getNumberOfLegs()>0) {
+				sb.append(leg.getType().getBodyDescription(owner));
+			}
 		}
 
 		if(owner.getLegConfiguration().getNumberOfLegs()>0) {


### PR DESCRIPTION
### What is the purpose of the pull request?
This is a followup-PR to PR #1467. This fixes an oversight for mer-tailed and serpent-tailed non-ferals where the full leg description was shown. See the highlighted part in the screenshot:
![image](https://user-images.githubusercontent.com/13157984/104785513-fa37db00-578a-11eb-9c6d-b37ebd2536f7.png)
This update fixes that, too.

### Give a brief description of what you changed or added.
Minor change to `Body.java`. See the list of files changed.

### Are any new graphical assets required?
No

### Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.3.14 Alpha

### So we have a better idea of who you are, what is your Discord Handle?
`@Stadler#3007`