### PR TITLE
slightly complexed NPC level modifier created by difficult setting

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -21026,7 +21026,7 @@ public abstract class GameCharacter implements XMLSaving {
 	public int getLevel() {
 		try { // There was a NullPointerException being thrown somewhere in here during NPC load from XML.
 			if(this.isPlayer()
-					|| !Main.getProperties().difficultyLevel.isNPCLevelScaling()
+					|| (!Main.getProperties().difficultyLevel.isNPCLevelScaling())
 					|| (this.isSlave() && this.getOwner().isPlayer())
 					|| (this.isElemental() && ((Elemental)this).getSummoner()!=null && ((Elemental)this).getSummoner().isPlayer())
 					|| Main.game.getPlayer().getFriendlyOccupants().contains(this.getId())
@@ -21034,17 +21034,8 @@ public abstract class GameCharacter implements XMLSaving {
 				return level;
 				
 			} else {
-				if(Main.getProperties().difficultyLevel == DifficultyLevel.HELL) {
-					if(level < Main.game.getPlayer().getLevel() * 2) {
-						return Main.game.getPlayer().getLevel() * 2;
-					} else {
-						return level;
-					}
-				} else if(level < Main.game.getPlayer().getLevel()) {
-					return Main.game.getPlayer().getLevel();
-				} else {
-					return level;
-				}
+				float scaling = Main.getProperties().difficultyLevel.getNPCLevelScaling();
+				return (int) Math.max(level, Main.game.getPlayer().getLevel() * scaling + level / (scaling * 2));
 			}
 		} catch(Exception ex) {
 			return level;

--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -21035,7 +21035,7 @@ public abstract class GameCharacter implements XMLSaving {
 				
 			} else {
 				float scaling = Main.getProperties().difficultyLevel.getNPCLevelScaling();
-				return (int) Math.max(level, Main.game.getPlayer().getLevel() * scaling + level / (scaling * 2));
+				return Math.round(Math.max(level, Main.game.getPlayer().getLevel() * scaling + level / (scaling * 2)));
 			}
 		} catch(Exception ex) {
 			return level;

--- a/src/com/lilithsthrone/game/settings/DifficultyLevel.java
+++ b/src/com/lilithsthrone/game/settings/DifficultyLevel.java
@@ -12,11 +12,11 @@ public enum DifficultyLevel {
 	
 	NORMAL("Human", "The way the game is meant to be played. No level scaling and no damage modifications.", PresetColour.RACE_HUMAN, false, 1f, 1f, 1f),
 
-	LEVEL_SCALING("Morph", "Enemies level up alongside your character with 50% mod, but do normal damage.", PresetColour.RACE_CAT_MORPH, true, 0.5f, 1f, 1f),
+	LEVEL_SCALING("Morph", "Enemies level up alongside your character, but do normal damage.", PresetColour.RACE_CAT_MORPH, true, 1f, 1f, 1f),
 	
-	HARD("Demon", "Enemies level up alongside your character with 75% mod and do 200% damage.", PresetColour.RACE_DEMON, true, 0.75f, 2f, 1f),
+	HARD("Demon", "Enemies level up alongside your character with 130% mod and do 200% damage.", PresetColour.RACE_DEMON, true, 1.3f, 2f, 1f),
 	
-	NIGHTMARE("Lilin", "Enemies level up alongside your character with 130% mod, do 200% damage, and take only 50% damage from all sources.", PresetColour.BASE_PURPLE, true, 1.3f, 2f, 0.5f),
+	NIGHTMARE("Lilin", "Enemies level up alongside your character with 150% mod, do 200% damage, and take only 50% damage from all sources.", PresetColour.BASE_PURPLE, true, 1.5f, 2f, 0.5f),
 	
 	HELL("Lilith", "Enemies level up alongside your character with 170% mod, do 400% damage, and take only 25% damage from all sources. Be prepared to lose. A lot.", PresetColour.BASE_CRIMSON, true, 1.7f, 2f, 0.25f);
 

--- a/src/com/lilithsthrone/game/settings/DifficultyLevel.java
+++ b/src/com/lilithsthrone/game/settings/DifficultyLevel.java
@@ -10,28 +10,30 @@ import com.lilithsthrone.utils.colours.PresetColour;
  */
 public enum DifficultyLevel {
 	
-	NORMAL("Human", "The way the game is meant to be played. No level scaling and no damage modifications.", PresetColour.RACE_HUMAN, false, 1, 1),
+	NORMAL("Human", "The way the game is meant to be played. No level scaling and no damage modifications.", PresetColour.RACE_HUMAN, false, 1f, 1f, 1f),
 
-	LEVEL_SCALING("Morph", "Enemies level up alongside your character, but do normal damage.", PresetColour.RACE_CAT_MORPH, true, 1, 1),
+	LEVEL_SCALING("Morph", "Enemies level up alongside your character with 50% mod, but do normal damage.", PresetColour.RACE_CAT_MORPH, true, 0.5f, 1f, 1f),
 	
-	HARD("Demon", "Enemies level up alongside your character and do 200% damage.", PresetColour.RACE_DEMON, true, 2, 1),
+	HARD("Demon", "Enemies level up alongside your character with 75% mod and do 200% damage.", PresetColour.RACE_DEMON, true, 0.75f, 2f, 1f),
 	
-	NIGHTMARE("Lilin", "Enemies level up alongside your character, do 200% damage, and take only 50% damage from all sources.", PresetColour.BASE_PURPLE, true, 2, 0.5f),
+	NIGHTMARE("Lilin", "Enemies level up alongside your character with 130% mod, do 200% damage, and take only 50% damage from all sources.", PresetColour.BASE_PURPLE, true, 1.3f, 2f, 0.5f),
 	
-	HELL("Lilith", "Enemies are always 2x your character's level, do 400% damage, and take only 25% damage from all sources. Be prepared to lose. A lot.", PresetColour.BASE_CRIMSON, true, 4, 0.25f);
+	HELL("Lilith", "Enemies level up alongside your character with 170% mod, do 400% damage, and take only 25% damage from all sources. Be prepared to lose. A lot.", PresetColour.BASE_CRIMSON, true, 1.7f, 2f, 0.25f);
 
 	private String name;
 	private String description;
 	private Colour colour;
 	private boolean isNPCLevelScaling;
+	private float levelScalingNPC;
 	private float damageModifierNPC;
 	private float damageModifierPlayer;
 	
-	private DifficultyLevel(String name, String description, Colour colour, boolean isNPCLevelScaling, float damageModifierNPC, float damageModifierPlayer) {
+	private DifficultyLevel(String name, String description, Colour colour, boolean isNPCLevelScaling, float levelScalingNPC, float damageModifierNPC, float damageModifierPlayer) {
 		this.name = name;
 		this.description = description;
 		this.colour = colour;
 		this.isNPCLevelScaling = isNPCLevelScaling;
+		this.levelScalingNPC = levelScalingNPC;
 		this.damageModifierNPC = damageModifierNPC;
 		this.damageModifierPlayer = damageModifierPlayer;
 	}
@@ -50,6 +52,11 @@ public enum DifficultyLevel {
 
 	public boolean isNPCLevelScaling() {
 		return isNPCLevelScaling;
+	}
+	
+	public float getNPCLevelScaling()
+	{
+		return levelScalingNPC;
 	}
 
 	public float getDamageModifierNPC() {

--- a/src/com/lilithsthrone/game/settings/DifficultyLevel.java
+++ b/src/com/lilithsthrone/game/settings/DifficultyLevel.java
@@ -18,7 +18,7 @@ public enum DifficultyLevel {
 	
 	NIGHTMARE("Lilin", "Enemies level up alongside your character with 150% mod, do 200% damage, and take only 50% damage from all sources.", PresetColour.BASE_PURPLE, true, 1.5f, 2f, 0.5f),
 	
-	HELL("Lilith", "Enemies level up alongside your character with 170% mod, do 400% damage, and take only 25% damage from all sources. Be prepared to lose. A lot.", PresetColour.BASE_CRIMSON, true, 1.7f, 2f, 0.25f);
+	HELL("Lilith", "Enemies level up alongside your character with 170% mod, do 400% damage, and take only 25% damage from all sources. Be prepared to lose. A lot.", PresetColour.BASE_CRIMSON, true, 1.7f, 4f, 0.25f);
 
 	private String name;
 	private String description;


### PR DESCRIPTION
<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
Disperce difficult over difficultness level, as well as making npc levels more varied.
- Give a brief description of what you changed or added.
Before this PR, the level multiplier was constant(with hardcoded exception for max difficult), now it varies between difficult levels.
Also NPC level expr was changed to _baseLevel * scale + baseLevel / (scale * 2)_, so level of NPC not overlapped fully by modifier.
Now level multiplier for each difficultness level equal:
  Morph  - 100%
  Demon - 130%
  Lilin      - 150%
  Lilith     - 170%
Brief was changed.

- Are any new graphical assets required?
No.
- Has this change been tested? If so, mention the version number that the test was based on.
Sure, on dev branch.
- So we have a better idea of who you are, what is your Discord Handle?
kcalbCube