### PR TITLE
Enhancement: NPCs can spawn dirty

### DIFF
--- a/src/com/lilithsthrone/game/character/CharacterUtils.java
+++ b/src/com/lilithsthrone/game/character/CharacterUtils.java
@@ -2930,6 +2930,24 @@ public class CharacterUtils {
 		}
 	}
 	
+	public void applyDirtiness(GameCharacter character) {
+		ArrayList<InventorySlot> validSlots = new ArrayList<>();
+		
+		for(InventorySlot slot : InventorySlot.getClothingSlots()) {
+			if(slot.getBodyPartClothingBlock(character) == null) {
+				validSlots.add(slot);
+			}
+		}
+		
+		int dirtySlots = Util.random.nextInt(validSlots.size()/2) + 1;
+		
+		for(int i = 0; i < dirtySlots; i++) {
+			InventorySlot slot = Util.randomItemFrom(validSlots);
+			character.inventory.addDirtySlot(slot);
+			validSlots.remove(slot);
+		}
+	}
+	
 	public List<AbstractClothing> generateEnchantedClothingForTrader(GameCharacter trader, List<AbstractClothing> clothingToSell, int numberOfUncommonsToGenerate, int numberofRaresToGenerate) {
 
 		List<AbstractClothing> clothingGenerated = new ArrayList<>();

--- a/src/com/lilithsthrone/game/character/npc/NPC.java
+++ b/src/com/lilithsthrone/game/character/npc/NPC.java
@@ -162,6 +162,9 @@ public abstract class NPC extends GameCharacter implements XMLSaving {
 			if(!flags.contains(NPCGenerationFlag.NO_CLOTHING_EQUIP) && this.getBody()!=null) {
 				equipClothing(EquipClothingSetting.getAllClothingSettings());
 			}
+			if(this.getBody()!=null && ((flags.contains(NPCGenerationFlag.DIRTY) || hasFetish(Fetish.FETISH_CUM_ADDICT)) && Math.random() > 0.9)) {
+				Main.game.getCharacterUtils().applyDirtiness(this);
+			}
 		}
 		
 		if(this.getBody()!=null) {

--- a/src/com/lilithsthrone/game/character/npc/NPCGenerationFlag.java
+++ b/src/com/lilithsthrone/game/character/npc/NPCGenerationFlag.java
@@ -7,5 +7,7 @@ package com.lilithsthrone.game.character.npc;
  */
 public enum NPCGenerationFlag {
 
-	NO_CLOTHING_EQUIP;
+	NO_CLOTHING_EQUIP,
+
+	DIRTY;
 }

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionAlleywayAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionAlleywayAttacker.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.lilithsthrone.game.character.fetishes.Fetish;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -159,6 +160,9 @@ public class DominionAlleywayAttacker extends NPC {
 				this.equipClothing(EquipClothingSetting.getAllClothingSettings());
 			}
 			Main.game.getCharacterUtils().applyMakeup(this, true);
+			if((Arrays.asList(generationFlags).contains(NPCGenerationFlag.DIRTY) || hasFetish(Fetish.FETISH_CUM_ADDICT)) && Math.random() > 0.9) {
+				Main.game.getCharacterUtils().applyDirtiness(this);
+			}
 			
 			// Set starting perks based on the character's race
 			initPerkTreeAndBackgroundPerks();

--- a/src/com/lilithsthrone/game/dialogue/encounters/Encounter.java
+++ b/src/com/lilithsthrone/game/dialogue/encounters/Encounter.java
@@ -18,6 +18,7 @@ import com.lilithsthrone.game.character.effects.Perk;
 import com.lilithsthrone.game.character.effects.StatusEffect;
 import com.lilithsthrone.game.character.gender.Gender;
 import com.lilithsthrone.game.character.npc.NPC;
+import com.lilithsthrone.game.character.npc.NPCGenerationFlag;
 import com.lilithsthrone.game.character.npc.dominion.Cultist;
 import com.lilithsthrone.game.character.npc.dominion.DominionAlleywayAttacker;
 import com.lilithsthrone.game.character.npc.dominion.DominionSuccubusAttacker;
@@ -186,7 +187,7 @@ public class Encounter {
 		@Override
 		protected DialogueNode initialiseEncounter(EncounterType node) {
 			if(node == EncounterType.DOMINION_STORM_ATTACK && Main.game.getCurrentWeather() == Weather.MAGIC_STORM) {
-				NPC npc = new DominionAlleywayAttacker(Gender.getGenderFromUserPreferences(false, false));
+				NPC npc = new DominionAlleywayAttacker(Gender.getGenderFromUserPreferences(false, false), false, NPCGenerationFlag.DIRTY);
 				try {
 					Main.game.addNPC(npc, false);
 				} catch (Exception e) {


### PR DESCRIPTION
If an NPC has the CUM_ADDICT fetish, or they are an arcane storm
attacker, there is a 10% chance that they will spawn with some
dirty inventory slots. If chosen, the NPC will have between 1 slot
and half their slots marked as dirty.

No assets required, does not affect save data format.

Tested on 0.4.1.