### PR TITLE
Freedom Certificate stops future enslavement

### DIFF
--- a/res/txt/characters/enslavement.xml
+++ b/res/txt/characters/enslavement.xml
@@ -104,6 +104,19 @@
 	]]>
 	</htmlContent>
 
+	<htmlContent tag="ENSLAVEMENT_FAIL_FREEDOM_CERTIFICATION"><![CDATA[
+	<p>
+		Holding the [#SPECIAL_PARSE_0] in one [pc.hand], you take a step towards [npc.name]. [npc.She] freezes up for a moment as [npc.she] sees what you're about to do before relaxing, and says [npc.speech(If you're trying to enslave me again, it's no use! You set me free, remember?)]
+	</p>
+	<p>
+		Ignoring [npc.her] warning, you force the [#SPECIAL_PARSE_0] onto [npc.her], before stepping back and waiting to see if anything happens. True to [npc.her] words, however, the [#SPECIAL_PARSE_0]'s arcane enchantment doesn't recognise [npc.herHim] as being a criminal, which is evidenced by glowing red lettering that's projected into the air, reading:
+	</p>
+	<p style='text-align:center;'>
+		[style.italicsBad(Target not wanted for enslavement!)]
+	</p>
+	]]>
+	</htmlContent>
+	
 	<htmlContent tag="ENSLAVEMENT_FAIL_NOT_WANTED_DEMON"><![CDATA[
 	<p>
 		Holding the [#SPECIAL_PARSE_0] in one [pc.hand], you take a step towards v. [npc.She] lets out a mocking laugh as [npc.she] sees what you're about to do, and sneers, [npc.speech(If you're trying to enslave me, it's no use! No Enforcer would ever sign off on a demon's enslavement warrant!)]
@@ -143,7 +156,6 @@
 	</p>
 	]]>
 	</htmlContent>
-	
 	
 	<!-- SET_SLAVE_FREE_SCARLETT -->
 	

--- a/src/com/lilithsthrone/game/dialogue/companions/CompanionManagement.java
+++ b/src/com/lilithsthrone/game/dialogue/companions/CompanionManagement.java
@@ -594,6 +594,7 @@ public class CompanionManagement {
 					} else if(!OccupancyUtil.isFreeRoomAvailableForOccupant()) {
 						unavailableGuestDescription = "[style.italicsMinorBad(As you do not have a free guest room for [npc.name] to move in to, you will be unable to invite [npc.herHim] to stay here in the mansion after freeing [npc.herHim]!)]";
 					}
+					characterSelected().setEnslavementDialogue(SlaveDialogue.FREEDOM_DIALOG, false);
 					String thanksjava = unavailableGuestDescription;
 					
 					return new Response("Set free",

--- a/src/com/lilithsthrone/game/dialogue/companions/SlaveDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/companions/SlaveDialogue.java
@@ -332,6 +332,32 @@ public class SlaveDialogue {
 		}
 	};
 	
+	public static final DialogueNode FREEDOM_DIALOG = new DialogueNode("Freed Slave", "", true) {
+		@Override
+		public void applyPreParsingEffects() {
+			Main.game.getTextEndStringBuilder().append(enslavementTarget.setAffection(Main.game.getPlayer(), -100));
+		}
+		
+		@Override
+		public String getContent() {
+			GameCharacter target = enslavementTarget;
+			AbstractClothing enslavementClothing = target.getEnslavementClothing();
+			UtilText.addSpecialParsingString(enslavementClothing.getName(), true);
+			UtilText.addSpecialParsingString(enslavementClothing.getClothingType().isPlural()?"them":"it", false);
+			return UtilText.parseFromXMLFile("characters/enslavement", "ENSLAVEMENT_FAIL_FREEDOM_CERTIFICATION", target);
+		}
+		
+		@Override
+		public Response getResponse(int responseTab, int index) {
+			if (index == 1) {
+				return new Response("Continue",
+						UtilText.parse(SlaveDialogue.getEnslavementTarget(), "That didn't work, but it doesn't mean you're finished with [npc.name] yet!"),
+						SlaveDialogue.getFollowupEnslavementDialogue());
+			}
+			return null;
+		}
+	};
+	
 	public static final DialogueNode SLAVE_START = new DialogueNode("", ".", true) {
 		@Override
 		public DialogueNodeType getDialogueNodeType() {


### PR DESCRIPTION
- What is the purpose of the pull request?
Stop NPCs freed with the Freedom Certificate being valid slavery targets

- Give a brief description of what you changed or added.
NPCs freed with the Freedom Certificate have their enslavement dialog changed and able to be enslaved set to false

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
0.4.3.4

- So we have a better idea of who you are, what is your Discord Handle?
Maxis010#3060

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
