### PR TITLE
Parser error and typo fixes

### DIFF
--- a/res/colours/dsg/raccoonGrey.xml
+++ b/res/colours/dsg/raccoonGrey.xml
@@ -7,7 +7,7 @@
 	<metallic>false</metallic>
 	
 	<!-- The name of this colour. -->
-	<name><![CDATA[Racoon Grey]]></name>
+	<name><![CDATA[Raccoon Grey]]></name>
 	
 	<!-- This colour's hex code, which is used when the game is set in the default 'dark' theme. -->
 	<!-- Pantone PMS Warm Gray 11 UP TPG Shark-->

--- a/res/items/NoStepOnSnek/race/octopus_shrimp_cocktail.xml
+++ b/res/items/NoStepOnSnek/race/octopus_shrimp_cocktail.xml
@@ -41,7 +41,7 @@
 			<p style='margin-bottom:0; padding-bottom:0;'>
 				[npc.Name] [npc.verb(start)] to feel stronger...
 			</p>
-			[#npc.addPotionEffect(MAJOR_PHYSIQUE, 2)]
+			[#npc.addPotionEffect(ATTRIBUTE_MAJOR_PHYSIQUE, 2)]
 		]]></applyEffects>
 		
 		<itemTags>

--- a/res/items/NoStepOnSnek/race/snake_eggs.xml
+++ b/res/items/NoStepOnSnek/race/snake_eggs.xml
@@ -41,7 +41,7 @@
 			<p style='margin-bottom:0; padding-bottom:0;'>
 				[npc.Name] [npc.verb(start)] to feel stronger...
 			</p>
-			[#npc.addPotionEffect(MAJOR_PHYSIQUE, 2)]
+			[#npc.addPotionEffect(ATTRIBUTE_MAJOR_PHYSIQUE, 2)]
 		]]></applyEffects>
 		
 		<itemTags>
