### PR TITLE
Bugfix: Pattern id fixes

### DIFF
--- a/res/mods/modding.txt
+++ b/res/mods/modding.txt
@@ -6,6 +6,7 @@ Currently supported directories:
 CLOTHING MODS: res/mods/(yourName)/items/clothing
 TATTOO MODS: res/mods/(yourName)/items/tattoos
 WEAPON MODS: res/mods/(yourName)/items/weapons
+PATTERN MODS: res/mods/(yourName)/items/patterns
 OUTFIT MODS: res/mods/(yourname)/outfits/(descriptiveFolderName)
 SET BONUS MODS: res/mods/(yourname)/setBonuses
 STATUS EFFECT MODS: res/mods/(yourname)/statusEffects
@@ -27,6 +28,8 @@ Within these mod folders (which you create), place the .xml and .svg files that 
 I've included at least one example in each directory for you to reference (the 'clothing' example is in the 'template' folder). If you need any help, there is a 'mod-discussion' channel in the LT discord. ^^
 
 Commented examples not found in the mod folder can be found here:
+Patterns:
+	res/patterns/irbynx/camo.xml for patterns
 Dialogue:
 	res/dialogue/innoxia/flags.xml for dialogue flags
 	res/dialogue/innoxia/encounters/fields/elis/woods.xml for dialogue nodes

--- a/res/patterns/irbynx/camo.xml
+++ b/res/patterns/irbynx/camo.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <pattern>
+	<!-- This name will be displayed in-game to the player. It will automatically be capitalised as needed. -->
 	<name><![CDATA[camo]]></name>
+
+	<!-- If 'true', this pattern can be used when generating random clothing. If 'false', it will be reserved to the dye menu. -->
 	<defaultPattern>true</defaultPattern>
-    <patternName>camo.svg</patternName>
+
+	<!-- The SVG with the actual pattern image. See `pattern-modding.txt` for additional info on making the SVG. -->
+	<patternName>camo.svg</patternName>
 </pattern>

--- a/res/patterns/irbynx/pattern-modding.txt
+++ b/res/patterns/irbynx/pattern-modding.txt
@@ -4,7 +4,7 @@ They don't have the full functionality to make them perfectly work yet; for now 
 
 To add a pattern:
 * Make an SVG that would look good as a 'background pattern'. Have it's background color match the primary color (one of the red colors so the dye brush could change it in game)
-* Name the item using lower case and underscores (_) where the spaces should be. The name will be used in game, so name your things like "tiger_striped.svg" or "cow_patterned.svg"; it will replace underscores with spaces and capitalize as necessary.
+* Make an XML for your pattern. See `camo.xml` for a commented example.
 * That's it! Adding a pattern is actually kinda easy. Keep shapes as paths or rectangles and don't use orange/yellow replacement colors for now, however, as this feature isn't polished yet.
 
 To add support of patterns to an item (clothing only):

