### PR TITLE
Fixed NullReferenceEx when slave laying eggs

### DIFF
--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -2356,7 +2356,7 @@ public class Game implements XMLSaving {
 								case URETHRA_VAGINA:
 									break;
 							}
-							List<String> events = Util.newArrayListOfValues(UtilText.parse(npc, "[npc.She] completed [npc.her] "+areaEgged+" incubation and gave birth to:<br/>")+npc.getLastLitterBirthed().getBirthedDescription());
+							List<String> events = Util.newArrayListOfValues(UtilText.parse(npc, "[npc.She] completed [npc.her] "+areaEgged+" incubation and gave birth to:<br/>")+npc.getLastLitterIncubated().getBirthedDescription());
 							SlaveryEventLogEntry incubationBirthEntry = new SlaveryEventLogEntry(getHourOfDay(),
 									npc,
 									null,

--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -19606,6 +19606,13 @@ public abstract class GameCharacter implements XMLSaving {
 		return littersBirthed.get(littersBirthed.size() - 1);
 	}
 	
+	public Litter getLastLitterIncubated() {
+		if(incubatedLitters.isEmpty()) {
+			return null;
+		}
+		return incubatedLitters.get(incubatedLitters.size() - 1);
+	}
+	
 	public List<Litter> getLittersFathered() {
 		return littersFathered;
 	}


### PR DESCRIPTION
<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
Fixes NullReferenceException if a slave laying eggs hasn't birthed live young

- Give a brief description of what you changed or added.
Added copy of getLastLitterBirthed() for incubated litters and replaced the method call when creating the event

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.4.0 Alpha

- So we have a better idea of who you are, what is your Discord Handle?
Maxis010#3060

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
