### PR TITLE
Bugfix: sorting comparator inconsistency for horns and wings

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/CharacterModificationUtils.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/CharacterModificationUtils.java
@@ -5,6 +5,7 @@ import java.time.format.TextStyle;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1288,8 +1289,15 @@ public class CharacterModificationUtils {
 		contentSB.setLength(0);
 		
 		List<AbstractWingType> sortedTypes = new ArrayList<>(WingType.getAllWingTypes());
-		sortedTypes.sort((w1, w2) -> w1.getTransformName().compareTo(w2.getTransformName()));
-		sortedTypes.sort((w1, w2) -> w1==WingType.NONE?-1:w1.getRace().getName(false).compareTo(w2.getRace().getName(false)));
+		/*
+		 * 'None' is first, then the rest of the 'no race' options.
+		 * Then, the races are sorted alphabetically.
+		 * Within a race (including 'no race'), options are sorted alphabetically.
+		 */
+		sortedTypes.sort(Comparator.comparingInt((AbstractWingType w) -> w == WingType.NONE ? 0 : 1)
+				.thenComparingInt(w -> w.getRace() == Race.NONE ? 0 : 1)
+				.thenComparing(w -> w.getRace().getName(false))
+				.thenComparing(AbstractWingType::getTransformName));
 		
 		for(AbstractWingType wing : sortedTypes) {
 			if((wing.getRace() !=null && availableRaces.contains(wing.getRace()))
@@ -1334,8 +1342,15 @@ public class CharacterModificationUtils {
 		
 		
 		List<AbstractHornType> sortedTypes = new ArrayList<>(types);
-		sortedTypes.sort((h1, h2) -> h1.getTransformName().compareTo(h2.getTransformName()));
-		sortedTypes.sort((h1, h2) -> h1==HornType.NONE?-1:h1.getRace().getName(false).compareTo(h2.getRace().getName(false)));
+		/*
+		 * 'None' is first, then the rest of the 'no race' options.
+		 * Then, the races are sorted alphabetically.
+		 * Within a race (including 'no race'), options are sorted alphabetically.
+		 */
+		sortedTypes.sort(Comparator.comparingInt((AbstractHornType h) -> h == HornType.NONE ? 0 : 1)
+				.thenComparingInt(h -> h.getRace() == Race.NONE ? 0 : 1)
+				.thenComparing(h -> h.getRace().getName(false))
+				.thenComparing(AbstractHornType::getTransformName));
 		
 		for(AbstractHornType horn : sortedTypes) {
 			if((horn.getRace()!=null && availableRaces.contains(horn.getRace()))


### PR DESCRIPTION
In the self-transform menu, the horn and wing types are sorted before displaying to the player.

The comparator used for sorting, in certain cases, could reveal itself to violate the general contract.

Since the sort function we are using is stable, the comparator given to it must also be stable. This is the general contract.

Stability primarily means that the sort order must be consistent (for example, if it says [1,2] is in the correct order, it must then say that [2,1] is in the incorrect order), and that it must not reorder equal elements (for example, it must not say that [1,1] is in the incorrect order).

The existing comparator function would fail this contract if HornType.NONE (or WingType.NONE) were ever passed in as the second element.

The rewrite changes from the two-argument comparator into the single-argument key extractor form, by using the Comparator class, and first-item enforcement (such as for HornType.NONE) is performed by mapping the desired first group to zero, and all other elements to one.

Bug report: https://discord.com/channels/302617912949211136/302618549820850176/904738543165923378

Tested on: 0.4.2
Discord: Phlarx#1765