--- a/src/com/lilithsthrone/controller/MainControllerInitMethod.java
+++ b/src/com/lilithsthrone/controller/MainControllerInitMethod.java
@@ -5566,13 +5566,13 @@ public class MainControllerInitMethod {
 
 				// Clothing pattern selection:
 				for(Pattern pattern : Pattern.getAllPatterns()) {
-					id = "ITEM_PATTERN_"+pattern.getName();
+					id = "ITEM_PATTERN_"+pattern.getId();
 					
 					if (((EventTarget) MainController.document.getElementById(id)) != null) {
 						
 						((EventTarget) MainController.document.getElementById(id)).addEventListener("click", e -> {
-							if(InventoryDialogue.dyePreviewPattern != pattern.getName()){
-								InventoryDialogue.dyePreviewPattern = pattern.getName();
+							if(!InventoryDialogue.dyePreviewPattern.equals(pattern.getId())){
+								InventoryDialogue.dyePreviewPattern = pattern.getId();
 								Main.game.setContent(new Response("", "", Main.game.getCurrentDialogueNode()));
 							}
 						}, false);

--- a/src/com/lilithsthrone/game/character/npc/dominion/Nyan.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Nyan.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.lilithsthrone.rendering.Pattern;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -500,7 +501,7 @@ public class Nyan extends NPC {
 					PresetColour.CLOTHING_PURPLE_VERY_DARK,
 					PresetColour.CLOTHING_YELLOW));
 			dress = Main.game.getItemGen().generateClothing("phlarx_dresses_vintage_dress", dressColour, PresetColour.CLOTHING_WHITE, PresetColour.CLOTHING_STEEL, false);
-			dress.setPattern("polka_dots_small");
+			dress.setPattern(Pattern.getPatternIdByName("polka_dots_small"));
 			dress.setPatternColour(0, PresetColour.CLOTHING_BLACK);
 			dress.setPatternColour(1, PresetColour.CLOTHING_WHITE);
 			

--- a/src/com/lilithsthrone/game/character/npc/fields/Fae.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Fae.java
@@ -4,6 +4,7 @@ import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.lilithsthrone.rendering.Pattern;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -228,7 +229,7 @@ public class Fae extends NPC {
 		this.setMoney(5000);
 		
 		AbstractClothing scrunchie = Main.game.getItemGen().generateClothing("norin_hair_accessories_hair_scrunchie", PresetColour.CLOTHING_BLACK, false);
-		scrunchie.setPattern("polka_dots_big");
+		scrunchie.setPattern(Pattern.getPatternIdByName("polka_dots_big"));
 		scrunchie.setPatternColour(0, PresetColour.CLOTHING_RED_BURGUNDY);
 		scrunchie.setPatternColour(1, PresetColour.CLOTHING_BLACK);
 		this.equipClothingFromNowhere(scrunchie, true, this);

--- a/src/com/lilithsthrone/game/character/npc/fields/Kazik.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Kazik.java
@@ -4,6 +4,7 @@ import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.lilithsthrone.rendering.Pattern;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -219,7 +220,7 @@ public class Kazik extends NPC {
 		this.equipClothingFromNowhere(Main.game.getItemGen().generateClothing("innoxia_eye_aviators", PresetColour.CLOTHING_GOLD, PresetColour.CLOTHING_ORANGE, null, false), true, this);
 
 		AbstractClothing boxers = Main.game.getItemGen().generateClothing(ClothingType.GROIN_BOXERS, PresetColour.CLOTHING_BLACK, false);
-		boxers.setPattern("camo");
+		boxers.setPattern(Pattern.getPatternIdByName("camo"));
 		boxers.setPatternColour(0, PresetColour.CLOTHING_DESATURATED_BROWN);
 		boxers.setPatternColour(1, PresetColour.CLOTHING_GREEN_DRAB);
 		this.equipClothingFromNowhere(boxers, true, this);
@@ -230,7 +231,7 @@ public class Kazik extends NPC {
 		this.equipClothingFromNowhere(Main.game.getItemGen().generateClothing(ClothingType.WRIST_MENS_WATCH, PresetColour.CLOTHING_PLATINUM, PresetColour.CLOTHING_GUNMETAL, PresetColour.CLOTHING_GUNMETAL, false), true, this);
 
 		AbstractClothing tshirt = Main.game.getItemGen().generateClothing("innoxia_torso_tshirt", PresetColour.CLOTHING_BLACK, false);
-		tshirt.setPattern("camo");
+		tshirt.setPattern(Pattern.getPatternIdByName("camo"));
 		tshirt.setPatternColour(0, PresetColour.CLOTHING_DESATURATED_BROWN);
 		tshirt.setPatternColour(1, PresetColour.CLOTHING_GREEN_DRAB);
 		this.equipClothingFromNowhere(tshirt, true, this);

--- a/src/com/lilithsthrone/game/character/npc/fields/Monica.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Monica.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.lilithsthrone.rendering.Pattern;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -352,7 +353,7 @@ public class Monica extends NPC {
 		this.equipClothingFromNowhere(Main.game.getItemGen().generateClothing("innoxia_foot_flats", PresetColour.CLOTHING_BLACK, false), true, this);
 		
 		AbstractClothing dress = Main.game.getItemGen().generateClothing("phlarx_dresses_vintage_dress", PresetColour.CLOTHING_YELLOW, PresetColour.CLOTHING_BLACK, PresetColour.CLOTHING_SILVER, false);
-		dress.setPattern("irbynx_cow_patterned");
+		dress.setPattern(Pattern.getPatternIdByName("irbynx_cow_patterned"));
 		dress.setPatternColours(Util.newArrayListOfValues(PresetColour.CLOTHING_BLACK, PresetColour.CLOTHING_WHITE));
 		this.equipClothingFromNowhere(dress, true, this);
 

--- a/src/com/lilithsthrone/game/character/npc/submission/Vengar.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/Vengar.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.submission;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.rendering.Pattern;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -315,7 +316,7 @@ public class Vengar extends NPC {
 			this.isAbleToBeDisplaced(this.getClothingInSlot(InventorySlot.TORSO_UNDER), DisplacementType.UNBUTTONS, true, true, this);
 			
 			AbstractClothing cargo = Main.game.getItemGen().generateClothing("innoxia_leg_cargo_trousers", PresetColour.CLOTHING_BLACK, false);
-			cargo.setPattern("multi_camo");
+			cargo.setPattern(Pattern.getPatternIdByName("multi_camo"));
 			cargo.setPatternColour(0, PresetColour.CLOTHING_BLACK);
 			cargo.setPatternColour(1, PresetColour.CLOTHING_BLACK_JET);
 			cargo.setPatternColour(2, PresetColour.CLOTHING_GREY);

--- a/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/InventoryDialogue.java
@@ -6633,14 +6633,14 @@ public class InventoryDialogue {
 					+ "Pattern:<br/>");
 	 
 			for (Pattern pattern : Pattern.getAllPatterns()) {
-				if (dyePreviewPattern.equals(pattern.getName())) {
+				if (dyePreviewPattern.equals(pattern.getId())) {
 					inventorySB.append(
 							"<div class='cosmetics-button active'>"
 								+ "<b style='color:" + PresetColour.GENERIC_GOOD.toWebHexString() + ";'>" + Util.capitaliseSentence(pattern.getNiceName()) + "</b>"
 							+ "</div>");
 				} else {
 					inventorySB.append(
-							"<div id='ITEM_PATTERN_"+pattern.getName()+"' class='cosmetics-button'>"
+							"<div id='ITEM_PATTERN_"+pattern.getId()+"' class='cosmetics-button'>"
 							+ "<span style='color:"+PresetColour.TRANSFORMATION_GENERIC.getShades()[0]+";'>" + Util.capitaliseSentence(pattern.getNiceName()) + "</span>"
 							+ "</div>");
 				}

--- a/src/com/lilithsthrone/game/inventory/clothing/AbstractClothing.java
+++ b/src/com/lilithsthrone/game/inventory/clothing/AbstractClothing.java
@@ -70,7 +70,7 @@ public abstract class AbstractClothing extends AbstractCoreItem implements XMLSa
 	
 	protected List<ItemEffect> effects;
 	
-	private String pattern; // name of the pattern. 
+	private String pattern; // id of the pattern.
 	private List<Colour> patternColours;
 
 	private Map<String, String> stickers; // Mapping StickerCategory id to Sticker id
@@ -221,7 +221,7 @@ public abstract class AbstractClothing extends AbstractCoreItem implements XMLSa
 		patternColours = new ArrayList<>();
 		
 		if(Math.random()<clothingType.getPatternChance()) {
-			pattern = Util.randomItemFrom(clothingType.getDefaultPatterns()).getName();
+			pattern = Util.randomItemFrom(clothingType.getDefaultPatterns()).getId();
 			
 		} else {
 			pattern = "none";
@@ -647,7 +647,11 @@ public abstract class AbstractClothing extends AbstractCoreItem implements XMLSa
 		if(!Main.isVersionOlderThan(Game.loadingVersion, "0.3.7.8")) {
 			Element patternElement = (Element) parentElement.getElementsByTagName("pattern").item(0);
 			if(patternElement!=null) {
-				clothing.setPattern(patternElement.getAttribute("id"));
+				String patternId = patternElement.getAttribute("id");
+				if(Pattern.getPattern(patternId) == null) {
+					patternId = Pattern.getPatternIdByName(patternId);
+				}
+				clothing.setPattern(patternId);
 				NodeList nodes = patternElement.getElementsByTagName("colour");
 				for(int i=0; i<nodes.getLength(); i++) {
 					Element cElement = (Element) nodes.item(i);
@@ -661,8 +665,11 @@ public abstract class AbstractClothing extends AbstractCoreItem implements XMLSa
 		} else {
 			try {
 				if(!parentElement.getAttribute("pattern").isEmpty()) {
-					String pat = parentElement.getAttribute("pattern");
-					clothing.setPattern(pat);
+					String patternId = parentElement.getAttribute("pattern");
+					if(Pattern.getPattern(patternId) == null) {
+						patternId = Pattern.getPatternIdByName(patternId);
+					}
+					clothing.setPattern(patternId);
 				} else {
 					clothing.setPattern("none");
 				}
@@ -812,7 +819,7 @@ public abstract class AbstractClothing extends AbstractCoreItem implements XMLSa
 	}
 	
 	/**
-	 * Returns the name of a pattern that the clothing has.
+	 * Returns the id of a pattern that the clothing has.
 	 * @return
 	 */
 	public String getPattern() {

--- a/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
+++ b/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
@@ -716,7 +716,7 @@ public abstract class AbstractClothingType extends AbstractCoreType {
 			Function<Element, List<Pattern> > getPatternsFromElement = (patternsElement) -> { //Helper function to get the patterns
 				try {
 					return patternsElement.getAllOf("pattern").stream()
-							.map(Element::getTextContent).map(Pattern::getPattern)
+							.map(Element::getTextContent).map(Pattern::getPatternByIdOrName)
 							.collect(Collectors.toList());
 				} catch (Exception e) {
 					printHelpfulErrorForEnumValueMismatches(e);


### PR DESCRIPTION
Fix several issues around pattern modding:
- Fix bug where the ID of a pattern was inconsistent (e.g. "camo" versus "irbynx_camo"). This was fixed with duct tape for the built-in patterns, but modded patterns remained broken.
- Fix a bug where the svg defined in the pattern xml was not respected (would replace the xml file's extension only, instead of the full file name).
- Use full pattern id in saves, instead of just the name. Falls back to using just the name to load old saves, for compatibility.
- Update modding information for patterns.

Bug investigation started here: https://discord.com/channels/302617912949211136/446038411791433729/900455907371122729

Tested on: 0.4.1.9
Discord: Phlarx#1765