### PR TITLE
Slime Tweaks

### DIFF
--- a/res/items/innoxia/race/slime_biojuice_canister.xml
+++ b/res/items/innoxia/race/slime_biojuice_canister.xml
@@ -44,6 +44,10 @@
 				<p style='margin-bottom:0; padding-bottom:0;'>
 					[style.colourDisabled([npc.NameIsFull] already a slime, so nothing happens...)]
 				</p>
+			#ELSEIF(npc.getBody().getBodyMaterial()!=BODY_MATERIAL_FLESH)
+				<p style='margin-bottom:0; padding-bottom:0;'>
+					[style.colourDisabled([npc.NameIsFull] an elemental, so nothing happens...)]
+				</p>
 			#ELSE
 				[#npc.setBodyMaterial(BODY_MATERIAL_SLIME)]
 			#ENDIF

--- a/res/items/innoxia/race/slime_biojuice_canister.xml
+++ b/res/items/innoxia/race/slime_biojuice_canister.xml
@@ -5,7 +5,7 @@
 		<determiner><![CDATA[a]]></determiner>
 		<name><![CDATA[Biojuice Canister]]></name>
 		<namePlural pluralByDefault="false"><![CDATA[Biojuice Canister]]></namePlural>
-		<description><![CDATA[A canister of glowing pink liquid, which has a thick, slimy consistency. The warning sign on the front makes it quite clear that drinking this would be a bad idea...]]></description> 
+		<description><![CDATA[A canister of heavily processed glowing pink liquid, which has a thick, slimy consistency. The warning sign on the front makes it quite clear that drinking this would be a bad idea...]]></description>
 		
 		<useDescriptor>drink</useDescriptor>
 		
@@ -31,13 +31,13 @@
 		<enchantmentEffectId>RACE</enchantmentEffectId>
 		
 		<effectTooltipLines>
-			<line><![CDATA[[#ATTRIBUTE_MAJOR_CORRUPTION.getFormattedValue(25)]]]></line>
+			<line><![CDATA[[#ATTRIBUTE_MAJOR_CORRUPTION.getFormattedValue(10)]]]></line>
 			<line><![CDATA[[#ATTRIBUTE_MAJOR_CORRUPTION.getFormattedValue(25)] to 'potion effects']]></line>
 			<line><![CDATA[[style.boldSlime(Transforms body into slime!)]]]></line>
 		</effectTooltipLines>
 		
 		<applyEffects><![CDATA[
-			[#npc.incrementAttribute(ATTRIBUTE_MAJOR_CORRUPTION, 25)]
+			[#npc.incrementAttribute(ATTRIBUTE_MAJOR_CORRUPTION, 10)]
 			[#npc.addPotionEffect(ATTRIBUTE_MAJOR_CORRUPTION, 25)]
 			
 			#IF(npc.getBody().getBodyMaterial()==BODY_MATERIAL_SLIME)

--- a/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/TunnelSlimeDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/npcDialogue/submission/TunnelSlimeDialogue.java
@@ -7,14 +7,11 @@ import com.lilithsthrone.game.character.fetishes.Fetish;
 import com.lilithsthrone.game.character.npc.NPC;
 import com.lilithsthrone.game.character.npc.NPCFlagValue;
 import com.lilithsthrone.game.dialogue.DialogueNode;
-import com.lilithsthrone.game.dialogue.responses.Response;
-import com.lilithsthrone.game.dialogue.responses.ResponseCombat;
-import com.lilithsthrone.game.dialogue.responses.ResponseEffectsOnly;
-import com.lilithsthrone.game.dialogue.responses.ResponseSex;
-import com.lilithsthrone.game.dialogue.responses.ResponseTag;
+import com.lilithsthrone.game.dialogue.responses.*;
 import com.lilithsthrone.game.dialogue.utils.BodyChanging;
 import com.lilithsthrone.game.dialogue.utils.InventoryInteraction;
 import com.lilithsthrone.game.dialogue.utils.UtilText;
+import com.lilithsthrone.game.inventory.ItemGeneration;
 import com.lilithsthrone.game.sex.SexControl;
 import com.lilithsthrone.game.sex.SexPace;
 import com.lilithsthrone.game.sex.managers.universal.SMGeneric;
@@ -153,8 +150,8 @@ public class TunnelSlimeDialogue {
 							}
 							@Override
 							public void effects() {
-								Main.game.getTextEndStringBuilder().append(Main.game.getPlayer().setBodyMaterial(BodyMaterial.SLIME));
-								
+								Main.game.getTextEndStringBuilder().append(getSlime().useItem(new ItemGeneration().generateItem("RACE_INGREDIENT_SLIME"),
+										Main.game.getPlayer(), false, true));
 								if(getSlime().isAttractedTo(Main.game.getPlayer())) {
 									Main.game.getTextEndStringBuilder().append(UtilText.parseFromXMLFile("places/submission/tunnelSlime", "TRANSFORMED_SLIME_OFFER_SEX"));
 								} else {
@@ -816,7 +813,8 @@ public class TunnelSlimeDialogue {
 						}
 						@Override
 						public void effects() {
-							Main.game.getPlayer().setBodyMaterial(BodyMaterial.SLIME);
+							Main.game.getTextEndStringBuilder().append(getSlime().useItem(new ItemGeneration().generateItem("RACE_INGREDIENT_SLIME"),
+									Main.game.getPlayer(), false, true));
 						}
 					};
 					

--- a/src/com/lilithsthrone/game/inventory/enchanting/ItemEffectType.java
+++ b/src/com/lilithsthrone/game/inventory/enchanting/ItemEffectType.java
@@ -2582,7 +2582,11 @@ public class ItemEffectType {
 							}
 							@Override
 							public String applyEffect(TFModifier primaryModifier, TFModifier secondaryModifier, TFPotency potency, int limit, GameCharacter user, GameCharacter target, ItemEffectTimer timer) {
-								return target.setBodyMaterial(BodyMaterial.FLESH);
+								return target.getBodyMaterial() == BodyMaterial.SLIME
+										? target.setBodyMaterial(BodyMaterial.FLESH)
+										: "<p style='margin-bottom:0; padding-bottom:0;'>" +
+											"[style.colourDisabled([npc.NameIsFull] an elemental, so nothing happens...)]" +
+											"</p>";
 							}
 						});
 				


### PR DESCRIPTION
- What is the purpose of the pull request?
Tweak how slimes work a bit.
- Give a brief description of what you changed or added.

1. made it so that the slime attacker's slime transformation applies the same effects as the biojuice for the sake of consistency
2. Added flavor text to the biojuice description to mention that it's "heavily processed" and thus corruptive where the source (slime queen in the bath scene) is not
3. Nerfed the permanent corruption gain from biojuice, as it seemed like a harsh effect if a new player just wandered into the submission.
4. Made it so that elementals can't have their body material transformed into SLIME or FLESH using the biojuice or flesh potions.

- Are any new graphical assets required?
No
- Has this change been tested? If so, mention the version number that the test was based on.
0.4.3.9
- So we have a better idea of who you are, what is your Discord Handle?
MintyChip#1944