@@ -53,7 +53,7 @@
 	<useDescriptions>
 		<selfUse><![CDATA[
 		[npc.Name] [npc.verb(open)] the box and quickly [npc.verb(peel)] one of the eggs before swallowing it
-		#IF(npc.getFaceType()==FACE_TYPE_innoxia_snake)
+		#IF(npc.getFaceType()==FACE_TYPE_NoStepOnSnek_snake_face)
 			 whole.
 		#ELSE
 			 in just a couple bites.
@@ -62,7 +62,7 @@
 		]]></selfUse>
 		<otherUse><![CDATA[
 		[npc.Name] [npc.verb(open)] the box to offer [npc2.name] some nice eggs in these trying times. [npc2.Name] [npc2.verb(take)] and quickly [npc.verb(peel)] one of them before swallowing it
-		#IF(npc2.getFaceType()==FACE_TYPE_innoxia_snake)
+		#IF(npc2.getFaceType()==FACE_TYPE_NoStepOnSnek_snake_face)
 			 whole.
 		#ELSE
 			 in just a couple bites.

--- a/res/items/dsg/race/otter_fish_and_chips.xml
+++ b/res/items/dsg/race/otter_fish_and_chips.xml
@@ -40,8 +40,7 @@
 			<p style='margin-bottom:0; padding-bottom:0;'>
 				[npc.Name] [npc.verb(start)] to feel stronger...
 			</p>
-			[#npc.addPotionEffect(MAJOR_PHYSIQUE, 1)]
-			#ENDIF
+			[#npc.addPotionEffect(ATTRIBUTE_MAJOR_PHYSIQUE, 1)]
 		]]></applyEffects>
 		
 		<itemTags>

--- a/res/items/dsg/race/shark_tuna_sashimi.xml
+++ b/res/items/dsg/race/shark_tuna_sashimi.xml
@@ -40,7 +40,7 @@
 			<p style='margin-bottom:0; padding-bottom:0;'>
 				[npc.Name] [npc.verb(start)] to feel stronger...
 			</p>
-			[#npc.addPotionEffect(MAJOR_PHYSIQUE, 2)]
+			[#npc.addPotionEffect(ATTRIBUTE_MAJOR_PHYSIQUE, 2)]
 		]]></applyEffects>
 		
 		<itemTags>
@@ -52,7 +52,7 @@
 	<useDescriptions>
 		<selfUse><![CDATA[
 		[npc.Name] [npc.verb(remove)] the glass cover and [npc.verb(marvel)] at the exquisite marbling of the fatty tuna meat. Unable to resist the delicious looking seafood inside, [npc.she]
-		#IF(npc.getFaceType()==FACE_TYPE_dsg_shark)
+		#IF(npc.getFaceType()==FACE_TYPE_dsg_shark_face)
 			 [npc.verb(tip)] the plate towards [npc.her] cavernous shark mouth and ungracefully dumps the contents inside, swallowing it all without much difficulty...or chewing.
 		#ELSE
 			 [npc.verb(savor)] every wasabi-tinged bite, and in a matter of moments [npc.has] completely emptied the plate.
@@ -60,7 +60,7 @@
 		]]></selfUse>
 		<otherUse><![CDATA[
 		[npc.Name] [npc.verb(remove)] glass cover from the plate and [npc.verb(hold)] it out to [npc2.name], allowing [npc2.herHim] to marvel at the exquisite marbling of the fatty tuna meat. Unable to resist the delicious-looking seafood inside, [npc2.she]
-		#IF(npc.getFaceType()==FACE_TYPE_dsg_shark)
+		#IF(npc.getFaceType()==FACE_TYPE_dsg_shark_face)
 			 [npc2.verb(tip)] the plate towards [npc2.her] cavernous shark mouth and ungracefully dumps the contents inside, swallowing it all without much difficulty...or chewing.
 		#ELSE
 			 [npc2.verb(savor)] every wasabi-tinged bite, and in a matter of moments [npc2.has] completely emptied the plate.

--- a/res/race/NoStepOnSnek/snake/bodyParts/vagina.xml
+++ b/res/race/NoStepOnSnek/snake/bodyParts/vagina.xml
@@ -24,6 +24,5 @@
 	]]></transformationDescription>
 	<bodyDescription><![CDATA[
 		[npc.she] [npc.has] #IF(npc.isPiercedVagina())a pierced#ELSEa#ENDIF snake-pussy, with [npc.labiaSize], [npc.pussyPrimaryColour(true)] labia and [npc.pussySecondaryColour(true)] inner-walls.
-		<br>[npc.She] [npc.is] viviparous.<br>
 	]]></bodyDescription>
 </vagina>

--- a/res/race/dsg/raccoon/bodyParts/arm.xml
+++ b/res/race/dsg/raccoon/bodyParts/arm.xml
@@ -82,7 +82,7 @@
 	This description immediately follows a brief description of the arm type beginning to transform. -->
 	<transformationDescription><![CDATA[
 		Within a matter of moments, a layer of [npc.armFullDescription] has quickly grown over them, and, looking down, [npc.she] [npc.verb(see)] [npc.her] new fur growing over the backs of [npc.her] hands as sharp claws push out to replace [npc.her] fingernails. [npc.Her] palms rapidly transform to be [npc.materialDescriptor] tough leathery pads, and at [npc.her] upper-biceps, [npc.her] fur smoothly transitions into the [npc.skin] that's covering the rest of [npc.her] body.
-		<br/>As the transformation comes to an end, [npc.nameIsFull] left with anthropomorphic, [style.boldRacoon(raccoon-like arms and hands)], which are [npc.materialDescriptor] [npc.armFullDescription].
+		<br/>As the transformation comes to an end, [npc.nameIsFull] left with anthropomorphic, [style.boldRaccoon(raccoon-like arms and hands)], which are [npc.materialDescriptor] [npc.armFullDescription].
 	]]></transformationDescription>
 	
 	<!-- How these arms are described in a character's description page. -->

--- a/res/race/dsg/raccoon/bodyParts/ass.xml
+++ b/res/race/dsg/raccoon/bodyParts/ass.xml
@@ -57,7 +57,7 @@
 	<!-- The description which is shown when a character transforms to obtain this ass type.
 	This description immediately follows a brief description of the ass type undergoing a transformation. -->
 	<transformationDescription><![CDATA[
-		[npc.She] now [npc.has] a [style.boldRacoon(raccoon-like)], [npc.assholeFullDescription].
+		[npc.She] now [npc.has] a [style.boldRaccoon(raccoon-like)], [npc.assholeFullDescription].
 	]]></transformationDescription>
 	
 	<!-- How this ass is described in a character's description page.

--- a/res/race/dsg/raccoon/bodyParts/breast.xml
+++ b/res/race/dsg/raccoon/bodyParts/breast.xml
@@ -65,7 +65,7 @@
 	<!-- The description which is shown when a character transforms to obtain this breast type.
 	This description immediately follows a brief description of the ass type undergoing a transformation. -->
 	<transformationDescription><![CDATA[
-		[npc.She] now [npc.has] [style.boldRacoon(raccoon-like)], [npc.nipplesFullDescription], and when lactating, [npc.she] will produce [style.boldRacoon(raccoon milk)].
+		[npc.She] now [npc.has] [style.boldRaccoon(raccoon-like)], [npc.nipplesFullDescription], and when lactating, [npc.she] will produce [style.boldRaccoon(raccoon milk)].
 	]]></transformationDescription>
 	
 	<!-- How this breast type is described in a character's description page. -->
@@ -78,7 +78,7 @@
 	These 2 transformation descriptions are used when this breast type is being used for crotch-boobs. i.e. Breasts located on the character's lower stomach. -->
 	
 	<crotchBoobsTransformationDescription><![CDATA[
-		[npc.She] now [npc.has] [style.boldHyena(raccoon-like)], [npc.crotchNipplesFullDescription], and when lactating, [npc.she] will produce [style.boldRacoon(raccoon milk)].
+		[npc.She] now [npc.has] [style.boldHyena(raccoon-like)], [npc.crotchNipplesFullDescription], and when lactating, [npc.she] will produce [style.boldRaccoon(raccoon milk)].
 	]]></crotchBoobsTransformationDescription>
 	
 	<crotchBoobsBodyDescription><![CDATA[

--- a/res/race/dsg/raccoon/bodyParts/ear.xml
+++ b/res/race/dsg/raccoon/bodyParts/ear.xml
@@ -54,7 +54,7 @@
 		 Just like the rest of [npc.her] body, they're made out of [npc.earFullDescription],
 		#ENDIF
 		 and as the transformation finishes, [npc.she] experimentally [npc.verb(twitch)] [npc.her] new raccoon-like ears back and forth.
-		<br/>[npc.Name] now [npc.has] [style.boldRacoon(large, raccoon-like ears)], which are [npc.materialCompositionDescriptor] [npc.earFullDescription].
+		<br/>[npc.Name] now [npc.has] [style.boldRaccoon(large, raccoon-like ears)], which are [npc.materialCompositionDescriptor] [npc.earFullDescription].
 	]]></transformationDescription>
 	
 	<!-- How this ear is described in a character's description page. -->

--- a/res/race/dsg/raccoon/bodyParts/eye.xml
+++ b/res/race/dsg/raccoon/bodyParts/eye.xml
@@ -44,7 +44,7 @@
 	This description immediately follows a brief description of the eye type undergoing a transformation. -->
 	<transformationDescription><![CDATA[
 		By the time [npc.she] hesitantly [npc.verb(open)] them again, they've changed into raccoon-like eyes, with large irises and pupils.
-		<br/>[npc.Name] now [npc.has] [style.boldRacoon(raccoon-like eyes)] with [style.boldGenericTF([npc.irisShape])], [npc.irisFullDescription(true)] and [style.boldGenericTF([npc.pupilShape])], [npc.pupilFullDescription(true)].
+		<br/>[npc.Name] now [npc.has] [style.boldRaccoon(raccoon-like eyes)] with [style.boldGenericTF([npc.irisShape])], [npc.irisFullDescription(true)] and [style.boldGenericTF([npc.pupilShape])], [npc.pupilFullDescription(true)].
 	]]></transformationDescription>
 	
 	<!-- How this eye is described in a character's description page. -->

--- a/res/race/dsg/raccoon/bodyParts/face.xml
+++ b/res/race/dsg/raccoon/bodyParts/face.xml
@@ -79,7 +79,7 @@
 			 Just like the rest of [npc.her] body, [npc.her] new face is [npc.materialDescriptor] [npc.faceSkin+], 
 		#ENDIF
 		and as the transformation finally comes to an end, [npc.sheIs] left panting and sighing as [npc.she] [npc.verb(try)] to catch [npc.her] breath.
-		<br/>[npc.Name] now [npc.has] an anthropomorphic [style.boldRacoon(raccoon-like face)], [npc.materialDescriptor] [npc.faceFullDescription]. Within [npc.her] [npc.mouth], [npc.she] [npc.has] a [style.boldRacoon(flat, raccoon-like tongue)].
+		<br/>[npc.Name] now [npc.has] an anthropomorphic [style.boldRaccoon(raccoon-like face)], [npc.materialDescriptor] [npc.faceFullDescription]. Within [npc.her] [npc.mouth], [npc.she] [npc.has] a [style.boldRaccoon(flat, raccoon-like tongue)].
 	]]></transformationDescription>
 	
 	<!-- How this face is described in a character's description page. -->

