### PR TITLE
Enhancement: Dynamic tooltip heights

### DIFF
--- a/src/com/lilithsthrone/controller/MainController.java
+++ b/src/com/lilithsthrone/controller/MainController.java
@@ -2381,16 +2381,44 @@ public class MainController implements Initializable {
 			webEngine.loadContent(content);
 		}
 	}
-	
-	public void setTooltipContent(String content) {
+
+	/**
+	 * Sets the tooltip content, and returns the pixel height
+	 * of the resultant tooltip content.
+	 * 
+	 * To calculate height, wraps the content in a #sizing-box
+	 * div, and checks that element's height.
+	 * 
+	 * This does not set the tooltip height, but only measures
+	 * the content height. The tooltip must be manually
+	 * resized as needed.
+	 * 
+	 * Additionally, this should be called before setting the
+	 * tooltip position, if that requires knowledge of the
+	 * final height.
+	 * 
+	 * @param content HTML content to display in the tooltip
+	 * @return the calculated height of the tooltip content
+	 */
+	public int setTooltipContent(String content) {
 		if (Main.getProperties().hasValue(PropertyValue.fadeInText)) {
 			content = "<div class='tooltip-animation' style='width: 100%;'>" + content + "</div>";
 		}
+		content = "<div id='sizing-box' style='width: 100%;'>" + content + "</div>";
 		if(useJavascriptToSetContent) {
 			setWebEngineContent(webEngineTooltip, content);
 		} else {
 			webEngineTooltip.loadContent(content);
 		}
+		int height = 0;
+		try {
+			// add 8 + 8 to account for the top + bottom margins
+			height = 16 + (int)Main.mainController.getWebEngineTooltip().executeScript("document.getElementById('sizing-box').scrollHeight");
+		} catch(Exception e) {
+			System.err.println("Failed to locate the tooltip sizing box!");
+			e.printStackTrace();
+		}
+		return height;
 	}
 	
 	public void setAttributePanelContent(String content) {

--- a/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipResponseDescriptionEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipResponseDescriptionEventListener.java
@@ -253,6 +253,22 @@ public class TooltipResponseDescriptionEventListener implements EventListener {
 					boxHeight+= 28 + ((response.lineHeight()+1)*18);
 				}
 				
+				/* TODO
+				 * Verify that there is no adverse effects to using this method to calculate the tooltip height,
+				 * then remove all boxHeight calculations above, I guess, and apply this method to other
+				 * tooltip types that could use this.
+				 */
+				int realHeight = Main.mainController.setTooltipContent(UtilText.parse(tooltipSB.toString()));
+				
+				if(false) {
+					// for every response tooltip, print the height values
+					// very spammy
+					System.out.println("predicted: " + boxHeight);
+					System.out.println("measured:  " + realHeight);
+				}
+				
+				boxHeight = realHeight;
+
 				Main.mainController.setTooltipSize(360, boxHeight);
 				
 				double xPosition = ((MouseEvent) event).getScreenX() + 16 - 180;
@@ -266,7 +282,6 @@ public class TooltipResponseDescriptionEventListener implements EventListener {
 				Main.mainController.getTooltip().setAnchorY(yPosition);
 				
 				TooltipUpdateThread.updateToolTip(xPosition,yPosition);
-				Main.mainController.setTooltipContent(UtilText.parse(tooltipSB.toString()));
 			}
 			
 		}

--- a/src/com/lilithsthrone/game/combat/Combat.java
+++ b/src/com/lilithsthrone/game/combat/Combat.java
@@ -1093,9 +1093,8 @@ public class Combat {
 		if(move.getStatusEffects(Main.game.getPlayer(), moveTarget, isCrit)!=null && !move.getStatusEffects(Main.game.getPlayer(), moveTarget, isCrit).isEmpty()) {
 			for(Entry<AbstractStatusEffect, Integer> entry : move.getStatusEffects(Main.game.getPlayer(), moveTarget, isCrit).entrySet()) {
 				moveStatblock.append("Applies <b style='color:"+entry.getKey().getColour().toWebHexString()+";'>"+Util.capitaliseSentence(entry.getKey().getName(moveTarget))+"</b>"
-						+ " for <b>"+entry.getValue()+(entry.getValue()==1?" turn":" turns")+"</b>");
+						+ " for <b>"+entry.getValue()+(entry.getValue()==1?" turn":" turns")+"</b><br/>");
 			}
-			moveStatblock.append("<br/>");
 		}
 		
 		StringBuilder critText = new StringBuilder();

--- a/src/com/lilithsthrone/res/css/webViewTooltip_stylesheet.css
+++ b/src/com/lilithsthrone/res/css/webViewTooltip_stylesheet.css
@@ -178,7 +178,7 @@ h6{
 .description{
 	margin:8px 8px 0 8px;
 	padding:8px;
-	height:106px;
+	min-height:106px;
 	background-color:#19191a;
 	box-sizing: border-box;
 	width: calc(100% - 16px);


### PR DESCRIPTION
The PR only applies to tooltips generated by `TooltipResponseDescriptionEventListener`, and so only affects the tooltips for the response buttons.

Further rollout can occur once this has been proven to be an effective and stable strategy.

This change also:
- Changed response 'description' css `height` to `min-height`, allowing the description box to grow.
- Combat moves which inflict multiple effects now display each effect on a new line.

In testing, I have noticed a few times where the first two or three tooltips generated can occasionally have a larger than expected height. After the initial few, all subsequent tooltips were fully stable. I am unsure of the cause.

Tested on: 0.4.2
Discord: Phlarx#1765

#### Images:
This tooltip would have overflowed, so that the lower text in the description would have been unreadable:
![loooong](https://user-images.githubusercontent.com/31363213/140685901-dd04eb5d-e496-4a2a-b476-0d1cdbab8556.png)

This tooltip is unchanged in shape and size from the current behavior:
![normal](https://user-images.githubusercontent.com/31363213/140685992-e0e20278-240f-4041-8b4a-6907892a3f7d.png)
