### PR TITLE
Bugfix: Rare bug when importing clothing

### DIFF
--- a/src/com/lilithsthrone/game/character/attributes/Attribute.java
+++ b/src/com/lilithsthrone/game/character/attributes/Attribute.java
@@ -619,11 +619,7 @@ public class Attribute {
 			return oldConversionMapping.get(attributeId);
 		}
 
-		attributeId = Util.getClosestStringMatch(attributeId, idToAttributeMap.keySet());
-
-		if(Util.getLastStringMatchDistance()>3) {
-			return null;
-		}
+		attributeId = Util.getClosestStringMatch(attributeId, idToAttributeMap.keySet(), 3);
 		
 		return idToAttributeMap.get(attributeId);
 	}

--- a/src/com/lilithsthrone/game/dialogue/DialogueFlagValue.java
+++ b/src/com/lilithsthrone/game/dialogue/DialogueFlagValue.java
@@ -485,12 +485,8 @@ public class DialogueFlagValue {
 			return null;
 		}
 		
-		id = Util.getClosestStringMatch(id, idToDialogueFlagValueMap.keySet());
-		
-		if(Util.getLastStringMatchDistance()>3) {
-			return null;
-		}
-		
+		id = Util.getClosestStringMatch(id, idToDialogueFlagValueMap.keySet(), 3);
+				
 		return idToDialogueFlagValueMap.get(id);
 	}
 	

--- a/src/com/lilithsthrone/utils/Util.java
+++ b/src/com/lilithsthrone/utils/Util.java
@@ -55,8 +55,6 @@ public class Util {
 
 	private static StringBuilder utilitiesStringBuilder = new StringBuilder();
 	
-	private static int stringMatchDistance;
-	
 	private static Map<KeyCode, String> KEY_NAMES = new LinkedHashMap<KeyCode, String>() {
 		private static final long serialVersionUID = 1L;
 	{
@@ -1449,15 +1447,16 @@ public class Util {
 	 * @param input String for which to find the closest match.
 	 * @param choices Collection of valid Strings, among which the closest match to {@code input}
 	 *                   will be found.
+	 * @param maxDistance The maximum distance for a match. If no match within this distance,
+	 *                    return null.
 	 * @return The closest match.
 	 */
-	public static String getClosestStringMatch(String input, Collection<String> choices) {
+	public static String getClosestStringMatch(String input, Collection<String> choices, int maxDistance) {
 		// If input is empty, just return the empty string. It would make no sense to guess, so hopefully the caller will handle the case correctly.
 		if (input.isEmpty() || choices.contains(input)) {
-			stringMatchDistance = Integer.MIN_VALUE;
 			return input;
 		}
-		stringMatchDistance = Integer.MAX_VALUE;
+		int stringMatchDistance = Integer.MAX_VALUE;
 		String closestString = input;
 		for(String choice : choices) {
 			int newDistance = getLevenshteinDistance(input, choice);
@@ -1465,6 +1464,10 @@ public class Util {
 				closestString = choice;
 				stringMatchDistance = newDistance;
 			}
+		}
+		if(stringMatchDistance>maxDistance) {
+			System.err.println("Warning: getClosestStringMatch() did not find a close enough match for '"+input+"'; returning null. (Closest match was '"+closestString+"' at distance: "+stringMatchDistance+")");
+			return null;
 		}
 		if(stringMatchDistance>0) { // Only show error message if difference is more than just capitalisation differences
 			System.err.println("Warning: getClosestStringMatch() did not find an exact match for '"+input+"'; returning '"+closestString+"' instead. (Distance: "+stringMatchDistance+")");
@@ -1475,8 +1478,8 @@ public class Util {
 		return closestString;
 	}
 	
-	public static int getLastStringMatchDistance() {
-		return stringMatchDistance;
+	public static String getClosestStringMatch(String input, Collection<String> choices) {
+		return getClosestStringMatch(input, choices, Integer.MAX_VALUE);
 	}
 
 	private static String unordered(String input, int prefix) {


### PR DESCRIPTION
(probably could happen with other items, too, but reproduced when loading a save with clothes from an uninstalled mod within Nyan's 'special' inventory)

- On very rare occasions, `AbstractClothing.loadFromXML(e, doc)` was returning null, due to a null response from `ClothingType.getClothingTypeFromId(loadedId, slotHint)`, due to `Util.getClosestStringMatch(id, choiceMap.keySet())` returning a value that was not a member of the key set. Specifically, the value returned was the input.
- The bug is most likely due to the fact that the `getClosestStringMatch` function used a global variable, and so if the function was ever called in parallel, the two instances could and would interfere.
- As this is a race condition, it is very timing-sensitive, and so is both rare and unlikely to detect in the wild.
- Fix: refactor `getClosestStringMatch` to no longer use a global var, and adjust the consumers of that global var to use a different design.

Original report and investigation:
https://discord.com/channels/302617912949211136/446038411791433729/902082219059859456

Discovered on 0.4.1.1 with Java 8
Reproduced on 0.4.1.9 with Java 8
Tested on 0.4.1.9 with Java 8 and Java 14

Discord: Phlarx#1765



Note: additional safeguards may optionally be added somewhere to prevent the issue at other points in the chain (not an exhaustive list):
- In `Nyan.java` and `Monica.java`, within `loadFromXML`, add a check to prevent adding null AbstractClothing to the clothing lists. May also warrant the same for other merchants (these two are the only ones that use `getAllClothingListsMap`, so I didn't check the others).
- In `GameCharacter.java`, within `addClothing`, add a check for when the provided clothing is null (specifically in my case to prevent passing null through to `droppedItemText`). May also warrant the same for `addItem` and `addWeapon`.