### PR TITLE
QoL: Buy-max when unable to afford buy-all

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
@@ -2449,7 +2449,18 @@ public class InventoryDialogue {
 									return new Response("Buy (All) ("+UtilText.formatAsMoneyUncoloured(sellPrice*count, "span")+")", "Your inventory is already full!", null);
 								}
 								if(Main.game.getPlayer().getMoney() < sellPrice*count) {
-									return new Response("Buy (All) ("+UtilText.formatAsMoneyUncoloured(sellPrice*count, "span")+")", "You can't afford to buy this!", null);
+									int affordableCount = Main.game.getPlayer().getMoney() / sellPrice;
+									if(affordableCount > 0) {
+										return new Response("Buy (Max " + affordableCount + ") (" + UtilText.formatAsMoney(sellPrice * affordableCount, "span") + ")",
+												"Buy the " + item.getName() + " for " + UtilText.formatAsMoney(sellPrice * affordableCount) + ".", INVENTORY_MENU) {
+											@Override
+											public void effects() {
+												sellItems(inventoryNPC, Main.game.getPlayer(), item, affordableCount, sellPrice);
+											}
+										};
+									} else {
+										return new Response("Buy (All) ("+UtilText.formatAsMoneyUncoloured(sellPrice*count, "span")+")", "You can't afford to buy this!", null);
+									}
 								}
 								return new Response("Buy (All) (" + UtilText.formatAsMoney(sellPrice*count, "span") + ")",
 										"Buy the " + item.getName() + " for " + UtilText.formatAsMoney(sellPrice*count) + ".", INVENTORY_MENU){
@@ -3622,7 +3633,18 @@ public class InventoryDialogue {
 									return new Response("Buy (All) ("+UtilText.formatAsMoneyUncoloured(sellPrice*count, "span")+")", "Your inventory is already full!", null);
 								}
 								if(Main.game.getPlayer().getMoney() < sellPrice*count) {
-									return new Response("Buy (All) ("+UtilText.formatAsMoneyUncoloured(sellPrice*count, "span")+")", "You can't afford to buy this!", null);
+									int affordableCount = Main.game.getPlayer().getMoney() / sellPrice;
+									if(affordableCount > 0) {
+										return new Response("Buy (Max " + affordableCount + ") (" + UtilText.formatAsMoney(sellPrice * affordableCount, "span") + ")",
+												"Buy the " + weapon.getName() + " for " + UtilText.formatAsMoney(sellPrice * affordableCount) + ".", INVENTORY_MENU) {
+											@Override
+											public void effects() {
+												sellWeapons(inventoryNPC, Main.game.getPlayer(), weapon, affordableCount, sellPrice);
+											}
+										};
+									} else {
+										return new Response("Buy (All) ("+UtilText.formatAsMoneyUncoloured(sellPrice*count, "span")+")", "You can't afford to buy this!", null);
+									}
 								}
 								return new Response("Buy (All) (" + UtilText.formatAsMoney(sellPrice*count, "span") + ")",
 										"Buy the " + weapon.getName() + " for " + UtilText.formatAsMoney(sellPrice*count) + ".", INVENTORY_MENU){
@@ -5180,7 +5202,18 @@ public class InventoryDialogue {
 									return new Response("Buy (All) ("+UtilText.formatAsMoneyUncoloured(sellPrice*count, "span")+")", "Your inventory is already full!", null);
 								}
 								if(Main.game.getPlayer().getMoney() < sellPrice*count) {
-									return new Response("Buy (All) ("+UtilText.formatAsMoneyUncoloured(sellPrice*count, "span")+")", "You can't afford to buy this!", null);
+									int affordableCount = Main.game.getPlayer().getMoney() / sellPrice;
+									if(affordableCount > 0) {
+										return new Response("Buy (Max " + affordableCount + ") (" + UtilText.formatAsMoney(sellPrice * affordableCount, "span") + ")",
+												"Buy the " + clothing.getName() + " for " + UtilText.formatAsMoney(sellPrice * affordableCount) + ".", INVENTORY_MENU) {
+											@Override
+											public void effects() {
+												sellClothing(inventoryNPC, Main.game.getPlayer(), clothing, affordableCount, sellPrice);
+											}
+										};
+									} else {
+										return new Response("Buy (All) ("+UtilText.formatAsMoneyUncoloured(sellPrice*count, "span")+")", "You can't afford to buy this!", null);
+									}
 								}
 								return new Response("Buy (All) (" + UtilText.formatAsMoney(sellPrice*count, "span") + ")",
 										"Buy the " + clothing.getName() + " for " + UtilText.formatAsMoney(sellPrice*count) + ".", INVENTORY_MENU){


### PR DESCRIPTION
When the player does not have enough flames to use "Buy (All)",
but has enough to buy at least one item, the game will offer
"Buy (Max NN)" in the "Buy (All)" slot, where NN is the amount
that will be purchased.

No assets required, does not affect save data.

Tested on 0.4.1.