### PR TITLE
secondaryColour and tertiaryColour default to colour in subspecies.xml

### DIFF
--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -383,9 +383,11 @@ public abstract class AbstractSubspecies {
 
 				this.race = Race.getRaceFromId(coreElement.getMandatoryFirstOf("race").getTextContent());
 				
+				String secondaryColourText = coreElement.getMandatoryFirstOf("secondaryColour").getTextContent();
+				String tertiaryColourText = coreElement.getMandatoryFirstOf("tertiaryColour").getTextContent();
 				this.colour = PresetColour.getColourFromId(coreElement.getMandatoryFirstOf("colour").getTextContent());
-				this.secondaryColour = PresetColour.getColourFromId(coreElement.getMandatoryFirstOf("secondaryColour").getTextContent());
-				this.tertiaryColour = PresetColour.getColourFromId(coreElement.getMandatoryFirstOf("tertiaryColour").getTextContent());
+				this.secondaryColour = secondaryColourText.isEmpty() ? this.colour : PresetColour.getColourFromId(secondaryColourText);
+				this.tertiaryColour = tertiaryColourText.isEmpty() ? this.colour : PresetColour.getColourFromId(tertiaryColourText);
 				
 				this.mainSubspecies = Boolean.valueOf(coreElement.getMandatoryFirstOf("mainSubspecies").getTextContent());
 				this.baseSlaveValue = Integer.valueOf(coreElement.getMandatoryFirstOf("baseSlaveValue").getTextContent());


### PR DESCRIPTION
### What is the purpose of the pull request?
In subspecies XMLs the `<secondaryColour>` and `<tertiaryColour>` should default to `<colour>`

### Give a brief description of what you changed or added.
If `<secondaryColour>` or `<tertiaryColour>` are empty they default to `this.colour` now.

### Are any new graphical assets required?
No.

### Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.3.15 Alpha

### So we have a better idea of who you are, what is your Discord Handle?
`@Stadler#3007`