### PR TITLE
Removed unnecessary copy when accessing the unique item count of an inventory.

### DIFF
--- a/src/com/lilithsthrone/game/inventory/AbstractInventory.java
+++ b/src/com/lilithsthrone/game/inventory/AbstractInventory.java
@@ -72,6 +72,10 @@ class AbstractInventory<T extends AbstractCoreItem, U extends AbstractCoreType> 
 		return Collections.unmodifiableMap(duplicateCounts);
 	}
 
+	int getUniqueItemCount(){
+		return duplicateCounts.size();
+	}
+
 	int getQuestEntryCount() {
 		return (int) duplicateCounts.keySet().stream().filter(e -> e.getRarity().equals(Rarity.QUEST)).count();
 	}

--- a/src/com/lilithsthrone/game/inventory/CharacterInventory.java
+++ b/src/com/lilithsthrone/game/inventory/CharacterInventory.java
@@ -617,7 +617,7 @@ public class CharacterInventory implements XMLSaving {
 	}
 	
 	public int getUniqueItemCount() {
-		return getAllItemsInInventory().size();
+		return itemSubInventory.getUniqueItemCount();
 	}
 	
 	public int getUniqueQuestItemCount() {
@@ -743,7 +743,7 @@ public class CharacterInventory implements XMLSaving {
 	}
 
 	public int getUniqueWeaponCount() {
-		return getAllWeaponsInInventory().size();
+		return weaponSubInventory.getUniqueItemCount();
 	}
 	
 	public int getUniqueQuestWeaponCount() {
@@ -903,7 +903,7 @@ public class CharacterInventory implements XMLSaving {
 	}
 
 	public int getUniqueClothingCount() {
-		return getAllClothingInInventory().size();
+		return clothingSubInventory.getUniqueItemCount();
 	}
 
 	public int getUniqueQuestClothingCount() {


### PR DESCRIPTION
<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
Removal of an unnecessary copy during inventory accesses.

- Give a brief description of what you changed or added.
Added a function to get the unique item count from an AbstractInventory.  When clicking on an item in the inventory, the function `com.lilithsthrone.game.inventory.CharacterInventory;getUniqueItemCount()` is called 108 interspersed between rendering updates and inventory accesses. The current version uses the function `com.lilithsthrone.game.inventory.CharacterInventory;getAllItemsInInventory()` and gets the size of the result. The issue is that `Collections.unmodifiableMap(...)` copies the entire contents of the input map into a new map. This results in an excessive cleanup job for the garbage collector, and slows the entire game down immensely, not to mention using the inventory is a laggy experience from the get go. By removing all 108 unnecessary copies the inventory screen works very smooth and the entire game has significantly less lag caused by an excessive increase in memory usage. 

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, latest as of 7-12-2021, version 4.1, commit [81a1fc0](https://github.com/Innoxia/liliths-throne-public/commit/81a1fc0b147c557baf890e25224da14fb2f487c1)

- So we have a better idea of who you are, what is your Discord Handle?
Amber💞#5285

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
