### PR TITLE
Enhancement: NPC Generation changes

### DIFF
--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -4411,7 +4411,7 @@ public class Game implements XMLSaving {
 	 * Generates and instantly adds a new NPC of the type 'npcGenerationId'.
 	 * The game does not wait until the NPC Update Loop has finished, and will immediately add this NPC.
 	 *
-	 * @param npcGenerationId The ID of the NPC class to spawn.
+	 * @param npcGenerationId The ID of the NPC class to spawn. Use one of the names below, or use a qualified name (like dominion.DominionAlleywayAttacker) for any other NPC class.
 	 * @param parserTarget The parser id to assign to this NPC, which can then be used in the parsing engine. Pass in an empty String or a null to not assign a parserTarget to this NPC.
 	 * @return The ID of the NPC which is spawned as a result of calling this method.
 	 */
@@ -4433,16 +4433,20 @@ public class Game implements XMLSaving {
 		} else if(npcGenerationId.equalsIgnoreCase("EvelyxMilker")) {
 			npc = new EvelyxMilker();
 		}
-		if(npc!=null) {
-			String idGenerated = addNPC(npc, false, forceImmediateAddition);
-			if(parserTarget!=null && !parserTarget.isEmpty()) {
-				ParserTarget.addAdditionalParserTarget(parserTarget, npc);
+		if(npc==null) {
+			try {
+				npc = (NPC) Class.forName("com.lilithsthrone.game.character.npc."+npcGenerationId).newInstance();
+			} catch (Exception ex) {
+				System.err.println("Failed to add NPC: "+npcGenerationId);
+				ex.printStackTrace();
+				return "";
 			}
-			return idGenerated;
 		}
-		System.err.println("Failed to add NPC: "+npcGenerationId);
-		new Exception().printStackTrace();
-		return "";
+		String idGenerated = addNPC(npc, false, forceImmediateAddition);
+		if(parserTarget!=null && !parserTarget.isEmpty()) {
+			ParserTarget.addAdditionalParserTarget(parserTarget, npc);
+		}
+		return idGenerated;
 	}
 	
 	// Alaco : Methods in lambdas can't throw exceptions, so we have to wrap addNPC

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionAlleywayAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionAlleywayAttacker.java
@@ -52,7 +52,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class DominionAlleywayAttacker extends NPC {
 
 	public DominionAlleywayAttacker() {
-		this(Gender.F_V_B_FEMALE, false);
+		this(Gender.getGenderFromUserPreferences(false, false), false);
 	}
 	
 	public DominionAlleywayAttacker(Gender gender) {

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionClubNPC.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionClubNPC.java
@@ -32,7 +32,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class DominionClubNPC extends NPC {
 
 	public DominionClubNPC() {
-		this(Gender.F_V_B_FEMALE, Subspecies.DOG_MORPH, RaceStage.GREATER, false);
+		this(Gender.getGenderFromUserPreferences(false, false), Subspecies.DOG_MORPH, RaceStage.GREATER, false);
 	}
 	
 	public DominionClubNPC(boolean isImported) {

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionExpressCentaur.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionExpressCentaur.java
@@ -41,7 +41,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class DominionExpressCentaur extends NPC {
 
 	public DominionExpressCentaur() {
-		this(Gender.F_V_B_FEMALE, PresetColour.CLOTHING_STEEL, false);
+		this(Gender.getGenderFromUserPreferences(false, false), PresetColour.CLOTHING_STEEL, false);
 	}
 	
 	public DominionExpressCentaur(boolean isImported) {

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionSuccubusAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionSuccubusAttacker.java
@@ -4,6 +4,7 @@ import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.lilithsthrone.game.character.body.valueEnums.Femininity;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -59,7 +60,7 @@ public class DominionSuccubusAttacker extends NPC {
 	public DominionSuccubusAttacker(boolean isImported) {
 		super(isImported, null, null, "",
 				Util.random.nextInt(50)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
-				5, Gender.F_V_B_FEMALE, Subspecies.DEMON, RaceStage.GREATER,
+				5, Gender.getGenderFromUserPreferences(Femininity.FEMININE), Subspecies.DEMON, RaceStage.GREATER,
 				new CharacterInventory(10), WorldType.DOMINION, PlaceType.DOMINION_BACK_ALLEYS, false);
 
 		if(!isImported) {

--- a/src/com/lilithsthrone/game/character/npc/dominion/EnforcerPatrol.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/EnforcerPatrol.java
@@ -57,7 +57,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class EnforcerPatrol extends NPC {
 
 	public EnforcerPatrol() {
-		this(Occupation.NPC_ENFORCER_PATROL_CONSTABLE, Gender.F_V_B_FEMALE, false);
+		this(Occupation.NPC_ENFORCER_PATROL_CONSTABLE, Gender.getGenderFromUserPreferences(false, false), false);
 	}
 	
 	public EnforcerPatrol(boolean isImported) {

--- a/src/com/lilithsthrone/game/character/npc/dominion/EnforcerWarehouseGuard.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/EnforcerWarehouseGuard.java
@@ -51,7 +51,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class EnforcerWarehouseGuard extends NPC {
 
 	public EnforcerWarehouseGuard() {
-		this(Occupation.NPC_ENFORCER_SWORD_SERGEANT, Subspecies.WOLF_MORPH, RaceStage.GREATER, Gender.F_V_B_FEMALE, false);
+		this(Occupation.NPC_ENFORCER_SWORD_SERGEANT, Subspecies.WOLF_MORPH, RaceStage.GREATER, Gender.getGenderFromUserPreferences(false, false), false);
 	}
 	
 	public EnforcerWarehouseGuard(boolean isImported) {

--- a/src/com/lilithsthrone/game/character/npc/dominion/HarpyNestsAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/HarpyNestsAttacker.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.lilithsthrone.game.character.body.valueEnums.Femininity;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -42,7 +43,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class HarpyNestsAttacker extends NPC {
 
 	public HarpyNestsAttacker() {
-		this(Gender.F_V_B_FEMALE, false);
+		this(Gender.getGenderFromUserPreferences(Femininity.FEMININE), false);
 	}
 	
 	public HarpyNestsAttacker(Gender gender) {

--- a/src/com/lilithsthrone/game/character/npc/dominion/ReindeerOverseer.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/ReindeerOverseer.java
@@ -47,7 +47,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class ReindeerOverseer extends NPC {
 	
 	public ReindeerOverseer() {
-		this(Gender.F_V_B_FEMALE, false);
+		this(Gender.getGenderFromUserPreferences(false, false), false);
 	}
 	
 	public ReindeerOverseer(Gender gender) {

--- a/src/com/lilithsthrone/game/character/npc/dominion/SlaveInStocks.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/SlaveInStocks.java
@@ -44,7 +44,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class SlaveInStocks extends NPC {
 
 	public SlaveInStocks() {
-		this(Gender.F_V_B_FEMALE, false);
+		this(Gender.getGenderFromUserPreferences(false, false), false);
 	}
 	
 	public SlaveInStocks(Gender gender) {

--- a/src/com/lilithsthrone/game/character/npc/misc/BasicSlave.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/BasicSlave.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.misc;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.body.valueEnums.Femininity;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -35,7 +36,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class BasicSlave extends NPC {
 
 	public BasicSlave() {
-		this(Gender.F_V_B_FEMALE, false);
+		this(Gender.getGenderFromUserPreferences(false, false), false);
 	}
 	
 	public BasicSlave(Gender gender) {

--- a/src/com/lilithsthrone/game/character/npc/misc/GenericFemaleNPC.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/GenericFemaleNPC.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.misc;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.body.valueEnums.Femininity;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -32,7 +33,7 @@ public class GenericFemaleNPC extends NPC {
 	public GenericFemaleNPC(boolean isImported) {
 		super(isImported, new NameTriplet("unknown female"), null, "Unknown.",
 				25, Month.JUNE, 15,
-				1, Gender.F_V_B_FEMALE, Subspecies.HUMAN, RaceStage.HUMAN,
+				1, Gender.getGenderFromUserPreferences(Femininity.FEMININE), Subspecies.HUMAN, RaceStage.HUMAN,
 				new CharacterInventory(0), WorldType.EMPTY, PlaceType.GENERIC_HOLDING_CELL, true);
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/misc/GenericMaleNPC.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/GenericMaleNPC.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.misc;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.body.valueEnums.Femininity;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -32,7 +33,7 @@ public class GenericMaleNPC extends NPC {
 	public GenericMaleNPC(boolean isImported) {
 		super(isImported, new NameTriplet("unknown male"), null, "Unknown.",
 				25, Month.JUNE, 15,
-				1, Gender.M_P_MALE, Subspecies.HUMAN, RaceStage.HUMAN,
+				1, Gender.getGenderFromUserPreferences(Femininity.MASCULINE), Subspecies.HUMAN, RaceStage.HUMAN,
 				new CharacterInventory(0), WorldType.EMPTY, PlaceType.GENERIC_HOLDING_CELL, true);
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/misc/GenericSexualPartner.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/GenericSexualPartner.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import com.lilithsthrone.game.character.body.valueEnums.Femininity;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -52,7 +53,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class GenericSexualPartner extends NPC {
 
 	public GenericSexualPartner() {
-		this(Gender.F_V_B_FEMALE, WorldType.EMPTY, new Vector2i(0, 0), false);
+		this(Gender.getGenderFromUserPreferences(false, false), WorldType.EMPTY, new Vector2i(0, 0), false);
 	}
 	
 	public GenericSexualPartner(boolean isImported) {

--- a/src/com/lilithsthrone/game/character/npc/misc/SlaveForSale.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/SlaveForSale.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.lilithsthrone.game.character.body.valueEnums.Femininity;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -39,11 +40,11 @@ import com.lilithsthrone.world.places.PlaceType;
 public class SlaveForSale extends NPC {
 
 	public SlaveForSale() {
-		this(false);
+		this(Gender.getGenderFromUserPreferences(false, false), false);
 	}
 
 	public SlaveForSale(boolean isImported) {
-		this(Gender.F_V_B_FEMALE, isImported);
+		this(Gender.getGenderFromUserPreferences(false, false), isImported);
 	}
 	
 	public SlaveForSale(Gender gender, boolean isImported) {

--- a/src/com/lilithsthrone/game/character/npc/submission/BatCavernLurkerAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/BatCavernLurkerAttacker.java
@@ -38,7 +38,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class BatCavernLurkerAttacker extends NPC {
 
 	public BatCavernLurkerAttacker() {
-		this(Gender.F_V_B_FEMALE, false);
+		this(Gender.getGenderFromUserPreferences(false, false), false);
 	}
 	
 	public BatCavernLurkerAttacker(Gender gender) {

--- a/src/com/lilithsthrone/game/character/npc/submission/BatCavernSlimeAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/BatCavernSlimeAttacker.java
@@ -36,7 +36,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class BatCavernSlimeAttacker extends NPC {
 
 	public BatCavernSlimeAttacker() {
-		this(Gender.F_V_B_FEMALE, false);
+		this(Gender.getGenderFromUserPreferences(false, false), false);
 	}
 	
 	public BatCavernSlimeAttacker(Gender gender) {

--- a/src/com/lilithsthrone/game/character/npc/submission/GamblingDenPatron.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/GamblingDenPatron.java
@@ -42,7 +42,7 @@ public class GamblingDenPatron extends NPC {
 	private DicePokerTable table;
 	
 	public GamblingDenPatron() {
-		this(Gender.F_V_B_FEMALE, DicePokerTable.COPPER, false);
+		this(Gender.getGenderFromUserPreferences(false, false), DicePokerTable.COPPER, false);
 	}
 	
 	public GamblingDenPatron(Gender gender) {

--- a/src/com/lilithsthrone/game/character/npc/submission/ImpAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/ImpAttacker.java
@@ -68,7 +68,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class ImpAttacker extends NPC {
 
 	public ImpAttacker() {
-		this(Subspecies.IMP, Gender.F_V_B_FEMALE, false);
+		this(Subspecies.IMP, Gender.getGenderFromUserPreferences(false, false), false);
 	}
 	
 	public ImpAttacker(boolean isImported) {

--- a/src/com/lilithsthrone/game/character/npc/submission/RatGangMember.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/RatGangMember.java
@@ -50,7 +50,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class RatGangMember extends NPC {
 
 	public RatGangMember() {
-		this(Gender.F_V_B_FEMALE, false);
+		this(Gender.getGenderFromUserPreferences(false, false), false);
 	}
 	
 	public RatGangMember(Gender gender) {

--- a/src/com/lilithsthrone/game/character/npc/submission/RatWarrensCaptive.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/RatWarrensCaptive.java
@@ -4,6 +4,7 @@ import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.lilithsthrone.game.character.body.valueEnums.*;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -16,21 +17,6 @@ import com.lilithsthrone.game.character.body.Penis;
 import com.lilithsthrone.game.character.body.coverings.BodyCoveringType;
 import com.lilithsthrone.game.character.body.coverings.Covering;
 import com.lilithsthrone.game.character.body.types.FluidType;
-import com.lilithsthrone.game.character.body.valueEnums.AreolaeSize;
-import com.lilithsthrone.game.character.body.valueEnums.BodyHair;
-import com.lilithsthrone.game.character.body.valueEnums.CupSize;
-import com.lilithsthrone.game.character.body.valueEnums.FluidFlavour;
-import com.lilithsthrone.game.character.body.valueEnums.FluidModifier;
-import com.lilithsthrone.game.character.body.valueEnums.FluidRegeneration;
-import com.lilithsthrone.game.character.body.valueEnums.LabiaSize;
-import com.lilithsthrone.game.character.body.valueEnums.Lactation;
-import com.lilithsthrone.game.character.body.valueEnums.NippleSize;
-import com.lilithsthrone.game.character.body.valueEnums.OrificeDepth;
-import com.lilithsthrone.game.character.body.valueEnums.OrificeElasticity;
-import com.lilithsthrone.game.character.body.valueEnums.OrificeModifier;
-import com.lilithsthrone.game.character.body.valueEnums.OrificePlasticity;
-import com.lilithsthrone.game.character.body.valueEnums.PenetrationGirth;
-import com.lilithsthrone.game.character.body.valueEnums.Wetness;
 import com.lilithsthrone.game.character.fetishes.Fetish;
 import com.lilithsthrone.game.character.gender.Gender;
 import com.lilithsthrone.game.character.npc.NPC;
@@ -65,7 +51,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class RatWarrensCaptive extends NPC {
 
 	public RatWarrensCaptive() {
-		this(Gender.F_V_B_FEMALE, false);
+		this(Gender.getGenderFromUserPreferences(Femininity.FEMININE), false);
 	}
 	
 	public RatWarrensCaptive(Gender gender) {

--- a/src/com/lilithsthrone/game/character/npc/submission/RebelBaseInsaneSurvivor.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/RebelBaseInsaneSurvivor.java
@@ -59,7 +59,7 @@ public class RebelBaseInsaneSurvivor extends NPC {
     public static final int RECRUITMENT_YEAR = 1990;
     
     public RebelBaseInsaneSurvivor() {
-        this(Gender.M_P_MALE, false);
+        this(Gender.getGenderFromUserPreferences(false, false), false);
     }
     
     public RebelBaseInsaneSurvivor(Gender gender) {

--- a/src/com/lilithsthrone/game/character/npc/submission/SubmissionAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/SubmissionAttacker.java
@@ -50,7 +50,7 @@ import com.lilithsthrone.world.places.PlaceType;
 public class SubmissionAttacker extends NPC {
 
 	public SubmissionAttacker() {
-		this(Gender.F_V_B_FEMALE, false);
+		this(Gender.getGenderFromUserPreferences(false, false), false);
 	}
 	
 	public SubmissionAttacker(Gender gender) {


### PR DESCRIPTION
- What is the purpose of the pull request?

Allow all NPC classes to be instantiated with the addNPC(String npcGenerationId, String parserTarget) method;

- Give a brief description of what you changed or added.

Added a fall-through method to instantiate the class (using the (NPC) Class.forName().newInstance() method). 

Now you can use one of the predefined names (like FieldsBandit), or use a qualified name (like dominion.DominionAlleywayAttacker) for any other NPC class.

Also updated the default (no parameter) constructors to make use of the gender preferences, rather than default values.

- Are any new graphical assets required?

No.

- Has this change been tested? If so, mention the version number that the test was based on.

Yes, tested with version 0.4.2.1 and the AceXP encounters mod.

- So we have a better idea of who you are, what is your Discord Handle?

AceXP#0930
