### PR TITLE
Unenchantable item tag

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
@@ -29,6 +29,7 @@ import com.lilithsthrone.game.dialogue.responses.ResponseEffectsOnly;
 import com.lilithsthrone.game.dialogue.story.CharacterCreation;
 import com.lilithsthrone.game.inventory.ColourReplacement;
 import com.lilithsthrone.game.inventory.InventorySlot;
+import com.lilithsthrone.game.inventory.ItemTag;
 import com.lilithsthrone.game.inventory.Rarity;
 import com.lilithsthrone.game.inventory.ShopTransaction;
 import com.lilithsthrone.game.inventory.clothing.AbstractClothing;
@@ -182,10 +183,12 @@ public class InventoryDialogue {
 				return "Inventory";
 			}
 		}
+
 		@Override
 		public String getHeaderContent() {
 			return inventoryView();
 		}
+
 		@Override
 		public String getContent() {
 			UtilText.nodeContentSB.setLength(0);
@@ -1111,7 +1114,7 @@ public class InventoryDialogue {
 								}
 								
 							} else if(index == 5) {
-								if(item.getEnchantmentItemType(null)==null) {
+								if(item.getEnchantmentItemType(null)==null || item.getItemTags().contains(ItemTag.UNENCHANTABLE)) {
 									return new Response("Enchant", "This item cannot be enchanted!", null);
 									
 								} else if(Main.game.isDebugMode()
@@ -1368,7 +1371,7 @@ public class InventoryDialogue {
 								};
 								
 							} else if(index == 5) {
-								if(item.getEnchantmentItemType(null)==null) {
+								if(item.getEnchantmentItemType(null)==null || item.getItemTags().contains(ItemTag.UNENCHANTABLE)) {
 									return new Response("Enchant", "This item cannot be enchanted!", null);
 									
 								} else if(Main.game.isDebugMode()
@@ -1754,7 +1757,7 @@ public class InventoryDialogue {
 								}
 								
 							} else if(index == 5) {
-								if(item.getEnchantmentItemType(null)==null) {
+								if(item.getEnchantmentItemType(null)==null || item.getItemTags().contains(ItemTag.UNENCHANTABLE)) {
 									return new Response("Enchant", "This item cannot be enchanted!", null);
 									
 								} else if(Main.game.isDebugMode()
@@ -2720,7 +2723,7 @@ public class InventoryDialogue {
 								}
 								
 							} else if(index == 5) {
-								if(weapon.getEnchantmentItemType(null)==null) {
+								if(weapon.getEnchantmentItemType(null)==null || weapon.getItemTags().contains(ItemTag.UNENCHANTABLE)) {
 									return new Response("Enchant", "This weapon cannot be enchanted!", null);
 									
 								} else if(Main.game.isDebugMode()
@@ -2901,7 +2904,7 @@ public class InventoryDialogue {
 								}
 								
 							} else if(index == 5) {
-								if(weapon.getEnchantmentItemType(null)==null) {
+								if(weapon.getEnchantmentItemType(null)==null || weapon.getItemTags().contains(ItemTag.UNENCHANTABLE)) {
 									return new Response("Enchant", "This weapon cannot be enchanted!", null);
 									
 								} else if(Main.game.isDebugMode()
@@ -3124,7 +3127,7 @@ public class InventoryDialogue {
 								}
 								
 							} else if(index == 5) {
-								if(weapon.getEnchantmentItemType(null)==null) {
+								if(weapon.getEnchantmentItemType(null)==null || weapon.getItemTags().contains(ItemTag.UNENCHANTABLE)) {
 									return new Response("Enchant", "This weapon cannot be enchanted!", null);
 									
 								} else if(Main.game.isDebugMode()
@@ -3934,7 +3937,7 @@ public class InventoryDialogue {
 								}
 								if(Main.game.isDebugMode()
 										|| (Main.game.getPlayer().hasQuest(QuestLine.SIDE_ENCHANTMENT_DISCOVERY) && Main.game.getPlayer().isQuestCompleted(QuestLine.SIDE_ENCHANTMENT_DISCOVERY))) {
-									if(clothing.getEnchantmentItemType(null)==null) {
+									if(clothing.getEnchantmentItemType(null)==null || clothing.getItemTags().contains(ItemTag.UNENCHANTABLE)) {
 										return new Response("Enchant", "This clothing cannot be enchanted!", null);
 										
 									} else if(!clothing.isEnchantmentKnown()) {
@@ -4119,7 +4122,7 @@ public class InventoryDialogue {
 								}
 								if(Main.game.isDebugMode()
 										|| (Main.game.getPlayer().hasQuest(QuestLine.SIDE_ENCHANTMENT_DISCOVERY) && Main.game.getPlayer().isQuestCompleted(QuestLine.SIDE_ENCHANTMENT_DISCOVERY))) {
-									if(clothing.getEnchantmentItemType(null)==null) {
+									if(clothing.getEnchantmentItemType(null)==null || clothing.getItemTags().contains(ItemTag.UNENCHANTABLE)) {
 										return new Response("Enchant", "This clothing cannot be enchanted!", null);
 										
 									} else if(!clothing.isEnchantmentKnown()) {
@@ -4473,7 +4476,7 @@ public class InventoryDialogue {
 								}
 								if(Main.game.isDebugMode()
 										|| (Main.game.getPlayer().hasQuest(QuestLine.SIDE_ENCHANTMENT_DISCOVERY) && Main.game.getPlayer().isQuestCompleted(QuestLine.SIDE_ENCHANTMENT_DISCOVERY))) {
-									if(clothing.getEnchantmentItemType(null)==null) {
+									if(clothing.getEnchantmentItemType(null)==null || clothing.getItemTags().contains(ItemTag.UNENCHANTABLE)) {
 										return new Response("Enchant", "This clothing cannot be enchanted!", null);
 										
 									} else if(!clothing.isEnchantmentKnown()) {

--- a/src/com/lilithsthrone/game/inventory/ItemTag.java
+++ b/src/com/lilithsthrone/game/inventory/ItemTag.java
@@ -97,6 +97,11 @@ public enum ItemTag {
 					"[style.colourGood(Provides equipper with key)]"),
 			false),
 	
+	UNENCHANTABLE(  // Prevents the player from enchanting this in the inventory menu.
+			Util.newArrayListOfValues(
+					"[style.colourBad(Unenchantable)]"),
+			false),
+
 	SPREADS_FEET( // Prevents double foot actions, like wrap-around footjobs
 			Util.newArrayListOfValues(
 					"[style.colourBad(Restricts sex actions)]"),


### PR DESCRIPTION
Adds a new item tag called UNENCHANTABLE, which greys out an item's enchant button in the inventory as if it were a normally unenchantable item type.

The tag works by modifying the nine if statements in InventoryDialogue that check if an item is an unenchantable item type to also check if they have this item tag.

The purpose of this tag is to potentially allow unique and gimmick items to retain their identity without a player stripping them of all enchantments in order to gain a set bonus with no downside, and to allow an item to increase enchantment capacity to make its enchantments free without worrying about the player removing them to gain enchantment capacity instead. The reason this tag was created was to take advantage of the fact that enchantments on an item can vary, while set bonuses are fixed to a specific effect. The idea is that an item could have a special move that permanently modifies its enchantments, which would be undermined by the player being able to enchant the item.

(This pull request briefly closed and had to be resubmitted. This is because I'm still learning how to use git and was trying to restructure my fork so it's in a more usable state on my end, so I would more easily be able to make more PRs than just this one. Sorry.