### PR TITLE
Update Penis.java with non-linear girth/diameter function

### DIFF
--- a/src/com/lilithsthrone/game/character/body/Penis.java
+++ b/src/com/lilithsthrone/game/character/body/Penis.java
@@ -428,12 +428,12 @@ public class Penis implements BodyPartInterface {
 	}
 	
 	public static float getGenericDiameter(int length, PenetrationGirth girth, Set<PenetrationModifier> mods) {
-		return Units.round((length * 0.25f) * (1f + girth.getDiameterPercentageModifier() + (mods.contains(PenetrationModifier.FLARED)?0.05f:0) + (mods.contains(PenetrationModifier.TAPERED)?-0.05f:0)), 2);
+		return Units.round((((length * 10f) ** 0.7f) * 0.1f) * (1f + girth.getDiameterPercentageModifier() + (mods.contains(PenetrationModifier.FLARED)?0.05f:0) + (mods.contains(PenetrationModifier.TAPERED)?-0.05f:0)), 2);
 	}
 	
 	public float getDiameter() {
 		return getGenericDiameter(length, getGirth(), penisModifiers);
-//		return Units.round((length * 0.25f) * (1f + this.getGirth().getDiameterPercentageModifier() + (this.hasPenisModifier(PenetrationModifier.FLARED)?0.05f:0) + (this.hasPenisModifier(PenetrationModifier.TAPERED)?-0.05f:0)), 2);
+//		return Units.round((((length * 10f) ** 0.7f) * 0.1f) * (1f + this.getGirth().getDiameterPercentageModifier() + (this.hasPenisModifier(PenetrationModifier.FLARED)?0.05f:0) + (this.hasPenisModifier(PenetrationModifier.TAPERED)?-0.05f:0)), 2);
 	}
 	
 	public boolean isPierced() {


### PR DESCRIPTION
Penis girth is really big on absurdly long penises; at 1m, it's 25cm by default and 45 for 'Fat' penises. That's really _really_ big.

Changing the linear function to an exponential one would change that. The net effect is that really short penises would be wider by default, and really long ones would be thinner. The changes are greatest for the really long penises.

From 1 to 9cm, the base girth is slightly larger than the original linear function, and 10cm is the inflection point where the girth (diameter) increase slows down. At 1cm girth becomes 0.5cm, at 5cm it's 1.5cm, at 10cm it's 2.5cm, 15cm : 3.3cm, 30cm : 5.4, 60cm : 8.8cm, and at 100 cm : 12.6cm. Fat and Thin would not change, at 180% and 40% of the base girth. This puts the maximum girth at about 22.6cm (23.8cm Flared), and the Thin girth is still 5cm, each at 1m.

What was changed: Changed the math for diameter from length * 0.25 to length in mm ^ 0.7, but retained the centimeter units in the result by dividing by 10 after the exponent.

No new graphical assets are required.

I've not tested this change in-game.