### PR TITLE
Fixed text run-off for tooltips

### DIFF
--- a/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipInventoryEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipInventoryEventListener.java
@@ -863,7 +863,7 @@ public class TooltipInventoryEventListener implements EventListener {
 
 		tooltipSB.append("</div>");
 
-		tooltipSB.append("<div class='container-full-width' style='padding:8px; height:106px;'>"
+		tooltipSB.append("<div class='container-full-width' style='padding:8px; min-height:106px;'>"
 						+ absItem.getDescription()
 					+ "</div>");
 		
@@ -982,6 +982,7 @@ public class TooltipInventoryEventListener implements EventListener {
 			if(cost>0) {
 				listIncrease++;
 				tooltipSB.append("Costs [style.boldArcane("+cost+" Arcane essence"+(cost>1?"s":"")+")] "+(absWep.getWeaponType().isMelee()?"per attack":"to fire")+"<br/>");
+				if(absWep.getWeaponType().isMelee()) {listIncrease++;}
 			}
 			
 			if(equippedToCharacter != null) {
@@ -1076,7 +1077,7 @@ public class TooltipInventoryEventListener implements EventListener {
 
 		tooltipSB.append("</div>");
 
-		tooltipSB.append("<div class='container-full-width' style='padding:8px; height:106px;'>"
+		tooltipSB.append("<div class='container-full-width' style='padding:8px; min-height:106px;'>"
 						+ UtilText.parse(absWep.getWeaponType().getDescription())
 					+ "</div>");
 
@@ -1276,7 +1277,7 @@ public class TooltipInventoryEventListener implements EventListener {
 
 		tooltipSB.append("</div>");
 
-		tooltipSB.append("<div class='container-full-width' style='padding:8px; height:106px;'>"
+		tooltipSB.append("<div class='container-full-width' style='padding:8px; min-height:106px;'>"
 						+ absClothing.getTypeDescription()
 					+ "</div>");
 		

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/enforcerHQ/BraxOffice.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/enforcerHQ/BraxOffice.java
@@ -55,7 +55,7 @@ public class BraxOffice {
 	}
 	
 	private static void givePlayerEnforcerUniform(StringBuilder sb) {
-		if(Main.game.getPlayer().isFeminine()) {
+		if((Main.game.getPlayer().isFeminine() && !Main.game.getPlayer().hasBaseFetish(Fetish.FETISH_CROSS_DRESSER)) || (!Main.game.getPlayer().isFeminine() && Main.game.getPlayer().hasBaseFetish(Fetish.FETISH_CROSS_DRESSER))) {
 			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_servequipset_enfskirt", PresetColour.CLOTHING_BLACK, false), false));
 			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_ptrlequipset_flsldshirt", PresetColour.CLOTHING_PINK, false), false));
 			


### PR DESCRIPTION
- What is the purpose of the pull request? (Minor fix to stop text run-off. Mostly visible with the Siren Scythe. Also made sure the tooltip height accounts for how 'per attack' moves to the next line, unlike 'per shot')

- Give a brief description of what you changed or added. (Changed the 'height' to 'min-height', so the height of the section adjusts for text that goes further than the box can hold. Also added a 'lineIncrease' for melee weapon descriptions that cost essence.)

- Are any new graphical assets required? (No)

- Has this change been tested? If so, mention the version number that the test was based on. (Yes, 4.4.1.)

- Nonnymouse#5520
