### PR TITLE
Bugfix: Allow orgasm actions while player is immobilized

### DIFF
--- a/src/com/lilithsthrone/game/sex/sexActions/SexActionInterface.java
+++ b/src/com/lilithsthrone/game/sex/sexActions/SexActionInterface.java
@@ -67,7 +67,7 @@ public interface SexActionInterface {
 	}
 
 	public default boolean isAvailableDuringImmobilisation() {
-		return this.getActionType()==SexActionType.SPEECH || this.getActionType()==SexActionType.SPEECH_WITH_ALTERNATIVE;
+		return this.getActionType()==SexActionType.SPEECH || this.getActionType()==SexActionType.SPEECH_WITH_ALTERNATIVE || this.getActionType()==SexActionType.PREPARE_FOR_PARTNER_ORGASM || this.getActionType()==SexActionType.ORGASM;
 	}
 	
 	/**


### PR DESCRIPTION
- As of 4.2.9, when a player is immobilized then no orgasm options are displayed.  The player is left with a blank grid with no options, and has to load from a previous save.
- This modification allows Prepare and Orgasm options to be displayed
- Deny option is deliberately excluded
- Changed tested and working on my system with latest dev 4.3.0 branch and with the release 4.2.9 branch.
- My discord handle is Miome#2106