### PR TITLE
Change antennae counting for tooltip

### DIFF
--- a/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipInformationEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipInformationEventListener.java
@@ -966,7 +966,7 @@ public class TooltipInformationEventListener implements EventListener {
 						}
 						if (owner.getAntennaType() != AntennaType.NONE) {
 							//TODO might need changing if made like horn count:
-							tooltipSB.append(getBodyPartDiv(owner, Util.capitaliseSentence(Util.intToString(owner.getAntennaRows()*2))+" antennae", owner.getAntennaRace(), owner.getAntennaCovering(), owner.isAntennaFeral()));
+							tooltipSB.append(getBodyPartDiv(owner, Util.capitaliseSentence(Util.intToString(owner.getAntennaRows()*owner.getAntennaePerRow()))+" antennae", owner.getAntennaRace(), owner.getAntennaCovering(), owner.isAntennaFeral()));
 						} else {
 							tooltipSB.append(getEmptyBodyPartDiv("Antennae", "None"));
 						}


### PR DESCRIPTION
Change to account for less/more than two antenna per row.

<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
Change tooltip for antenna to reflect exact number of antenna

- Give a brief description of what you changed or added.
Change how tooltip for antenna counts from `2 * rows` to `number per row * rows`

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.3.14 alpha

- So we have a better idea of who you are, what is your Discord Handle?
deboucher#8190

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
