### PR TITLE
Enhancement: Add additional entries to the parser namespace

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -25,19 +25,11 @@ import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
-import com.lilithsthrone.game.character.EquipClothingSetting;
-import com.lilithsthrone.game.character.body.valueEnums.FluidFlavour;
-import com.lilithsthrone.game.character.body.valueEnums.FluidModifier;
-import com.lilithsthrone.game.character.markings.AbstractTattooType;
-import com.lilithsthrone.game.character.markings.TattooType;
-import com.lilithsthrone.game.character.npc.NPCGenerationFlag;
-import com.lilithsthrone.game.inventory.outfit.AbstractOutfit;
-import com.lilithsthrone.game.inventory.outfit.OutfitType;
-import com.lilithsthrone.game.occupantManagement.slave.SlavePermission;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import com.lilithsthrone.game.PropertyValue;
+import com.lilithsthrone.game.character.EquipClothingSetting;
 import com.lilithsthrone.game.character.GameCharacter;
 import com.lilithsthrone.game.character.attributes.AbstractAttribute;
 import com.lilithsthrone.game.character.attributes.AffectionLevel;
@@ -113,6 +105,8 @@ import com.lilithsthrone.game.character.body.valueEnums.CoveringModifier;
 import com.lilithsthrone.game.character.body.valueEnums.CoveringPattern;
 import com.lilithsthrone.game.character.body.valueEnums.CumProduction;
 import com.lilithsthrone.game.character.body.valueEnums.Femininity;
+import com.lilithsthrone.game.character.body.valueEnums.FluidFlavour;
+import com.lilithsthrone.game.character.body.valueEnums.FluidModifier;
 import com.lilithsthrone.game.character.body.valueEnums.FootStructure;
 import com.lilithsthrone.game.character.body.valueEnums.GenitalArrangement;
 import com.lilithsthrone.game.character.body.valueEnums.HornLength;
@@ -138,8 +132,11 @@ import com.lilithsthrone.game.character.fetishes.FetishDesire;
 import com.lilithsthrone.game.character.gender.Gender;
 import com.lilithsthrone.game.character.gender.GenderPronoun;
 import com.lilithsthrone.game.character.gender.PronounType;
+import com.lilithsthrone.game.character.markings.AbstractTattooType;
+import com.lilithsthrone.game.character.markings.TattooType;
 import com.lilithsthrone.game.character.npc.NPC;
 import com.lilithsthrone.game.character.npc.NPCFlagValue;
+import com.lilithsthrone.game.character.npc.NPCGenerationFlag;
 import com.lilithsthrone.game.character.npc.dominion.Brax;
 import com.lilithsthrone.game.character.npc.dominion.Lilaya;
 import com.lilithsthrone.game.character.npc.dominion.Nyan;
@@ -164,6 +161,7 @@ import com.lilithsthrone.game.character.race.RacialBody;
 import com.lilithsthrone.game.character.race.Subspecies;
 import com.lilithsthrone.game.combat.CombatBehaviour;
 import com.lilithsthrone.game.combat.DamageType;
+import com.lilithsthrone.game.combat.DamageVariance;
 import com.lilithsthrone.game.combat.spells.Spell;
 import com.lilithsthrone.game.combat.spells.SpellSchool;
 import com.lilithsthrone.game.combat.spells.SpellUpgrade;
@@ -181,8 +179,11 @@ import com.lilithsthrone.game.inventory.clothing.AbstractClothingType;
 import com.lilithsthrone.game.inventory.clothing.ClothingType;
 import com.lilithsthrone.game.inventory.item.AbstractItemType;
 import com.lilithsthrone.game.inventory.item.ItemType;
+import com.lilithsthrone.game.inventory.outfit.AbstractOutfit;
+import com.lilithsthrone.game.inventory.outfit.OutfitType;
 import com.lilithsthrone.game.inventory.weapon.AbstractWeaponType;
 import com.lilithsthrone.game.inventory.weapon.WeaponType;
+import com.lilithsthrone.game.occupantManagement.slave.SlavePermission;
 import com.lilithsthrone.game.occupantManagement.slave.SlavePermissionSetting;
 import com.lilithsthrone.game.settings.ForcedFetishTendency;
 import com.lilithsthrone.game.settings.ForcedTFTendency;
@@ -9707,12 +9708,15 @@ public class UtilText {
 			engine.put("ITEM_TAG_"+it.toString(), it);
 		}
 		for(CoverableArea ca : CoverableArea.values()) {
+			engine.put("COVERABLE_AREA_"+ca.toString(), ca);
 			engine.put("CA_"+ca.toString(), ca);
 		}
 		for(InventorySlot is : InventorySlot.values()) {
+			engine.put("INV_SLOT_"+is.toString(), is);
 			engine.put("IS_"+is.toString(), is);
 		}
 		for(EquipClothingSetting ecs : EquipClothingSetting.values()) {
+			engine.put("EQUIP_CLOTHING_SETTING_"+ecs.toString(), ecs);
 			engine.put("ECS_"+ecs.toString(), ecs);
 		}
 		
