### PR TITLE
Typo Fixes for 0.4.4

### DIFF
--- a/res/clothing/sage/latex/stockings.xml
+++ b/res/clothing/sage/latex/stockings.xml
@@ -5,7 +5,7 @@
 		<determiner><![CDATA[a pair of]]></determiner>
 		<name><![CDATA[latex thigh-high stockings]]></name>
 		<namePlural pluralByDefault="true"><![CDATA[latex thigh-high stockings]]></namePlural>
-		<description><![CDATA[A pair of thigh-high latex stockings. They are made from black shiny latex that leaves nothing to the imagination.]]></description>
+		<description><![CDATA[A pair of thigh-high latex stockings. They are made from shiny latex that leaves nothing to the imagination.]]></description>
 		<physicalResistance>1</physicalResistance>
 		<femininity>ANDROGYNOUS</femininity>
 		<slot>SOCK</slot> 


### PR DESCRIPTION
Just some typo fixes as I find them. Merge whenever you please, and feel free to correct me if I miss something.

## Changes

* Latex stockings aren't always black, so the description has been tweaked to remove the color reference.