### PR TITLE
Fix become a demon for legconfigurations other than taur or biped.

### DIFF
--- a/src/com/lilithsthrone/game/character/body/valueEnums/LegConfiguration.java
+++ b/src/com/lilithsthrone/game/character/body/valueEnums/LegConfiguration.java
@@ -149,7 +149,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_HORSE_HOOFED);
+			character.setLegType(LegType.DEMON_HORSE_HOOFED.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_HORSE_HOOFED : LegType.DEMON_COMMON);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -234,7 +234,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_SNAKE);
+			character.setLegType(LegType.DEMON_SNAKE.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_SNAKE : LegType.DEMON_COMMON);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -362,7 +362,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_FISH);
+			character.setLegType(LegType.DEMON_FISH.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_FISH : LegType.DEMON_COMMON);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -462,7 +462,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_SPIDER);
+			character.setLegType(LegType.DEMON_SPIDER.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_SPIDER : LegType.DEMON_COMMON);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -576,7 +576,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_OCTOPUS);
+			character.setLegType(LegType.DEMON_OCTOPUS.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_OCTOPUS : LegType.DEMON_COMMON);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -672,7 +672,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_EAGLE);
+			character.setLegType(LegType.DEMON_EAGLE.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_EAGLE : LegType.DEMON_COMMON);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {

--- a/src/com/lilithsthrone/game/character/body/valueEnums/LegConfiguration.java
+++ b/src/com/lilithsthrone/game/character/body/valueEnums/LegConfiguration.java
@@ -14,6 +14,7 @@ import com.lilithsthrone.game.character.body.Tail;
 import com.lilithsthrone.game.character.body.Tentacle;
 import com.lilithsthrone.game.character.body.Testicle;
 import com.lilithsthrone.game.character.body.Vagina;
+import com.lilithsthrone.game.character.body.abstractTypes.AbstractLegType;
 import com.lilithsthrone.game.character.body.types.LegType;
 import com.lilithsthrone.game.character.body.types.WingType;
 import com.lilithsthrone.game.character.effects.StatusEffect;
@@ -149,7 +150,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_HORSE_HOOFED.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_HORSE_HOOFED : LegType.DEMON_COMMON);
+			this.setLegsToAvailableDemonLegs(character, LegType.DEMON_HORSE_HOOFED);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -234,7 +235,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_SNAKE.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_SNAKE : LegType.DEMON_COMMON);
+			this.setLegsToAvailableDemonLegs(character, LegType.DEMON_SNAKE);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -362,7 +363,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_FISH.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_FISH : LegType.DEMON_COMMON);
+			this.setLegsToAvailableDemonLegs(character, LegType.DEMON_FISH);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -462,7 +463,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_SPIDER.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_SPIDER : LegType.DEMON_COMMON);
+			this.setLegsToAvailableDemonLegs(character, LegType.DEMON_SPIDER);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -576,7 +577,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_OCTOPUS.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_OCTOPUS : LegType.DEMON_COMMON);
+			this.setLegsToAvailableDemonLegs(character, LegType.DEMON_OCTOPUS);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -672,7 +673,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_EAGLE.isAvailableForSelfTransformMenu(character) ? LegType.DEMON_EAGLE : LegType.DEMON_COMMON);
+			this.setLegsToAvailableDemonLegs(character, LegType.DEMON_EAGLE);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -854,6 +855,14 @@ public enum LegConfiguration {
 	
 	public void setLegsToDemon(GameCharacter character) {
 		throw new IllegalArgumentException("Demon legs for this leg configuration is not yet implemented!");
+	}
+
+	public void setLegsToAvailableDemonLegs(GameCharacter character, AbstractLegType legType) {
+		this.setLegsToAvailableDemonLegs(character, legType, LegType.DEMON_COMMON);
+	}
+
+	public void setLegsToAvailableDemonLegs(GameCharacter character, AbstractLegType legType, AbstractLegType fallBackLegType) {
+		character.setLegType(legType.isAvailableForSelfTransformMenu(character) ? legType : fallBackLegType);
 	}
 
 	public void setWingsToDemon(GameCharacter character) {

--- a/src/com/lilithsthrone/game/character/body/valueEnums/LegConfiguration.java
+++ b/src/com/lilithsthrone/game/character/body/valueEnums/LegConfiguration.java
@@ -233,6 +233,10 @@ public enum LegConfiguration {
 			}
 		}
 		@Override
+		public void setLegsToDemon(GameCharacter character) {
+			character.setLegType(LegType.DEMON_SNAKE);
+		}
+		@Override
 		public boolean isTailLostOnInitialTF() {
 			return true;
 		}
@@ -357,6 +361,10 @@ public enum LegConfiguration {
 			}
 		}
 		@Override
+		public void setLegsToDemon(GameCharacter character) {
+			character.setLegType(LegType.DEMON_FISH);
+		}
+		@Override
 		public boolean isTailLostOnInitialTF() {
 			return true;
 		}
@@ -451,6 +459,10 @@ public enum LegConfiguration {
 		@Override
 		public boolean isGenitalsExposed(GameCharacter character) { // As genitals are beneath the arachnid body, they are not easily visible.
 			return false;
+		}
+		@Override
+		public void setLegsToDemon(GameCharacter character) {
+			character.setLegType(LegType.DEMON_SPIDER);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {
@@ -563,6 +575,10 @@ public enum LegConfiguration {
 			return false;
 		}
 		@Override
+		public void setLegsToDemon(GameCharacter character) {
+			character.setLegType(LegType.DEMON_OCTOPUS);
+		}
+		@Override
 		public boolean isTailLostOnInitialTF() {
 			return true;
 		}
@@ -656,7 +672,7 @@ public enum LegConfiguration {
 		}
 		@Override
 		public void setLegsToDemon(GameCharacter character) {
-			character.setLegType(LegType.DEMON_COMMON);
+			character.setLegType(LegType.DEMON_EAGLE);
 		}
 		@Override
 		public boolean isTailLostOnInitialTF() {


### PR DESCRIPTION
### What is the purpose of the pull request?
Become a demon didn't work for several `LegConfiguration`s since `setLegsToDemon` wasn't implemented for that.

### Give a brief description of what you changed or added.
I've implemented the following methods:
```java
public void setLegsToAvailableDemonLegs(GameCharacter character, AbstractLegType legType) {
	this.setLegsToAvailableDemonLegs(character, legType, LegType.DEMON_COMMON);
}

public void setLegsToAvailableDemonLegs(GameCharacter character, AbstractLegType legType, AbstractLegType fallBackLegType) {
	character.setLegType(legType.isAvailableForSelfTransformMenu(character) ? legType : fallBackLegType);
}
```
They should be self-explanatory. If not: Feel free to ask.

Usage example for `LegConfiguration.AVIAN`:
```java
@Override
public void setLegsToDemon(GameCharacter character) {
	this.setLegsToAvailableDemonLegs(character, LegType.DEMON_EAGLE);
}
```

### Are any new graphical assets required?
No

### Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.3.15 Alpha

### So we have a better idea of who you are, what is your Discord Handle?
`@Stadler#3007`