### PR TITLE
Use eclispe compiler instead of javac - significantly faster builds.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,17 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.7.0</version>
 				<configuration>
+					<compilerId>eclipse</compilerId>
 					<source>1.8</source>
 					<target>1.8</target>
-					<useIncrementalCompilation>false</useIncrementalCompilation>
 				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.codehaus.plexus</groupId>
+						<artifactId>plexus-compiler-eclipse</artifactId>
+						<version>2.8.3</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?

Recompilation of the java code takes a long time, even then using a "high end" system. On this particular machine I'm seeing a 5+ minute compilation time and on a previous rig I was seeing 9~10 minute compilation times.
```
MacBook-Pro liliths-throne-public % export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
MacBook-Pro liliths-throne-public % time mvn clean package
[INFO] Scanning for projects...
[INFO]
[INFO] -----------------------< com.lilithsthrone:game >-----------------------
[INFO] Building lilithsthrone 1
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ game ---
[INFO] Deleting<snip>//liliths-throne-public/target
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ game ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1430 resources to com/lilithsthrone/res
[INFO] Copying 2584 resources to <snip>//liliths-throne-public/target/res
[INFO]
[INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ game ---
[INFO] Compiling 901 source files to<snip>//liliths-throne-public/target/classes
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ game ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory <snip>//liliths-throne-public/src/test/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.7.0:testCompile (default-testCompile) @ game ---
[INFO] No sources to compile
[INFO]
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ game ---
[INFO] No tests to run.
[INFO]
[INFO] --- maven-jar-plugin:3.0.2:jar (default-jar) @ game ---
[INFO] Building jar: <snip>/liliths-throne-public/target/game-1.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  05:39 min
[INFO] Finished at: 2021-11-23T11:39:36-06:00
[INFO] ------------------------------------------------------------------------
mvn clean package  368.30s user 6.17s system 110% cpu 5:40.09 total
```

- Give a brief description of what you changed or added.

This PR adds a configuration to the pom.xml that uses ECJ (See: https://pretagteam.com/question/using-eclipse-java-compiler-ecj-in-maven-builds ) instead of relying on javac. This results in a *much* faster build! As far as I can tell, you still need a javaFX enabled JDK though. (The Azul JavaFX builds work nicely).

```
MacBook-Pro liliths-throne-public % export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
MacBook-Pro liliths-throne-public % time mvn clean package
[INFO] Scanning for projects...
[INFO]
[INFO] -----------------------< com.lilithsthrone:game >-----------------------
[INFO] Building lilithsthrone 1
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ game ---
[INFO] Deleting <snip>/liliths-throne-public/target
[INFO]
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ game ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1430 resources to com/lilithsthrone/res
[INFO] Copying 2584 resources to <snip>/liliths-throne-public/target/res
[INFO]
[INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ game ---
[INFO] Changes detected - recompiling the module!
[INFO]
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ game ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory <snip>/liliths-throne-public/src/test/resources
[INFO]
[INFO] --- maven-compiler-plugin:3.7.0:testCompile (default-testCompile) @ game ---
[INFO] No sources to compile
[INFO]
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ game ---
[INFO] No tests to run.
[INFO]
[INFO] --- maven-jar-plugin:3.0.2:jar (default-jar) @ game ---
[INFO] Building jar: <snip>/liliths-throne-public/target/game-1.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.647 s
[INFO] Finished at: 2021-11-23T12:20:29-06:00
[INFO] ------------------------------------------------------------------------
mvn clean package  39.22s user 4.97s system 362% cpu 12.203 total
```

A big difference here is that `javac` is restricted to using a thread/core no matter how many cores your cpu actually has. ECJ is not. 

- Are any new graphical assets required?

No

- Has this change been tested? If so, mention the version number that the test was based on.

Compiles pass for commit: 
```
commit 75dec1220cc839d97362f4456eec5a6895dbd250 (upstream/dev, origin/dev, dev)
Author: Innoxia <innoxia7@gmail.com>
Date:   Sun Nov 21 01:27:56 2021 +0000

    increment version number after PR1622 merge
```

- So we have a better idea of who you are, what is your Discord Handle?

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