--- a/res/race/dsg/raccoon/bodyParts/hair.xml
+++ b/res/race/dsg/raccoon/bodyParts/hair.xml
@@ -52,7 +52,7 @@
 	This description immediately follows a brief description of the hair type beginning to transform. -->
 	<transformationDescription><![CDATA[
 		The transformation only lasts a matter of moments, leaving [npc.herHim] with fur-like hair.
-		<br/>[npc.Name] now [npc.has] [npc.hairColour] [style.boldRacoon(raccoon hair)].
+		<br/>[npc.Name] now [npc.has] [npc.hairColour] [style.boldRaccoon(raccoon hair)].
 	]]></transformationDescription>
 	
 	<!-- How this hair is described in a character's description page. -->

--- a/res/race/dsg/raccoon/bodyParts/leg.xml
+++ b/res/race/dsg/raccoon/bodyParts/leg.xml
@@ -88,7 +88,7 @@
 	This description immediately follows a brief description of the leg type beginning to transform. -->
 	<transformationDescription><![CDATA[
 		A layer of raccoon-like fur quickly grows over [npc.her] legs as they shift into a new form. As [npc.her] new fur spreads down to the ends of [npc.her] toes, [npc.her] toenails thicken into sharp claws, and tough leathery pads grow to cover [npc.her] soles, leaving [npc.herHim] with paw-like feet. As the transformation ends, [npc.she] [npc.verb(see)] that [npc.her] new fur smoothly transitions into the [npc.skin] covering the rest of [npc.her] body at [npc.her] upper-thigh.
-		<br/>[npc.Name] now [npc.has] anthropomorphic, [style.boldRacoon(raccoon-like legs and feet)], which are [npc.materialDescriptor] [npc.legFullDescription].
+		<br/>[npc.Name] now [npc.has] anthropomorphic, [style.boldRaccoon(raccoon-like legs and feet)], which are [npc.materialDescriptor] [npc.legFullDescription].
 	]]></transformationDescription>
 	
 	<!-- How these legs are described in a character's description page. -->

