### PR TITLE
Bugfix: Prevent null exception when a move has zero equip-weight

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -18498,7 +18498,9 @@ public abstract class GameCharacter implements XMLSaving {
 			if(Main.game.isStarted()) {
 				Map<AbstractCombatMove, Integer> availables = new HashMap<>();
 				for(AbstractCombatMove move : getAvailableMoves()) {
-					availables.put(move, move.getEquipWeighting());
+					if(move.getEquipWeighting() <= 0) { // non-positive weights mean that the move is never equipped automatically
+						availables.put(move, move.getEquipWeighting());
+					}
 				}
 				while(this.getEquippedMoves().size()<GameCharacter.MAX_COMBAT_MOVES
 						&& !availables.isEmpty()) {


### PR DESCRIPTION
Prevent null exception when there is a combat move with zero equip-weight.

No new assets required.

Tested on 0.4.1.3.

Note: this code area is kind of a special case, since it recurisively calls `Util.getRandomObjectFromWeightedMap` on a shrinking list, often until that list is empty.

There is two options for handling zero-weight values within `Util.getRandomObjectFromWeightedMap`:
A: They should never be selected
B: They should only be selected if there are no other non-zero-weight items available

The PR chooses option A, which means that for this specific area, we can't allow zero-weights into the list of choices, since they will never be selected, and therefore never be removed from the list, and thus messing with the loop termination condition.

If option B is desired, a different set of changes will be required.