@@ -9907,6 +9911,7 @@ public class UtilText {
 			engine.put("PERK_CATEGORY_"+pk.toString(), pk);
 		}
 		for(AbstractStatusEffect sa : StatusEffect.getAllStatusEffects()) {
+			engine.put("STATUS_EFFECT_"+StatusEffect.getIdFromStatusEffect(sa), sa);
 			engine.put("SE_"+StatusEffect.getIdFromStatusEffect(sa), sa);
 		}
 		for(AbstractAttribute att : Attribute.getAllAttributes()) {
@@ -9920,6 +9925,9 @@ public class UtilText {
 		// Combat:
 		for(DamageType damageType : DamageType.values()) {
 			engine.put("DAMAGE_TYPE_"+damageType.toString(), damageType);
+		}
+		for(DamageVariance damageVariance : DamageVariance.values()) {
+			engine.put("DAMAGE_VARIANCE_"+damageVariance.toString(), damageVariance);
 		}
 		for(SpellSchool spellSchool : SpellSchool.values()) {
 			engine.put("SPELL_SCHOOL_"+spellSchool.toString(), spellSchool);

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -26,6 +26,8 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
 import com.lilithsthrone.game.character.EquipClothingSetting;
+import com.lilithsthrone.game.character.body.valueEnums.FluidFlavour;
+import com.lilithsthrone.game.character.body.valueEnums.FluidModifier;
 import com.lilithsthrone.game.character.markings.AbstractTattooType;
 import com.lilithsthrone.game.character.markings.TattooType;
 import com.lilithsthrone.game.character.npc.NPCGenerationFlag;
@@ -9767,6 +9769,12 @@ public class UtilText {
 		}
 		for(CumProduction cumProduction : CumProduction.values()) {
 			engine.put("CUM_PRODUCTION_"+cumProduction.toString(), cumProduction);
+		}
+		for(FluidModifier fluidModifier : FluidModifier.values()) {
+			engine.put("FLUID_MODIFIER_"+fluidModifier.toString(), fluidModifier);
+		}
+		for(FluidFlavour fluidFlavour : FluidFlavour.values()) {
+			engine.put("FLUID_FLAVOUR_"+fluidFlavour.toString(), fluidFlavour);
 		}
 		for(BodyPartTag bpt : BodyPartTag.values()) {
 			engine.put("BODY_PART_TAG_"+bpt.toString(), bpt);

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -25,6 +25,13 @@ import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 
+import com.lilithsthrone.game.character.EquipClothingSetting;
+import com.lilithsthrone.game.character.markings.AbstractTattooType;
+import com.lilithsthrone.game.character.markings.TattooType;
+import com.lilithsthrone.game.character.npc.NPCGenerationFlag;
+import com.lilithsthrone.game.inventory.outfit.AbstractOutfit;
+import com.lilithsthrone.game.inventory.outfit.OutfitType;
+import com.lilithsthrone.game.occupantManagement.slave.SlavePermission;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -9682,8 +9689,17 @@ public class UtilText {
 		for(AbstractItemType itemType : ItemType.getAllItems()) {
 			engine.put("ITEM_"+ItemType.getIdFromItemType(itemType), itemType);
 		}
+		for(AbstractTattooType tattooType : TattooType.getAllTattooTypes()) {
+			engine.put("TATTOO_"+TattooType.getIdFromTattooType(tattooType), tattooType);
+		}
 		for(AbstractSetBonus setBonus : SetBonus.getAllSetBonuses()) {
 			engine.put("SET_BONUS_"+SetBonus.getIdFromSetBonus(setBonus), setBonus);
+		}
+		for(AbstractOutfit outfit : OutfitType.getAllOutfits()) {
+			engine.put("OUTFIT_"+OutfitType.getIdFromOutfitType(outfit), outfit);
+		}
+		for(OutfitType outfitType : OutfitType.values()) {
+			engine.put("OUTFIT_TYPE_"+outfitType.toString(), outfitType);
 		}
 		for(ItemTag it : ItemTag.values()) {
 			engine.put("ITEM_TAG_"+it.toString(), it);
@@ -9693,6 +9709,9 @@ public class UtilText {
 		}
 		for(InventorySlot is : InventorySlot.values()) {
 			engine.put("IS_"+is.toString(), is);
+		}
+		for(EquipClothingSetting ecs : EquipClothingSetting.values()) {
+			engine.put("ECS_"+ecs.toString(), ecs);
 		}
 		
 		// Misc.:
@@ -9936,6 +9955,12 @@ public class UtilText {
 		}
 		for(NPCFlagValue flag : NPCFlagValue.values()) {
 			engine.put("NPC_FLAG_"+flag.toString(), flag);
+		}
+		for(NPCGenerationFlag flag : NPCGenerationFlag.values()) {
+			engine.put("NPC_GEN_FLAG_"+flag.toString(), flag);
+		}
+		for(SlavePermission permission : SlavePermission.values()) {
+			engine.put("SLAVE_PERMISSION_"+permission.toString(), permission);
 		}
 		for(SlavePermissionSetting permission : SlavePermissionSetting.values()) {
 			engine.put("SLAVE_PERMISSION_SETTING_"+permission.toString(), permission);


### PR DESCRIPTION
Add parsing access for the following:
- AbstractOutfit via prefix `OUTFIT_`
- DamageVariance via prefix `DAMAGE_VARIANCE_`
- EquipClothingSetting via prefixes `ECS_` and `EQUIP_CLOTHING_SETTING_`
- FluidFlavour via prefix `FLUID_FLAVOUR_`
- FluidModifier via prefix `FLUID_MODIFIER_`
- NPCGenerationFlag via `NPC_GEN_FLAG_`
- OutfitType via prefix `OUTFIT_TYPE_`
- SlavePermission via prefix `SLAVE_PERMISSION_`
- TattooType via prefix `TATTOO_`

Add aliases for existing prefixes:
- AbstractStatusEffect via prefix `STATUS_EFFECT_` (alias for `SE_`)
- CoverableArea via prefix `COVERABLE_AREA_` (alias for `CA_`)
- InventorySlot via prefix `INV_SLOT_` (alias for `IS_`)

I have seen most of these come up in conversations in #mod-discussion and/or #developers over the past several months.

Feel free to adjust or remove as needed.

Tested on: 0.4.2
Discord: Phlarx#1765