### PR TITLE
Fix typo in ELSE statement

### DIFF
--- a/res/txt/misc/lyssiethReveal.xml
+++ b/res/txt/misc/lyssiethReveal.xml
@@ -1071,7 +1071,7 @@
 		 in length. There looks to be a large amount of farmland surrounding the capital, which is bordered by an expanse of wild grassland and forests. To the north, there's a huge expanse of what's marked as jungle, while to the south, the farmland transitions first into a wide savannah, and then into a desert.
 	</p>
 	<p>
-		[siren.speech(Elis is here,)] [siren.name] says, pointing to a mark west of Dominion. You look across to see that the town is just a few #IF(game.isMetricSizes())kilometres#ELSemiles#ENDIF to the east of the area marked as the 'Shinrin highlands', and that it looks to be roughly
+		[siren.speech(Elis is here,)] [siren.name] says, pointing to a mark west of Dominion. You look across to see that the town is just a few #IF(game.isMetricSizes())kilometres#ELSEmiles#ENDIF to the east of the area marked as the 'Shinrin highlands', and that it looks to be roughly
 		#IF(game.isMetricSizes())
 			 35 kilometres
 		#ELSE


### PR DESCRIPTION
Fixed the capitalization of the ELSE statement in /res/txt/misc/lyssiethReveal.xml#L1063.
Without the capitalization, the unit description is rendered as `kilometeres#ELSemiles` if the Metric Sizes option is enabled, and is omitted if not.

![2021-06-04T02-08-06](https://user-images.githubusercontent.com/85321724/120727584-34580e00-c4db-11eb-937b-4893117f824f.png)

No new graphical assets required.

This change has not been tested.

Discord handle `DaniDipp#0001`.
