### PR TITLE
Stops keys for locked clothing being removed during sex to avoid key loss on automatic re-equip

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -21861,7 +21861,7 @@ public abstract class GameCharacter implements XMLSaving {
 		for(NPC npc : Main.game.getAllNPCs()) {
 			npc.removeFromUnlockKeyMap(this.getId(), slot);
 		}
-		if(Main.game.getPlayer()!=null) {
+		if(Main.game.getPlayer()!=null && !Main.game.isInSex()) {
 			Main.game.getPlayer().removeFromUnlockKeyMap(this.getId(), slot);
 		} else {
 			System.err.println("Warning: Sealed clothing '"+clothing.getName()+"' did not have associated unlock key removed from player key mappings.");

--- a/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
@@ -8450,7 +8450,8 @@ public class InventoryDialogue {
 				public void effects() {
 					String s = "";
 					if(ownsKey) {
-						Main.game.getPlayer().removeFromUnlockKeyMap(owner.getId(), clothing.getSlotEquippedTo());
+						if(!Main.game.isInSex())
+						{Main.game.getPlayer().removeFromUnlockKeyMap(owner.getId(), clothing.getSlotEquippedTo());}
 						s = "<p>"
 								+ "Using the key which is in your possession, you unlock the "+clothing.getName()+"!"
 							+ "</p>";


### PR DESCRIPTION
Keys for locked items unequipped during sex are currently removed, even though the item is automatically re-equipped after sex.  This stops the key from being removed from the key map for sealed items unequipped during sex.

- What is the purpose of the pull request?
- See above

- Give a brief description of what you changed or added.

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Checked on 0.3.21 Alpha, didn't seem to duplicate keys or do anything weird.

- So we have a better idea of who you are, what is your Discord Handle?
- deboucher#8190

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