--- a/res/race/dsg/raccoon/bodyParts/penis.xml
+++ b/res/race/dsg/raccoon/bodyParts/penis.xml
@@ -68,8 +68,8 @@
 	This description immediately follows a brief description of the penis type beginning to transform. -->
 	<transformationDescription><![CDATA[
 		Letting out an involuntary moan, [npc.name] [npc.verb(feel)] [npc.her] penis shifting into a new form, and [npc.sheIs] hit by a wave of overwhelming arousal as a thick sheath suddenly grows around the base of [npc.her] shaft. As [npc.she] [npc.verb(pant)] and [npc.verb(gasp)] for air, the tip of [npc.her] cock narrows down as it tapers into its new form.
-		<br/>[npc.She] now [npc.has] a [style.boldRacoon(raccoon-like penis)], [npc.materialDescriptor] [npc.penisFullDescription(true)].
-		<br/>[npc.She] [npc.has] [style.boldRacoon([npc.ballsCount]#IF(npc.isInternalTesticles()) internal#ENDIF balls)], [npc.materialDescriptor] [npc.ballsFullDescription(true)], which produce [npc.cumColour(true)] [style.boldRacoon(raccoon cum)].
+		<br/>[npc.She] now [npc.has] a [style.boldRaccoon(raccoon-like penis)], [npc.materialDescriptor] [npc.penisFullDescription(true)].
+		<br/>[npc.She] [npc.has] [style.boldRaccoon([npc.ballsCount]#IF(npc.isInternalTesticles()) internal#ENDIF balls)], [npc.materialDescriptor] [npc.ballsFullDescription(true)], which produce [npc.cumColour(true)] [style.boldRaccoon(raccoon cum)].
 	]]></transformationDescription>
 	
 	<!-- How this penis is described in a character's description page. -->

--- a/res/race/dsg/raccoon/bodyParts/tail.xml
+++ b/res/race/dsg/raccoon/bodyParts/tail.xml
@@ -81,10 +81,10 @@
 	<transformationDescription><![CDATA[
 		#IF(npc.getTailCount()==1)
 			A furry, raccoon-like tail sprouts from just above [npc.her] ass, rapidly growing in size until it's about [npc.tailLength] long. [npc.She] quickly [npc.verb(realise)] that [npc.she] [npc.has] limited control over it, but [npc.is] still able to swish it from side to side.
-			<br/>[npc.Name] now [npc.has] a [style.boldRacoon(raccoon-like tail)], [npc.materialDescriptor] [npc.tailFullDescription(true)].
+			<br/>[npc.Name] now [npc.has] a [style.boldRaccoon(raccoon-like tail)], [npc.materialDescriptor] [npc.tailFullDescription(true)].
 		#ELSE
 			[npc.TailCount] furry, raccoon-like tails sprout from just above [npc.her] ass, rapidly growing in size until they're each about [npc.tailLength] long. [npc.She] quickly [npc.verb(realise)] that [npc.she] [npc.has] limited control over them, but [npc.is] still able to swish them from side to side.
-			<br/>[npc.Name] now [npc.has] [npc.tailCount] [style.boldRacoon(raccoon-like tails)], [npc.materialDescriptor] [npc.tailFullDescription(true)].
+			<br/>[npc.Name] now [npc.has] [npc.tailCount] [style.boldRaccoon(raccoon-like tails)], [npc.materialDescriptor] [npc.tailFullDescription(true)].
 		#ENDIF
 	]]></transformationDescription>
 	

--- a/res/race/dsg/raccoon/bodyParts/torso.xml
+++ b/res/race/dsg/raccoon/bodyParts/torso.xml
@@ -32,7 +32,7 @@
 	This description immediately follows a brief description of the torso type beginning to transform. -->
 	<transformationDescription><![CDATA[
 		After just a few moments, the transformation comes to an end, and [npc.she] [npc.verb(let)] out a deep sigh as the itching finally stops, leaving [npc.her] torso covered with raccoon-like fur. [npc.Her] new fur is a little shaggy around [npc.her] joints and is quite densely packed.
-		<br/>[npc.Name] now [npc.has] [style.boldRacoon(raccoon-like)], [npc.skinFullDescription].
+		<br/>[npc.Name] now [npc.has] [style.boldRaccoon(raccoon-like)], [npc.skinFullDescription].
 	]]></transformationDescription>
 	
 	<!-- How this torso is described in a character's description page. -->

--- a/res/race/dsg/raccoon/bodyParts/vagina.xml
+++ b/res/race/dsg/raccoon/bodyParts/vagina.xml
@@ -50,7 +50,7 @@
 		</p>
 		<p>
 			Just as [npc.she] [npc.verb(start)] to think that the transformation has come to an end, [npc.her] pussy involuntarily clenches down, and a desperate squeal escapes from between [npc.her] [npc.lips+] as a warm, tingling feeling spreads up through [npc.her] lower abdomen. Images of throbbing raccoon-cocks slamming deep into [npc.her] new pussy flash before [npc.her] eyes, and [npc.her] squeal turns into a satisfied moan as [npc.she] [npc.verb(imagine)] them pumping their potent seed deep into [npc.her] new womb. Just as quickly as they came, the images fade from [npc.her] mind, and as one last wave of tingling pleasure washes through [npc.her] body, [npc.she] [npc.verb(feel)] [npc.her] female reproductive organs finishing their transformation.
-			<br/>[npc.Name] now [npc.has] a [style.boldRacoon(raccoon vagina)], with [npc.pussyColourPrimary(true)] labia and [npc.pussyColourSecondary(true)] internal walls.
+			<br/>[npc.Name] now [npc.has] a [style.boldRaccoon(raccoon vagina)], with [npc.pussyColourPrimary(true)] labia and [npc.pussyColourSecondary(true)] internal walls.
 	]]></transformationDescription>
 	
 	<!-- How this torso is described in a character's description page.

--- a/res/race/dsg/raccoon/subspecies/bookEntries.xml
+++ b/res/race/dsg/raccoon/subspecies/bookEntries.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <bookText>
 	
-	<htmlContent tag="RACOON_BASIC"><![CDATA[
+	<htmlContent tag="RACCOON_BASIC"><![CDATA[
 	<p>
-		Racoon-morphs are extremely adaptable can be found in almost every corner of the Realm except the Endless Sea and perhaps the the Mountains of the Moon. Their triangular ears, distinct "bandit-mask" markings, and ringed tails distinguish them from other morphs.
+		Raccoon-morphs are extremely adaptable can be found in almost every corner of the Realm except the Endless Sea and perhaps the the Mountains of the Moon. Their triangular ears, distinct "bandit-mask" markings, and ringed tails distinguish them from other morphs.
 	</p>
 	]]>
 	</htmlContent>
 
-	<htmlContent tag="RACOON_ADVANCED"><![CDATA[
+	<htmlContent tag="RACCOON_ADVANCED"><![CDATA[
 	<p>
 		While all raccoon-morphs differ from one another individually, they have a reputation as adaptable scavengers. Their sensitive paws can discern by touch what average eyes fail to discern by sight. It is generally not recommended to try swindling a raccoon-morph with counterfeit goods and consequently many raccoon-morphs make their living in fields where either knowing how to spot fakes or how to producing convincing ones are vital skills.
 	</p>

--- a/res/race/dsg/raccoon/subspecies/raccoon.xml
+++ b/res/race/dsg/raccoon/subspecies/raccoon.xml
@@ -22,11 +22,11 @@
 	
 	<!-- The id of the item associated with this race which can be enchanted to modify attributes.
 	If you do not have an associated item made for this race then use 'innoxia_race_human_vanilla_water'. -->
-	<attributeItemId>dsg_race_raccoon_popcorn</attributeItemId>
+	<attributeItemId>dsg_race_raccoon_cotton_candy_soda</attributeItemId>
 	
 	<!-- The id of the item associated with this race which can be enchanted to create a transformation potion.
 	If you do not have an associated item made for this race then use 'innoxia_race_human_bread_roll'. -->
-	<transformativeItemId>dsg_race_raccoon_cotton_candy_soda</transformativeItemId>
+	<transformativeItemId>dsg_race_raccoon_popcorn</transformativeItemId>
 	
 	<!-- An integer representing how important this Subspecies is to be defined as a character's Subspecies override (meaning that this Subspecies will always be their true Subspecies, no matter the race of their body parts).
 	The default value is 0, which, along with any negative integer value, means that this Subspecies does not set an Override.
@@ -86,12 +86,12 @@
 	<bookIconName>raccoonicon</bookIconName>
 	
 	<!-- The name for the book. -->
-	<bookName>Foraging Racoons</bookName>
+	<bookName>Foraging Raccoons</bookName>
 	
 	<!-- The element names which contain the book's basic and advanced descriptions.
 	These should be entered into the 'bookEntries.xml' file in the same folder location as this file. -->
-	<basicDescriptionId>RACOON_BASIC</basicDescriptionId>
-	<advancedDescriptionId>RACOON_ADVANCED</advancedDescriptionId>
+	<basicDescriptionId>RACCOON_BASIC</basicDescriptionId>
+	<advancedDescriptionId>RACCOON_ADVANCED</advancedDescriptionId>
 	
 	<!-- The default preference for this subspecies spawning.
 	Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/race/SubspeciesPreference.java -->

--- a/res/race/dsg/shark/subspecies/shark.xml
+++ b/res/race/dsg/shark/subspecies/shark.xml
@@ -22,11 +22,11 @@
 	
 	<!-- The id of the item associated with this race which can be enchanted to modify attributes.
 	If you do not have an associated item made for this race then use 'innoxia_race_human_vanilla_water'. -->
-	<attributeItemId>dsg_race_shark_tuna_sashimi</attributeItemId>
+	<attributeItemId>dsg_race_shark_grog</attributeItemId>
 	
 	<!-- The id of the item associated with this race which can be enchanted to create a transformation potion.
 	If you do not have an associated item made for this race then use 'innoxia_race_human_bread_roll'. -->
-	<transformativeItemId>dsg_race_shark_grog</transformativeItemId>
+	<transformativeItemId>dsg_race_shark_tuna_sashimi</transformativeItemId>
 	
 	<!-- An integer representing how important this Subspecies is to be defined as a character's Subspecies override (meaning that this Subspecies will always be their true Subspecies, no matter the race of their body parts).
 	The default value is 0, which, along with any negative integer value, means that this Subspecies does not set an Override.

--- a/src/com/lilithsthrone/game/character/body/Vagina.java
+++ b/src/com/lilithsthrone/game/character/body/Vagina.java
@@ -292,9 +292,9 @@ public class Vagina implements BodyPartInterface {
 
 		sb.append("<p style='text-align:center;'>");
 			if(this.eggLayer) {
-				sb.append("<i>Instead of giving birth to live young, [npc.name] now [style.colourEgg([npc.verb(lay)] eggs)]!</i>");
+				sb.append(UtilText.parse(owner,"<i>Instead of giving birth to live young, [npc.name] now [style.colourEgg([npc.verb(lay)] eggs)]!</i>"));
 			} else {
-				sb.append("<i>[npc.Name] now [style.colourSex([npc.verb(give)] birth to live young)]!</i>");
+				sb.append(UtilText.parse(owner,"<i>[npc.Name] now [style.colourSex([npc.verb(give)] birth to live young)]!</i>"));
 			}
 		sb.append("</p>");
 		
@@ -303,14 +303,14 @@ public class Vagina implements BodyPartInterface {
 			orificeVagina.addOrificeModifier(owner, om);
 		}
 		
-		sb.append("<p>"
-				+ "Any old modifiers which [npc.her] pussy might have had have [style.boldShrink(transformed away)]!");
+		sb.append(UtilText.parse(owner,"<p>"
+				+ "Any old modifiers which [npc.her] pussy might have had have [style.boldShrink(transformed away)]!"));
 		
 		if(orificeVagina.getOrificeModifiers().isEmpty()) {
 			sb.append("</p>");
 		} else {
-			sb.append("<br/>"
-					+ "Instead, [npc.her] new pussy is:");
+			sb.append(UtilText.parse(owner,"<br/>"
+					+ "Instead, [npc.her] new pussy is:"));
 			
 			for(OrificeModifier om : orificeVagina.getOrificeModifiers()) {
 				sb.append("<br/>[style.boldGrow("+Util.capitaliseSentence(om.getName())+")]");


### PR DESCRIPTION
- What is the purpose of the pull request?

Fix various parser errors and typo fixes, mostly with modded races.

- Give a brief description of what you changed or added.

In the Boiled eggs (res/items/NoStepOnSnek/race/snake_eggs.xml)  it should  be FACE_TYPE_NoStepOnSnek_snake_face and ATTRIBUTE_MAJOR_PHYSIQUE.
In the sashimi (res/items/dsg/race/shark_tuna_sashimi.xml) it should be FACE_TYPE_dsg_shark_face and again ATTRIBUTE_MAJOR_PHYSIQUE.
Fish and chips (res/items/dsg/race/otter_fish_and_chips.xml) also needs ATTRIBUTE_MAJOR_PHYSIQUE, and there is an #ENDIF that shouldn't be there.
Shrimp cocktail (res/items/NoStepOnSnek/race/octopus_shrimp_cocktail.xml) also needs ATTRIBUTE_MAJOR_PHYSIQUE.

In res/race/dsg/raccoon/subspecies/raccoon.xml the dsg_race_raccoon_cotton_candy_soda should be swapped with dsg_race_raccoon_popcorn. And in res/race/dsg/shark/subspecies/shark.xml the items are also swapped. The sashimi is the TF item, and the grog is the drink (attribute item).

In the res/race/dsg/raccoon/bodyParts/ .xml, the transformationDescription should use style.boldRaccoon, not style.boldRacoon.

res/race/NoStepOnSnek/snake/bodyParts/vagina.xml has a line <br>[npc.She] [npc.is] viviparous.<br>. But there was a change in how egg-laying is determined, so this may not be true anymore. And the information is always shown in the description anyway, so this line is now no longer needed.

In src/com/lilithsthrone/game/character/body/Vagina.java some TF texts needs UtilText.parse(owner added as otherwise the text is wrong when being TF'd by a NPC.

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with 0.3.19

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930