### PR TITLE
Use only a single factory for XML work

### DIFF
--- a/src/com/lilithsthrone/controller/xmlParsing/Element.java
+++ b/src/com/lilithsthrone/controller/xmlParsing/Element.java
@@ -5,8 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 
@@ -50,7 +49,7 @@ public class Element {
 	public static Element getDocumentRootElement(File xmlFile) throws XMLLoadException{
 		try{
 			String fileDirectory = xmlFile.getAbsolutePath();
-			Document parsedDocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(xmlFile);
+			Document parsedDocument = Game.docFactory.newDocumentBuilder().parse(xmlFile);
 			parsedDocument.getDocumentElement().normalize();
 			return new Element(parsedDocument.getDocumentElement(), fileDirectory, parsedDocument);
 			

--- a/src/com/lilithsthrone/controller/xmlParsing/Element.java
+++ b/src/com/lilithsthrone/controller/xmlParsing/Element.java
@@ -9,8 +9,6 @@ import com.lilithsthrone.main.Main;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 /**
  * @author BlazingMagpie@gmail.com (or ping BlazingMagpie in Discord)
  * @since 0.2.5.8
@@ -51,14 +49,7 @@ public class Element {
 	public static Element getDocumentRootElement(File xmlFile) throws XMLLoadException{
 		try{
 			String fileDirectory = xmlFile.getAbsolutePath();
-			try {
-				if (Main.docBuilder==null) {
-					Main.docBuilder = Main.docFactory.newDocumentBuilder();
-				}
-			} catch (ParserConfigurationException e) {
-				e.printStackTrace();
-			}
-			Document parsedDocument = Main.docBuilder.parse(xmlFile);
+			Document parsedDocument = Main.getDocBuilder().parse(xmlFile);
 			parsedDocument.getDocumentElement().normalize();
 			return new Element(parsedDocument.getDocumentElement(), fileDirectory, parsedDocument);
 			

--- a/src/com/lilithsthrone/controller/xmlParsing/Element.java
+++ b/src/com/lilithsthrone/controller/xmlParsing/Element.java
@@ -5,9 +5,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import com.lilithsthrone.game.Game;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
+
+import javax.xml.parsers.DocumentBuilderFactory;
 
 /**
  * @author BlazingMagpie@gmail.com (or ping BlazingMagpie in Discord)
@@ -49,7 +50,7 @@ public class Element {
 	public static Element getDocumentRootElement(File xmlFile) throws XMLLoadException{
 		try{
 			String fileDirectory = xmlFile.getAbsolutePath();
-			Document parsedDocument = Game.docBuilder.parse(xmlFile);
+			Document parsedDocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(xmlFile);
 			parsedDocument.getDocumentElement().normalize();
 			return new Element(parsedDocument.getDocumentElement(), fileDirectory, parsedDocument);
 			

--- a/src/com/lilithsthrone/controller/xmlParsing/Element.java
+++ b/src/com/lilithsthrone/controller/xmlParsing/Element.java
@@ -49,7 +49,7 @@ public class Element {
 	public static Element getDocumentRootElement(File xmlFile) throws XMLLoadException{
 		try{
 			String fileDirectory = xmlFile.getAbsolutePath();
-			Document parsedDocument = Game.docFactory.newDocumentBuilder().parse(xmlFile);
+			Document parsedDocument = Game.docBuilder.parse(xmlFile);
 			parsedDocument.getDocumentElement().normalize();
 			return new Element(parsedDocument.getDocumentElement(), fileDirectory, parsedDocument);
 			

--- a/src/com/lilithsthrone/controller/xmlParsing/Element.java
+++ b/src/com/lilithsthrone/controller/xmlParsing/Element.java
@@ -5,10 +5,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * @author BlazingMagpie@gmail.com (or ping BlazingMagpie in Discord)
@@ -50,7 +51,14 @@ public class Element {
 	public static Element getDocumentRootElement(File xmlFile) throws XMLLoadException{
 		try{
 			String fileDirectory = xmlFile.getAbsolutePath();
-			Document parsedDocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(xmlFile);
+			try {
+				if (Main.docBuilder==null) {
+					Main.docBuilder = Main.docFactory.newDocumentBuilder();
+				}
+			} catch (ParserConfigurationException e) {
+				e.printStackTrace();
+			}
+			Document parsedDocument = Main.docBuilder.parse(xmlFile);
 			parsedDocument.getDocumentElement().normalize();
 			return new Element(parsedDocument.getDocumentElement(), fileDirectory, parsedDocument);
 			

--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -23,11 +23,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
@@ -342,7 +340,7 @@ public class Game implements XMLSaving {
 			}
 			// Starting stuff:
 
-			Document doc = Main.docBuilder.newDocument();
+			Document doc = Main.getDocBuilder().newDocument();
 
 			// Writing game stuff to export:
 			
@@ -408,7 +406,7 @@ public class Game implements XMLSaving {
 		
 		if (file.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(file);
+				Document doc = Main.getDocBuilder().parse(file);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();
@@ -478,7 +476,7 @@ public class Game implements XMLSaving {
 		}
 		// Starting stuff:
 
-		Document doc = Main.docBuilder.newDocument();
+		Document doc = Main.getDocBuilder().newDocument();
 
 		// Writing game stuff to export:
 
@@ -660,7 +658,7 @@ public class Game implements XMLSaving {
 		
 		if (file.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(file);
+				Document doc = Main.getDocBuilder().parse(file);
 
 				long time = System.nanoTime();
 				if(debug) {

--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -23,8 +23,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -299,10 +297,6 @@ public class Game implements XMLSaving {
 	// Slavery:
 	private OccupancyUtil occupancyUtil = new OccupancyUtil();
 
-	public static TransformerFactory transformerFactory = TransformerFactory.newInstance();
-	public static DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-	public static DocumentBuilder docBuilder;
-
 	public Game() {
 		worlds = new HashMap<>();
 		for(AbstractWorldType type : WorldType.getAllWorldTypes()) {
@@ -329,12 +323,6 @@ public class Game implements XMLSaving {
 		
 		savedInventories = new HashMap<>();
 
-		try {
-			docBuilder = docFactory.newDocumentBuilder();
-		} catch (ParserConfigurationException e) {
-			e.printStackTrace();
-		}
-
 		// Start in clouds:
 		currentWeather = Weather.CLOUD;
 		weatherTimeRemainingInSeconds = 5*60*60;
@@ -354,7 +342,7 @@ public class Game implements XMLSaving {
 			}
 			// Starting stuff:
 
-			Document doc = docBuilder.newDocument();
+			Document doc = Main.docBuilder.newDocument();
 
 			// Writing game stuff to export:
 			
@@ -365,7 +353,7 @@ public class Game implements XMLSaving {
 			
 			// Ending stuff:
 
-			Transformer transformer1 = transformerFactory.newTransformer();
+			Transformer transformer1 = Main.transformerFactory.newTransformer();
 			transformer1.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 			StringWriter writer = new StringWriter();
 
@@ -373,7 +361,7 @@ public class Game implements XMLSaving {
 			
 			// Save this xml:
 
-			Transformer transformer = transformerFactory.newTransformer();
+			Transformer transformer = Main.transformerFactory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 			DOMSource source = new DOMSource(doc);
@@ -420,7 +408,7 @@ public class Game implements XMLSaving {
 		
 		if (file.exists()) {
 			try {
-				Document doc = docBuilder.parse(file);
+				Document doc = Main.docBuilder.parse(file);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();
@@ -490,7 +478,7 @@ public class Game implements XMLSaving {
 		}
 		// Starting stuff:
 
-		Document doc = docBuilder.newDocument();
+		Document doc = Main.docBuilder.newDocument();
 
 		// Writing game stuff to export:
 
@@ -622,14 +610,14 @@ public class Game implements XMLSaving {
 
 		// Ending stuff:
 		try {
-			Transformer transformer1 = transformerFactory.newTransformer();
+			Transformer transformer1 = Main.transformerFactory.newTransformer();
 			transformer1.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 			StringWriter writer = new StringWriter();
 
 			transformer1.transform(new DOMSource(doc), new StreamResult(writer));
 
 			// Save this xml:
-			Transformer transformer = transformerFactory.newTransformer();
+			Transformer transformer = Main.transformerFactory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 			DOMSource source = new DOMSource(doc);
@@ -672,7 +660,7 @@ public class Game implements XMLSaving {
 		
 		if (file.exists()) {
 			try {
-				Document doc = docBuilder.parse(file);
+				Document doc = Main.docBuilder.parse(file);
 
 				long time = System.nanoTime();
 				if(debug) {

--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -8,12 +8,10 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
@@ -260,8 +258,7 @@ public class Properties {
 	public void savePropertiesAsXML(){
 		try {
 		
-			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+			DocumentBuilder docBuilder = Game.docFactory.newDocumentBuilder();
 			
 			Document doc = docBuilder.newDocument();
 			Element properties = doc.createElement("properties");
@@ -576,8 +573,7 @@ public class Properties {
 			
 			
 			// Write out to properties.xml:
-			TransformerFactory transformerFactory = TransformerFactory.newInstance();
-			Transformer transformer = transformerFactory.newTransformer();
+			Transformer transformer = Game.transformerFactory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 			DOMSource source = new DOMSource(doc);
@@ -603,8 +599,7 @@ public class Properties {
 		if (new File("data/properties.xml").exists())
 			try {
 				File propertiesXML = new File("data/properties.xml");
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(propertiesXML);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -7,7 +7,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -256,7 +255,7 @@ public class Properties {
 	
 	public void savePropertiesAsXML(){
 		try {
-			Document doc = Main.docBuilder.newDocument();
+			Document doc = Main.getDocBuilder().newDocument();
 			Element properties = doc.createElement("properties");
 			doc.appendChild(properties);
 
@@ -595,7 +594,7 @@ public class Properties {
 		if (new File("data/properties.xml").exists())
 			try {
 				File propertiesXML = new File("data/properties.xml");
-				Document doc = Main.docBuilder.parse(propertiesXML);
+				Document doc = Main.getDocBuilder().parse(propertiesXML);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -7,7 +7,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -257,10 +256,7 @@ public class Properties {
 	
 	public void savePropertiesAsXML(){
 		try {
-		
-			DocumentBuilder docBuilder = Game.docFactory.newDocumentBuilder();
-			
-			Document doc = docBuilder.newDocument();
+			Document doc = Game.docBuilder.newDocument();
 			Element properties = doc.createElement("properties");
 			doc.appendChild(properties);
 
@@ -581,7 +577,7 @@ public class Properties {
 		
 			transformer.transform(source, result);
 		
-		} catch (ParserConfigurationException | TransformerException e) {
+		} catch (TransformerException e) {
 			e.printStackTrace();
 		}
 	}
@@ -599,8 +595,7 @@ public class Properties {
 		if (new File("data/properties.xml").exists())
 			try {
 				File propertiesXML = new File("data/properties.xml");
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(propertiesXML);
+				Document doc = Game.docBuilder.parse(propertiesXML);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -256,7 +256,7 @@ public class Properties {
 	
 	public void savePropertiesAsXML(){
 		try {
-			Document doc = Game.docBuilder.newDocument();
+			Document doc = Main.docBuilder.newDocument();
 			Element properties = doc.createElement("properties");
 			doc.appendChild(properties);
 
@@ -569,7 +569,7 @@ public class Properties {
 			
 			
 			// Write out to properties.xml:
-			Transformer transformer = Game.transformerFactory.newTransformer();
+			Transformer transformer = Main.transformerFactory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 			DOMSource source = new DOMSource(doc);
@@ -595,7 +595,7 @@ public class Properties {
 		if (new File("data/properties.xml").exists())
 			try {
 				File propertiesXML = new File("data/properties.xml");
-				Document doc = Game.docBuilder.parse(propertiesXML);
+				Document doc = Main.docBuilder.parse(propertiesXML);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/CharacterUtils.java
+++ b/src/com/lilithsthrone/game/character/CharacterUtils.java
@@ -144,7 +144,7 @@ public class CharacterUtils {
 //			long timeStart = System.nanoTime();
 //			System.out.println(timeStart);
 
-			Document doc = Game.docBuilder.newDocument();
+			Document doc = Main.docBuilder.newDocument();
 			
 			Element properties = doc.createElement("playerCharacter");
 			doc.appendChild(properties);
@@ -154,7 +154,7 @@ public class CharacterUtils {
 			
 //			System.out.println("Difference2: "+(System.nanoTime()-timeStart)/1000000000f);
 			
-			Transformer transformer1 = Game.transformerFactory.newTransformer();
+			Transformer transformer1 = Main.transformerFactory.newTransformer();
 			transformer1.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 			StringWriter writer = new StringWriter();
 
@@ -169,7 +169,7 @@ public class CharacterUtils {
 //			System.out.println(output);
 			
 			// Save this xml:
-			Transformer transformer = Game.transformerFactory.newTransformer();
+			Transformer transformer = Main.transformerFactory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 			DOMSource source = new DOMSource(doc);
@@ -220,7 +220,7 @@ public class CharacterUtils {
 		
 		if (xmlFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(xmlFile);
+				Document doc = Main.docBuilder.parse(xmlFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/CharacterUtils.java
+++ b/src/com/lilithsthrone/game/character/CharacterUtils.java
@@ -144,7 +144,7 @@ public class CharacterUtils {
 //			long timeStart = System.nanoTime();
 //			System.out.println(timeStart);
 
-			Document doc = Main.docBuilder.newDocument();
+			Document doc = Main.getDocBuilder().newDocument();
 			
 			Element properties = doc.createElement("playerCharacter");
 			doc.appendChild(properties);
@@ -220,7 +220,7 @@ public class CharacterUtils {
 		
 		if (xmlFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(xmlFile);
+				Document doc = Main.getDocBuilder().parse(xmlFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/CharacterUtils.java
+++ b/src/com/lilithsthrone/game/character/CharacterUtils.java
@@ -15,15 +15,14 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -146,8 +145,7 @@ public class CharacterUtils {
 //			long timeStart = System.nanoTime();
 //			System.out.println(timeStart);
 			
-			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+			DocumentBuilder docBuilder = Game.docFactory.newDocumentBuilder();
 			
 			Document doc = docBuilder.newDocument();
 			
@@ -159,8 +157,7 @@ public class CharacterUtils {
 			
 //			System.out.println("Difference2: "+(System.nanoTime()-timeStart)/1000000000f);
 			
-			TransformerFactory tf = TransformerFactory.newInstance();
-			Transformer transformer1 = tf.newTransformer();
+			Transformer transformer1 = Game.transformerFactory.newTransformer();
 			transformer1.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 			StringWriter writer = new StringWriter();
 
@@ -175,8 +172,7 @@ public class CharacterUtils {
 //			System.out.println(output);
 			
 			// Save this xml:
-			TransformerFactory transformerFactory = TransformerFactory.newInstance();
-			Transformer transformer = transformerFactory.newTransformer();
+			Transformer transformer = Game.transformerFactory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 			DOMSource source = new DOMSource(doc);
@@ -227,8 +223,7 @@ public class CharacterUtils {
 		
 		if (xmlFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(xmlFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/CharacterUtils.java
+++ b/src/com/lilithsthrone/game/character/CharacterUtils.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -144,10 +143,8 @@ public class CharacterUtils {
 		try {
 //			long timeStart = System.nanoTime();
 //			System.out.println(timeStart);
-			
-			DocumentBuilder docBuilder = Game.docFactory.newDocumentBuilder();
-			
-			Document doc = docBuilder.newDocument();
+
+			Document doc = Game.docBuilder.newDocument();
 			
 			Element properties = doc.createElement("playerCharacter");
 			doc.appendChild(properties);
@@ -197,7 +194,7 @@ public class CharacterUtils {
 			
 			transformer.transform(source, result);
 		
-		} catch (ParserConfigurationException | TransformerException e) {
+		} catch (TransformerException e) {
 			e.printStackTrace();
 		}
 	}
@@ -223,8 +220,7 @@ public class CharacterUtils {
 		
 		if (xmlFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(xmlFile);
+				Document doc = Game.docBuilder.parse(xmlFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAntennaType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAntennaType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -90,8 +88,7 @@ public abstract class AbstractAntennaType implements BodyPartTypeInterface {
 	public AbstractAntennaType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAntennaType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAntennaType.java
@@ -88,7 +88,7 @@ public abstract class AbstractAntennaType implements BodyPartTypeInterface {
 	public AbstractAntennaType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAntennaType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAntennaType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -88,7 +88,7 @@ public abstract class AbstractAntennaType implements BodyPartTypeInterface {
 	public AbstractAntennaType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAntennaType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAntennaType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -90,8 +90,7 @@ public abstract class AbstractAntennaType implements BodyPartTypeInterface {
 	public AbstractAntennaType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAnusType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAnusType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -82,8 +82,7 @@ public abstract class AbstractAnusType implements BodyPartTypeInterface {
 	public AbstractAnusType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAnusType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAnusType.java
@@ -80,7 +80,7 @@ public abstract class AbstractAnusType implements BodyPartTypeInterface {
 	public AbstractAnusType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAnusType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAnusType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -80,7 +80,7 @@ public abstract class AbstractAnusType implements BodyPartTypeInterface {
 	public AbstractAnusType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAnusType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAnusType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -82,8 +80,7 @@ public abstract class AbstractAnusType implements BodyPartTypeInterface {
 	public AbstractAnusType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractArmType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractArmType.java
@@ -129,7 +129,7 @@ public abstract class AbstractArmType implements BodyPartTypeInterface {
 	public AbstractArmType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractArmType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractArmType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -129,7 +129,7 @@ public abstract class AbstractArmType implements BodyPartTypeInterface {
 	public AbstractArmType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractArmType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractArmType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -131,8 +129,7 @@ public abstract class AbstractArmType implements BodyPartTypeInterface {
 	public AbstractArmType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractArmType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractArmType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -131,8 +131,7 @@ public abstract class AbstractArmType implements BodyPartTypeInterface {
 	public AbstractArmType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAssType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAssType.java
@@ -84,7 +84,7 @@ public abstract class AbstractAssType implements BodyPartTypeInterface {
 	public AbstractAssType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAssType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAssType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -86,8 +86,7 @@ public abstract class AbstractAssType implements BodyPartTypeInterface {
 	public AbstractAssType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAssType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAssType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -86,8 +84,7 @@ public abstract class AbstractAssType implements BodyPartTypeInterface {
 	public AbstractAssType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAssType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractAssType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -84,7 +84,7 @@ public abstract class AbstractAssType implements BodyPartTypeInterface {
 	public AbstractAssType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractBreastType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractBreastType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -128,8 +126,7 @@ public abstract class AbstractBreastType implements BodyPartTypeInterface {
 	public AbstractBreastType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractBreastType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractBreastType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -128,8 +128,7 @@ public abstract class AbstractBreastType implements BodyPartTypeInterface {
 	public AbstractBreastType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractBreastType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractBreastType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -126,7 +126,7 @@ public abstract class AbstractBreastType implements BodyPartTypeInterface {
 	public AbstractBreastType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractBreastType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractBreastType.java
@@ -126,7 +126,7 @@ public abstract class AbstractBreastType implements BodyPartTypeInterface {
 	public AbstractBreastType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEarType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEarType.java
@@ -88,7 +88,7 @@ public abstract class AbstractEarType implements BodyPartTypeInterface {
 	public AbstractEarType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEarType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEarType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -88,7 +88,7 @@ public abstract class AbstractEarType implements BodyPartTypeInterface {
 	public AbstractEarType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEarType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEarType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -90,8 +90,7 @@ public abstract class AbstractEarType implements BodyPartTypeInterface {
 	public AbstractEarType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEarType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEarType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -90,8 +88,7 @@ public abstract class AbstractEarType implements BodyPartTypeInterface {
 	public AbstractEarType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEyeType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEyeType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -105,8 +105,7 @@ public abstract class AbstractEyeType implements BodyPartTypeInterface {
 	public AbstractEyeType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEyeType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEyeType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -103,7 +103,7 @@ public abstract class AbstractEyeType implements BodyPartTypeInterface {
 	public AbstractEyeType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEyeType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEyeType.java
@@ -103,7 +103,7 @@ public abstract class AbstractEyeType implements BodyPartTypeInterface {
 	public AbstractEyeType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEyeType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractEyeType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -105,8 +103,7 @@ public abstract class AbstractEyeType implements BodyPartTypeInterface {
 	public AbstractEyeType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFaceType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFaceType.java
@@ -148,7 +148,7 @@ public abstract class AbstractFaceType implements BodyPartTypeInterface {
 	public AbstractFaceType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFaceType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFaceType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -150,8 +148,7 @@ public abstract class AbstractFaceType implements BodyPartTypeInterface {
 	public AbstractFaceType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFaceType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFaceType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -148,7 +148,7 @@ public abstract class AbstractFaceType implements BodyPartTypeInterface {
 	public AbstractFaceType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFaceType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFaceType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -150,8 +150,7 @@ public abstract class AbstractFaceType implements BodyPartTypeInterface {
 	public AbstractFaceType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFluidType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFluidType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -89,8 +87,7 @@ public abstract class AbstractFluidType implements BodyPartTypeInterface {
 	public AbstractFluidType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFluidType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFluidType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -89,8 +89,7 @@ public abstract class AbstractFluidType implements BodyPartTypeInterface {
 	public AbstractFluidType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFluidType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFluidType.java
@@ -87,7 +87,7 @@ public abstract class AbstractFluidType implements BodyPartTypeInterface {
 	public AbstractFluidType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFluidType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractFluidType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -87,7 +87,7 @@ public abstract class AbstractFluidType implements BodyPartTypeInterface {
 	public AbstractFluidType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHairType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHairType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -95,8 +95,7 @@ public abstract class AbstractHairType implements BodyPartTypeInterface {
 	public AbstractHairType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHairType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHairType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -95,8 +93,7 @@ public abstract class AbstractHairType implements BodyPartTypeInterface {
 	public AbstractHairType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHairType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHairType.java
@@ -93,7 +93,7 @@ public abstract class AbstractHairType implements BodyPartTypeInterface {
 	public AbstractHairType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHairType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHairType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -93,7 +93,7 @@ public abstract class AbstractHairType implements BodyPartTypeInterface {
 	public AbstractHairType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHornType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHornType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -91,8 +91,7 @@ public abstract class AbstractHornType implements BodyPartTypeInterface {
 	public AbstractHornType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHornType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHornType.java
@@ -89,7 +89,7 @@ public abstract class AbstractHornType implements BodyPartTypeInterface {
 	public AbstractHornType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHornType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHornType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -89,7 +89,7 @@ public abstract class AbstractHornType implements BodyPartTypeInterface {
 	public AbstractHornType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHornType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractHornType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -91,8 +89,7 @@ public abstract class AbstractHornType implements BodyPartTypeInterface {
 	public AbstractHornType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractLegType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractLegType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -163,8 +161,7 @@ public abstract class AbstractLegType implements BodyPartTypeInterface {
 	public AbstractLegType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractLegType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractLegType.java
@@ -161,7 +161,7 @@ public abstract class AbstractLegType implements BodyPartTypeInterface {
 	public AbstractLegType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractLegType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractLegType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -163,8 +163,7 @@ public abstract class AbstractLegType implements BodyPartTypeInterface {
 	public AbstractLegType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractLegType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractLegType.java
@@ -161,7 +161,7 @@ public abstract class AbstractLegType implements BodyPartTypeInterface {
 	public AbstractLegType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractMouthType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractMouthType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -115,8 +115,7 @@ public abstract class AbstractMouthType implements BodyPartTypeInterface {
 	public AbstractMouthType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractMouthType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractMouthType.java
@@ -113,7 +113,7 @@ public abstract class AbstractMouthType implements BodyPartTypeInterface {
 	public AbstractMouthType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractMouthType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractMouthType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -113,7 +113,7 @@ public abstract class AbstractMouthType implements BodyPartTypeInterface {
 	public AbstractMouthType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractMouthType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractMouthType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -115,8 +113,7 @@ public abstract class AbstractMouthType implements BodyPartTypeInterface {
 	public AbstractMouthType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractNippleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractNippleType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -69,8 +67,7 @@ public abstract class AbstractNippleType implements BodyPartTypeInterface {
 	public AbstractNippleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractNippleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractNippleType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -67,7 +67,7 @@ public abstract class AbstractNippleType implements BodyPartTypeInterface {
 	public AbstractNippleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractNippleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractNippleType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -69,8 +69,7 @@ public abstract class AbstractNippleType implements BodyPartTypeInterface {
 	public AbstractNippleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractNippleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractNippleType.java
@@ -67,7 +67,7 @@ public abstract class AbstractNippleType implements BodyPartTypeInterface {
 	public AbstractNippleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractPenisType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractPenisType.java
@@ -7,8 +7,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -138,8 +138,7 @@ public abstract class AbstractPenisType implements BodyPartTypeInterface {
 	public AbstractPenisType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractPenisType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractPenisType.java
@@ -6,8 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -138,8 +136,7 @@ public abstract class AbstractPenisType implements BodyPartTypeInterface {
 	public AbstractPenisType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractPenisType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractPenisType.java
@@ -136,7 +136,7 @@ public abstract class AbstractPenisType implements BodyPartTypeInterface {
 	public AbstractPenisType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractPenisType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractPenisType.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -136,7 +136,7 @@ public abstract class AbstractPenisType implements BodyPartTypeInterface {
 	public AbstractPenisType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTailType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTailType.java
@@ -136,7 +136,7 @@ public abstract class AbstractTailType implements BodyPartTypeInterface {
 	public AbstractTailType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTailType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTailType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -138,8 +136,7 @@ public abstract class AbstractTailType implements BodyPartTypeInterface {
 	public AbstractTailType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTailType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTailType.java
@@ -136,7 +136,7 @@ public abstract class AbstractTailType implements BodyPartTypeInterface {
 	public AbstractTailType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTailType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTailType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -138,8 +138,7 @@ public abstract class AbstractTailType implements BodyPartTypeInterface {
 	public AbstractTailType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTentacleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTentacleType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -130,8 +128,7 @@ public abstract class AbstractTentacleType implements BodyPartTypeInterface {
 	public AbstractTentacleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTentacleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTentacleType.java
@@ -128,7 +128,7 @@ public abstract class AbstractTentacleType implements BodyPartTypeInterface {
 	public AbstractTentacleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTentacleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTentacleType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -130,8 +130,7 @@ public abstract class AbstractTentacleType implements BodyPartTypeInterface {
 	public AbstractTentacleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTentacleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTentacleType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -128,7 +128,7 @@ public abstract class AbstractTentacleType implements BodyPartTypeInterface {
 	public AbstractTentacleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTesticleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTesticleType.java
@@ -79,7 +79,7 @@ public abstract class AbstractTesticleType implements BodyPartTypeInterface {
 	public AbstractTesticleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTesticleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTesticleType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -81,8 +81,7 @@ public abstract class AbstractTesticleType implements BodyPartTypeInterface {
 	public AbstractTesticleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTesticleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTesticleType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -79,7 +79,7 @@ public abstract class AbstractTesticleType implements BodyPartTypeInterface {
 	public AbstractTesticleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTesticleType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTesticleType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -81,8 +79,7 @@ public abstract class AbstractTesticleType implements BodyPartTypeInterface {
 	public AbstractTesticleType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTongueType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTongueType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -86,8 +86,7 @@ public abstract class AbstractTongueType implements BodyPartTypeInterface {
 	public AbstractTongueType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTongueType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTongueType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -86,8 +84,7 @@ public abstract class AbstractTongueType implements BodyPartTypeInterface {
 	public AbstractTongueType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTongueType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTongueType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -84,7 +84,7 @@ public abstract class AbstractTongueType implements BodyPartTypeInterface {
 	public AbstractTongueType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTongueType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTongueType.java
@@ -84,7 +84,7 @@ public abstract class AbstractTongueType implements BodyPartTypeInterface {
 	public AbstractTongueType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTorsoType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTorsoType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -78,8 +78,7 @@ public abstract class AbstractTorsoType implements BodyPartTypeInterface {
 	public AbstractTorsoType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTorsoType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTorsoType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -76,7 +76,7 @@ public abstract class AbstractTorsoType implements BodyPartTypeInterface {
 	public AbstractTorsoType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTorsoType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTorsoType.java
@@ -76,7 +76,7 @@ public abstract class AbstractTorsoType implements BodyPartTypeInterface {
 	public AbstractTorsoType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTorsoType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractTorsoType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -78,8 +76,7 @@ public abstract class AbstractTorsoType implements BodyPartTypeInterface {
 	public AbstractTorsoType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractVaginaType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractVaginaType.java
@@ -144,7 +144,7 @@ public abstract class AbstractVaginaType implements BodyPartTypeInterface {
 	public AbstractVaginaType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractVaginaType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractVaginaType.java
@@ -6,8 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -146,8 +144,7 @@ public abstract class AbstractVaginaType implements BodyPartTypeInterface {
 	public AbstractVaginaType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractVaginaType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractVaginaType.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -144,7 +144,7 @@ public abstract class AbstractVaginaType implements BodyPartTypeInterface {
 	public AbstractVaginaType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractVaginaType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractVaginaType.java
@@ -7,8 +7,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -146,8 +146,7 @@ public abstract class AbstractVaginaType implements BodyPartTypeInterface {
 	public AbstractVaginaType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractWingType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractWingType.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -97,7 +97,7 @@ public abstract class AbstractWingType implements BodyPartTypeInterface {
 	public AbstractWingType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractWingType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractWingType.java
@@ -97,7 +97,7 @@ public abstract class AbstractWingType implements BodyPartTypeInterface {
 	public AbstractWingType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractWingType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractWingType.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -99,8 +99,7 @@ public abstract class AbstractWingType implements BodyPartTypeInterface {
 	public AbstractWingType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractWingType.java
+++ b/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractWingType.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -99,8 +97,7 @@ public abstract class AbstractWingType implements BodyPartTypeInterface {
 	public AbstractWingType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/coverings/AbstractBodyCoveringType.java
+++ b/src/com/lilithsthrone/game/character/body/coverings/AbstractBodyCoveringType.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -204,7 +204,7 @@ public abstract class AbstractBodyCoveringType {
 	public AbstractBodyCoveringType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/coverings/AbstractBodyCoveringType.java
+++ b/src/com/lilithsthrone/game/character/body/coverings/AbstractBodyCoveringType.java
@@ -204,7 +204,7 @@ public abstract class AbstractBodyCoveringType {
 	public AbstractBodyCoveringType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/coverings/AbstractBodyCoveringType.java
+++ b/src/com/lilithsthrone/game/character/body/coverings/AbstractBodyCoveringType.java
@@ -9,8 +9,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -206,8 +204,7 @@ public abstract class AbstractBodyCoveringType {
 	public AbstractBodyCoveringType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/body/coverings/AbstractBodyCoveringType.java
+++ b/src/com/lilithsthrone/game/character/body/coverings/AbstractBodyCoveringType.java
@@ -10,8 +10,8 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -206,8 +206,7 @@ public abstract class AbstractBodyCoveringType {
 	public AbstractBodyCoveringType(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/effects/AbstractStatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/AbstractStatusEffect.java
@@ -185,7 +185,7 @@ public abstract class AbstractStatusEffect {
 	public AbstractStatusEffect(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/effects/AbstractStatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/AbstractStatusEffect.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import javax.script.ScriptException;
-import javax.xml.parsers.DocumentBuilder;
 
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
@@ -186,8 +185,7 @@ public abstract class AbstractStatusEffect {
 	public AbstractStatusEffect(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/effects/AbstractStatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/AbstractStatusEffect.java
@@ -16,8 +16,8 @@ import java.util.Set;
 
 import javax.script.ScriptException;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -186,8 +186,7 @@ public abstract class AbstractStatusEffect {
 	public AbstractStatusEffect(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/effects/AbstractStatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/AbstractStatusEffect.java
@@ -185,7 +185,7 @@ public abstract class AbstractStatusEffect {
 	public AbstractStatusEffect(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/markings/AbstractTattooType.java
+++ b/src/com/lilithsthrone/game/character/markings/AbstractTattooType.java
@@ -10,8 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -110,8 +108,7 @@ public class AbstractTattooType extends AbstractCoreType {
 
 		if (tattooXMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(tattooXMLFile);
+				Document doc = Game.docBuilder.parse(tattooXMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/markings/AbstractTattooType.java
+++ b/src/com/lilithsthrone/game/character/markings/AbstractTattooType.java
@@ -108,7 +108,7 @@ public class AbstractTattooType extends AbstractCoreType {
 
 		if (tattooXMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(tattooXMLFile);
+				Document doc = Main.getDocBuilder().parse(tattooXMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/markings/AbstractTattooType.java
+++ b/src/com/lilithsthrone/game/character/markings/AbstractTattooType.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -108,7 +108,7 @@ public class AbstractTattooType extends AbstractCoreType {
 
 		if (tattooXMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(tattooXMLFile);
+				Document doc = Main.docBuilder.parse(tattooXMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/markings/AbstractTattooType.java
+++ b/src/com/lilithsthrone/game/character/markings/AbstractTattooType.java
@@ -11,8 +11,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -110,8 +110,7 @@ public class AbstractTattooType extends AbstractCoreType {
 
 		if (tattooXMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(tattooXMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/race/AbstractRace.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractRace.java
@@ -5,8 +5,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -152,8 +152,7 @@ public abstract class AbstractRace {
 	public AbstractRace(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/race/AbstractRace.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractRace.java
@@ -150,7 +150,7 @@ public abstract class AbstractRace {
 	public AbstractRace(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/race/AbstractRace.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractRace.java
@@ -150,7 +150,7 @@ public abstract class AbstractRace {
 	public AbstractRace(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/race/AbstractRace.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractRace.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -152,8 +150,7 @@ public abstract class AbstractRace {
 	public AbstractRace(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/race/AbstractRacialBody.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractRacialBody.java
@@ -457,7 +457,7 @@ public abstract class AbstractRacialBody {
 	public AbstractRacialBody(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/race/AbstractRacialBody.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractRacialBody.java
@@ -8,8 +8,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -459,8 +459,7 @@ public abstract class AbstractRacialBody {
 	public AbstractRacialBody(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/character/race/AbstractRacialBody.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractRacialBody.java
@@ -7,8 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -459,8 +457,7 @@ public abstract class AbstractRacialBody {
 	public AbstractRacialBody(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/race/AbstractRacialBody.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractRacialBody.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -457,7 +457,7 @@ public abstract class AbstractRacialBody {
 	public AbstractRacialBody(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -371,7 +371,7 @@ public abstract class AbstractSubspecies {
 	public AbstractSubspecies(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -371,7 +371,7 @@ public abstract class AbstractSubspecies {
 	public AbstractSubspecies(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -13,8 +13,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -373,8 +371,7 @@ public abstract class AbstractSubspecies {
 	public AbstractSubspecies(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -373,8 +373,7 @@ public abstract class AbstractSubspecies {
 	public AbstractSubspecies(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/combat/moves/AbstractCombatMove.java
+++ b/src/com/lilithsthrone/game/combat/moves/AbstractCombatMove.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -206,8 +206,7 @@ public abstract class AbstractCombatMove {
 	public AbstractCombatMove(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/combat/moves/AbstractCombatMove.java
+++ b/src/com/lilithsthrone/game/combat/moves/AbstractCombatMove.java
@@ -204,7 +204,7 @@ public abstract class AbstractCombatMove {
 	public AbstractCombatMove(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/combat/moves/AbstractCombatMove.java
+++ b/src/com/lilithsthrone/game/combat/moves/AbstractCombatMove.java
@@ -9,8 +9,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -206,8 +204,7 @@ public abstract class AbstractCombatMove {
 	public AbstractCombatMove(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/combat/moves/AbstractCombatMove.java
+++ b/src/com/lilithsthrone/game/combat/moves/AbstractCombatMove.java
@@ -204,7 +204,7 @@ public abstract class AbstractCombatMove {
 	public AbstractCombatMove(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
@@ -11,15 +11,14 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -967,8 +966,7 @@ public class EnchantmentDialogue {
 		try {
 			// Starting stuff:
 			
-			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+			DocumentBuilder docBuilder = Game.docFactory.newDocumentBuilder();
 			
 			Document doc = docBuilder.newDocument();
 			
@@ -1009,16 +1007,14 @@ public class EnchantmentDialogue {
 			
 			// Ending stuff:
 			
-			TransformerFactory tf = TransformerFactory.newInstance();
-			Transformer transformer1 = tf.newTransformer();
+			Transformer transformer1 = Game.transformerFactory.newTransformer();
 			transformer1.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 			StringWriter writer = new StringWriter();
 
 			transformer1.transform(new DOMSource(doc), new StreamResult(writer));
 			
 			// Save this xml:
-			TransformerFactory transformerFactory = TransformerFactory.newInstance();
-			Transformer transformer = transformerFactory.newTransformer();
+			Transformer transformer = Game.transformerFactory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 			DOMSource source = new DOMSource(doc);
@@ -1042,8 +1038,7 @@ public class EnchantmentDialogue {
 
 			if (file.exists()) {
 				try {
-					DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-					DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+					DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 					Document doc = dBuilder.parse(file);
 					
 					// Cast magic:

--- a/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -965,10 +964,7 @@ public class EnchantmentDialogue {
 
 		try {
 			// Starting stuff:
-			
-			DocumentBuilder docBuilder = Game.docFactory.newDocumentBuilder();
-			
-			Document doc = docBuilder.newDocument();
+			Document doc = Game.docBuilder.newDocument();
 			
 			Element enchantment = doc.createElement("enchantment");
 			doc.appendChild(enchantment);
@@ -1038,8 +1034,7 @@ public class EnchantmentDialogue {
 
 			if (file.exists()) {
 				try {
-					DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-					Document doc = dBuilder.parse(file);
+					Document doc = Game.docBuilder.parse(file);
 					
 					// Cast magic:
 					doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
@@ -964,7 +964,7 @@ public class EnchantmentDialogue {
 
 		try {
 			// Starting stuff:
-			Document doc = Game.docBuilder.newDocument();
+			Document doc = Main.docBuilder.newDocument();
 			
 			Element enchantment = doc.createElement("enchantment");
 			doc.appendChild(enchantment);
@@ -1003,14 +1003,14 @@ public class EnchantmentDialogue {
 			
 			// Ending stuff:
 			
-			Transformer transformer1 = Game.transformerFactory.newTransformer();
+			Transformer transformer1 = Main.transformerFactory.newTransformer();
 			transformer1.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
 			StringWriter writer = new StringWriter();
 
 			transformer1.transform(new DOMSource(doc), new StreamResult(writer));
 			
 			// Save this xml:
-			Transformer transformer = Game.transformerFactory.newTransformer();
+			Transformer transformer = Main.transformerFactory.newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
 			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 			DOMSource source = new DOMSource(doc);
@@ -1020,8 +1020,6 @@ public class EnchantmentDialogue {
 			
 			transformer.transform(source, result);
 			
-		} catch (ParserConfigurationException pce) {
-			pce.printStackTrace();
 		} catch (TransformerException tfe) {
 			tfe.printStackTrace();
 		}
@@ -1034,7 +1032,7 @@ public class EnchantmentDialogue {
 
 			if (file.exists()) {
 				try {
-					Document doc = Game.docBuilder.parse(file);
+					Document doc = Main.docBuilder.parse(file);
 					
 					// Cast magic:
 					doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/EnchantmentDialogue.java
@@ -10,14 +10,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -964,7 +962,7 @@ public class EnchantmentDialogue {
 
 		try {
 			// Starting stuff:
-			Document doc = Main.docBuilder.newDocument();
+			Document doc = Main.getDocBuilder().newDocument();
 			
 			Element enchantment = doc.createElement("enchantment");
 			doc.appendChild(enchantment);
@@ -1032,7 +1030,7 @@ public class EnchantmentDialogue {
 
 			if (file.exists()) {
 				try {
-					Document doc = Main.docBuilder.parse(file);
+					Document doc = Main.getDocBuilder().parse(file);
 					
 					// Cast magic:
 					doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -802,7 +802,7 @@ public class UtilText {
 		
 		if(file.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(file);
+				Document doc = Main.docBuilder.parse(file);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();
@@ -849,7 +849,7 @@ public class UtilText {
 		
 		if (file.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(file);
+				Document doc = Main.docBuilder.parse(file);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -21,7 +21,6 @@ import java.util.regex.Pattern;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
-import javax.xml.parsers.DocumentBuilder;
 
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
@@ -803,8 +802,7 @@ public class UtilText {
 		
 		if(file.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(file);
+				Document doc = Game.docBuilder.parse(file);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();
@@ -851,8 +849,7 @@ public class UtilText {
 		
 		if (file.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(file);
+				Document doc = Game.docBuilder.parse(file);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -22,8 +22,8 @@ import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -803,8 +803,7 @@ public class UtilText {
 		
 		if(file.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(file);
 				
 				// Cast magic:
@@ -852,8 +851,7 @@ public class UtilText {
 		
 		if (file.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(file);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -803,7 +803,7 @@ public class UtilText {
 		
 		if(file.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(file);
+				Document doc = Main.getDocBuilder().parse(file);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();
@@ -850,7 +850,7 @@ public class UtilText {
 		
 		if (file.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(file);
+				Document doc = Main.getDocBuilder().parse(file);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -210,7 +210,8 @@ public class UtilText {
 //	private static List<GameCharacter> specialNPCList = new ArrayList<>();
 	private static boolean parseCapitalise;
 	private static boolean parseAddPronoun;
-	
+
+	private static NashornScriptEngineFactory factory = new NashornScriptEngineFactory();
 	private static ScriptEngine engine;
 	
 	private static List<String> specialParsingStrings = new ArrayList<>();
@@ -9103,8 +9104,6 @@ public class UtilText {
 	}
 	
 	public static void initScriptEngine() {
-		
-		NashornScriptEngineFactory factory = new NashornScriptEngineFactory();
 		// http://hg.openjdk.java.net/jdk8/jdk8/nashorn/rev/eb7b8340ce3a
 		engine = factory.getScriptEngine("-strict", "--no-java", "--no-syntax-extensions");//, "-scripting");
 		try {

--- a/src/com/lilithsthrone/game/inventory/AbstractSetBonus.java
+++ b/src/com/lilithsthrone/game/inventory/AbstractSetBonus.java
@@ -44,7 +44,7 @@ public abstract class AbstractSetBonus {
 	public AbstractSetBonus(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/inventory/AbstractSetBonus.java
+++ b/src/com/lilithsthrone/game/inventory/AbstractSetBonus.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -46,8 +46,7 @@ public abstract class AbstractSetBonus {
 	public AbstractSetBonus(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/inventory/AbstractSetBonus.java
+++ b/src/com/lilithsthrone/game/inventory/AbstractSetBonus.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -44,7 +44,7 @@ public abstract class AbstractSetBonus {
 	public AbstractSetBonus(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
+				Document doc = Main.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/inventory/AbstractSetBonus.java
+++ b/src/com/lilithsthrone/game/inventory/AbstractSetBonus.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -46,8 +44,7 @@ public abstract class AbstractSetBonus {
 	public AbstractSetBonus(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/inventory/weapon/AbstractWeaponType.java
+++ b/src/com/lilithsthrone/game/inventory/weapon/AbstractWeaponType.java
@@ -17,7 +17,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -117,7 +117,7 @@ public abstract class AbstractWeaponType extends AbstractCoreType {
 
 		if (weaponXMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(weaponXMLFile);
+				Document doc = Main.docBuilder.parse(weaponXMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/inventory/weapon/AbstractWeaponType.java
+++ b/src/com/lilithsthrone/game/inventory/weapon/AbstractWeaponType.java
@@ -18,8 +18,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -119,8 +119,7 @@ public abstract class AbstractWeaponType extends AbstractCoreType {
 
 		if (weaponXMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(weaponXMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/game/inventory/weapon/AbstractWeaponType.java
+++ b/src/com/lilithsthrone/game/inventory/weapon/AbstractWeaponType.java
@@ -117,7 +117,7 @@ public abstract class AbstractWeaponType extends AbstractCoreType {
 
 		if (weaponXMLFile.exists()) {
 			try {
-				Document doc = Main.docBuilder.parse(weaponXMLFile);
+				Document doc = Main.getDocBuilder().parse(weaponXMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/game/inventory/weapon/AbstractWeaponType.java
+++ b/src/com/lilithsthrone/game/inventory/weapon/AbstractWeaponType.java
@@ -17,8 +17,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -119,8 +117,7 @@ public abstract class AbstractWeaponType extends AbstractCoreType {
 
 		if (weaponXMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(weaponXMLFile);
+				Document doc = Game.docBuilder.parse(weaponXMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/main/Main.java
+++ b/src/com/lilithsthrone/main/Main.java
@@ -51,6 +51,11 @@ import javafx.scene.layout.Pane;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.TransformerFactory;
+
 /**
  * @since 0.1.0
  * @version 0.3.10
@@ -61,6 +66,10 @@ public class Main extends Application {
 	public static Game game;
 	public static Sex sex;
 	public static Combat combat;
+
+	public static TransformerFactory transformerFactory = TransformerFactory.newInstance();
+	public static DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+	public static DocumentBuilder docBuilder;
 
 	public static MainController mainController;
 
@@ -1026,7 +1035,13 @@ public class Main extends Application {
 		dir.mkdir();
 		dir = new File("data/characters");
 		dir.mkdir();
-		
+
+		try {
+			docBuilder = docFactory.newDocumentBuilder();
+		} catch (ParserConfigurationException e) {
+			e.printStackTrace();
+		}
+
 		// Open error log
 		if(!DEBUG) {
 			System.out.println("Printing to error.log");

--- a/src/com/lilithsthrone/main/Main.java
+++ b/src/com/lilithsthrone/main/Main.java
@@ -68,8 +68,8 @@ public class Main extends Application {
 	public static Combat combat;
 
 	public static TransformerFactory transformerFactory = TransformerFactory.newInstance();
-	public static DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-	public static DocumentBuilder docBuilder;
+	private static DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+	private static DocumentBuilder docBuilder;
 
 	public static MainController mainController;
 
@@ -1026,6 +1026,17 @@ public class Main extends Application {
 		return Paths.get(path).toUri().toString().replaceAll("%20", " ");
 	}
 
+	public static DocumentBuilder getDocBuilder() {
+		if (docBuilder == null) {
+			try {
+				docBuilder = docFactory.newDocumentBuilder();
+			} catch (ParserConfigurationException e) {
+				e.printStackTrace();
+			}
+		}
+		return docBuilder;
+	}
+
 	public static void main(String[] args) {
 		
 		// Create folders:
@@ -1035,14 +1046,6 @@ public class Main extends Application {
 		dir.mkdir();
 		dir = new File("data/characters");
 		dir.mkdir();
-
-		try {
-			if (Main.docBuilder==null) {
-				Main.docBuilder = Main.docFactory.newDocumentBuilder();
-			}
-		} catch (ParserConfigurationException e) {
-			e.printStackTrace();
-		}
 
 		// Open error log
 		if(!DEBUG) {

--- a/src/com/lilithsthrone/main/Main.java
+++ b/src/com/lilithsthrone/main/Main.java
@@ -1037,7 +1037,9 @@ public class Main extends Application {
 		dir.mkdir();
 
 		try {
-			docBuilder = docFactory.newDocumentBuilder();
+			if (Main.docBuilder==null) {
+				Main.docBuilder = Main.docFactory.newDocumentBuilder();
+			}
 		} catch (ParserConfigurationException e) {
 			e.printStackTrace();
 		}

--- a/src/com/lilithsthrone/rendering/Artwork.java
+++ b/src/com/lilithsthrone/rendering/Artwork.java
@@ -6,8 +6,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -49,8 +49,7 @@ public class Artwork {
 			for(File subFile : dir.listFiles(textFilter)) {
 				if (subFile.exists()) {
 					try {
-						DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-						DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+						DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 						Document doc = dBuilder.parse(subFile);
 						
 						// Cast magic:

--- a/src/com/lilithsthrone/rendering/Artwork.java
+++ b/src/com/lilithsthrone/rendering/Artwork.java
@@ -47,7 +47,7 @@ public class Artwork {
 			for(File subFile : dir.listFiles(textFilter)) {
 				if (subFile.exists()) {
 					try {
-						Document doc = Main.docBuilder.parse(subFile);
+						Document doc = Main.getDocBuilder().parse(subFile);
 						
 						// Cast magic:
 						doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/rendering/Artwork.java
+++ b/src/com/lilithsthrone/rendering/Artwork.java
@@ -5,7 +5,7 @@ import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
+import com.lilithsthrone.main.Main;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -47,7 +47,7 @@ public class Artwork {
 			for(File subFile : dir.listFiles(textFilter)) {
 				if (subFile.exists()) {
 					try {
-						Document doc = Game.docBuilder.parse(subFile);
+						Document doc = Main.docBuilder.parse(subFile);
 						
 						// Cast magic:
 						doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/rendering/Artwork.java
+++ b/src/com/lilithsthrone/rendering/Artwork.java
@@ -5,8 +5,6 @@ import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -49,8 +47,7 @@ public class Artwork {
 			for(File subFile : dir.listFiles(textFilter)) {
 				if (subFile.exists()) {
 					try {
-						DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-						Document doc = dBuilder.parse(subFile);
+						Document doc = Game.docBuilder.parse(subFile);
 						
 						// Cast magic:
 						doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/res/doc/todo_list.txt
+++ b/src/com/lilithsthrone/res/doc/todo_list.txt
@@ -30,7 +30,7 @@ Not everything in this file is up-to-date, and everything is subject to change a
 	
 	Contributions:
 		Added support for multiple vagina or penis types per race in enchanted TF potion effects. (PR#1465 by Stadler76)
-		Fixed issue where the player's elemental had their combat moves reset every time you loading a saved game. (by AceXP)
+		Fixed issue where the combat moves of the player's elemental were reset. (by AceXP)
 	 	Fixed softlock at the end of combat when fighting imps in Submission. (by AceXP)
 		Improved performance by caching subspecies variables and only doing a recalculation when needed. (PR#1471 by AceXP)
 		Fixed typo in 'Ear pull' blowjob action. (PR#1472 by darkofoc)
@@ -532,11 +532,6 @@ Not everything in this file is up-to-date, and everything is subject to change a
 	Bug reports needs checking
 		From: "minor error with how the description for a spider lower..."
 	
-	exk bug:
-		It is related to the MC having a elemental with a passive form of HARPY_PHOENIX, so rather exotic.
-		 The resulting subspecies object for this has several fields that are Null, including things like SVGStringUncoloured. Which then leads to NullPointerExceptions in the ColourReplacement function.
-		 This leads to the left and right panels not rendering anymore.
-	 
 	Well one of my slaves just drained me of 4 levels and I was watching (Meta wise, she didnt know i was even there)
 		Prevent spectators from being drained
 	 
@@ -572,7 +567,7 @@ Not everything in this file is up-to-date, and everything is subject to change a
 	
 	we need an option to have Lilaya keep her skin tone when she becomes a full demon
 	
-	Adding images to characters not working if png image is PNG
+	Adding images to characters not working if png image is PNG (check PR #1448 by Cognitive Mist)
 	
 	Pubes on furry morphs being referred to as bushy fur instead of hair on morphs that have fur when
 	
@@ -590,8 +585,6 @@ Not everything in this file is up-to-date, and everything is subject to change a
 	If you are already a slime before you met your first slime in the tunnels then you can't be slimed by that slime and you will never learn about the Slime Queen
 	
 	For these pills, although there is a determiner provided in the XML file, the items in the game have a null value for determiner
-	
-	Check 'Kevin' save for multiple clients in Angel's Kiss bug
 	
 	male imp has "succubus-cock"?
 	
@@ -611,12 +604,6 @@ Not everything in this file is up-to-date, and everything is subject to change a
 	go slime -> demon horse legs -> taur -> unslime
 		demon gets slime options
 	
-	1. Visit any merchant
-	2. Select any enchantable item from the player character's inventory
-	3. Click on enchant
-	4. Without exiting the enchant window (cancel/finish enchantment), click on either player character or npc's equipped item inventory
-	5. Shop inventory becomes free to take, so is equipped ones
-	
 	unrelated to that, I did notice that 'well rested' seems to be applied after your hp/aura is refilled
 		went to bed at 39/39 hp and woke up with 40/70 or so
 	
@@ -635,7 +622,7 @@ Not everything in this file is up-to-date, and everything is subject to change a
 	
 	I suggest adding a selection of fetishes to the section on sexual experiences when creating a character
 	
-	Found a bug where player youkos for some reason have access to the slime transform menu
+	Found a bug where player youkos for some reason have access to the slime transform menu (need to account for self transform ability in transformtion dialogs) Now only demon/slime/debug.
 	
 	Blaze/Crystal post-victory scene should be travel disabled with option to continue (like Max)
 	
@@ -881,7 +868,7 @@ Not everything in this file is up-to-date, and everything is subject to change a
 	set weapon damage as tier constants
 	
 	coloured cum/milk/girlcum/saliva
-	
+
 	Enchanting a Burning opaque demonstone with + Fire damage doesn't affect unarmed fire damage
 		only + unarmed damage is affecting its melee damage. +fire damage isn't applying at all
 	

--- a/src/com/lilithsthrone/utils/Util.java
+++ b/src/com/lilithsthrone/utils/Util.java
@@ -26,8 +26,6 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -295,8 +293,7 @@ public class Util {
 	
 	public static String getXmlRootElementName(File XMLFile) {
 		try {
-			DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-			Document doc = dBuilder.parse(XMLFile);
+			Document doc = Game.docBuilder.parse(XMLFile);
 			
 			// Cast magic:
 			doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/utils/Util.java
+++ b/src/com/lilithsthrone/utils/Util.java
@@ -293,8 +293,8 @@ public class Util {
 	
 	public static String getXmlRootElementName(File XMLFile) {
 		try {
-			Document doc = Game.docBuilder.parse(XMLFile);
-			
+			Document doc = Main.docBuilder.parse(XMLFile);
+
 			// Cast magic:
 			doc.getDocumentElement().normalize();
 			

--- a/src/com/lilithsthrone/utils/Util.java
+++ b/src/com/lilithsthrone/utils/Util.java
@@ -27,8 +27,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -295,8 +295,7 @@ public class Util {
 	
 	public static String getXmlRootElementName(File XMLFile) {
 		try {
-			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+			DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 			Document doc = dBuilder.parse(XMLFile);
 			
 			// Cast magic:

--- a/src/com/lilithsthrone/utils/Util.java
+++ b/src/com/lilithsthrone/utils/Util.java
@@ -293,7 +293,7 @@ public class Util {
 	
 	public static String getXmlRootElementName(File XMLFile) {
 		try {
-			Document doc = Main.docBuilder.parse(XMLFile);
+			Document doc = Main.getDocBuilder().parse(XMLFile);
 
 			// Cast magic:
 			doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/utils/colours/Colour.java
+++ b/src/com/lilithsthrone/utils/colours/Colour.java
@@ -14,8 +14,6 @@ import com.lilithsthrone.utils.Util;
 
 import javafx.scene.paint.Color;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 /**
  * @since 0.3.7
  * @version 0.4
@@ -99,14 +97,7 @@ public class Colour {
 	public Colour(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				try {
-					if (Main.docBuilder==null) {
-						Main.docBuilder = Main.docFactory.newDocumentBuilder();
-					}
-				} catch (ParserConfigurationException e) {
-					e.printStackTrace();
-				}
-				Document doc = Main.docBuilder.parse(XMLFile);
+				Document doc = Main.getDocBuilder().parse(XMLFile);
 
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/utils/colours/Colour.java
+++ b/src/com/lilithsthrone/utils/colours/Colour.java
@@ -6,8 +6,8 @@ import java.util.Collections;
 import java.util.List;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 
+import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -100,8 +100,7 @@ public class Colour {
 	public Colour(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
 				Document doc = dBuilder.parse(XMLFile);
 				
 				// Cast magic:

--- a/src/com/lilithsthrone/utils/colours/Colour.java
+++ b/src/com/lilithsthrone/utils/colours/Colour.java
@@ -5,8 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javax.xml.parsers.DocumentBuilder;
-
 import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
@@ -100,8 +98,7 @@ public class Colour {
 	public Colour(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilder dBuilder = Game.docFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				Document doc = Game.docBuilder.parse(XMLFile);
 				
 				// Cast magic:
 				doc.getDocumentElement().normalize();

--- a/src/com/lilithsthrone/utils/colours/Colour.java
+++ b/src/com/lilithsthrone/utils/colours/Colour.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.lilithsthrone.game.Game;
 import org.w3c.dom.Document;
 
 import com.lilithsthrone.controller.xmlParsing.Element;
@@ -14,6 +13,9 @@ import com.lilithsthrone.main.Main;
 import com.lilithsthrone.utils.Util;
 
 import javafx.scene.paint.Color;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 /**
  * @since 0.3.7
@@ -98,8 +100,10 @@ public class Colour {
 	public Colour(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				Document doc = Game.docBuilder.parse(XMLFile);
-				
+				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+				Document doc = dBuilder.parse(XMLFile);
+
 				// Cast magic:
 				doc.getDocumentElement().normalize();
 				

--- a/src/com/lilithsthrone/utils/colours/Colour.java
+++ b/src/com/lilithsthrone/utils/colours/Colour.java
@@ -14,8 +14,7 @@ import com.lilithsthrone.utils.Util;
 
 import javafx.scene.paint.Color;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * @since 0.3.7
@@ -100,9 +99,14 @@ public class Colour {
 	public Colour(File XMLFile, String author, boolean mod) {
 		if (XMLFile.exists()) {
 			try {
-				DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-				DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-				Document doc = dBuilder.parse(XMLFile);
+				try {
+					if (Main.docBuilder==null) {
+						Main.docBuilder = Main.docFactory.newDocumentBuilder();
+					}
+				} catch (ParserConfigurationException e) {
+					e.printStackTrace();
+				}
+				Document doc = Main.docBuilder.parse(XMLFile);
 
 				// Cast magic:
 				doc.getDocumentElement().normalize();


### PR DESCRIPTION
- What is the purpose of the pull request?

Improve performance and memory usage.

- Give a brief description of what you changed or added.

Use a single instance of the TransformerFactory, DocumentBuilderFactory and DocumentBuilder. This means that there is less overhead in many cases having to do with XML files, like reading files, saving files. Also memory usage is improved.

Note: I also added some remarks to the to_do list, and removed a few items that were done already.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with different saves with version 0.3.14

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930