### PR TITLE
[0.4.4.1] Typo Fixes

### DIFF
--- a/res/clothing/sage/latex/bra.xml
+++ b/res/clothing/sage/latex/bra.xml
@@ -75,13 +75,13 @@
 
 	<displacementText type="REMOVE_OR_EQUIP">
 		<self>
-		  <![CDATA[[npc.Name] [npc.verb(unzips)] [npc.her] latex bra and [npc.verb(take)] it off.]]>
+		  <![CDATA[[npc.Name] [npc.verb(unzip)] [npc.her] latex bra and [npc.verb(take)] it off.]]>
 		</self>
 		<other>
-		  <![CDATA[[npc.Name] [npc.verb(unzips)] [npc2.namePos] latex bra and [npc.verb(take)] it off.]]>
+		  <![CDATA[[npc.Name] [npc.verb(unzip)] [npc2.namePos] latex bra and [npc.verb(take)] it off.]]>
 		</other>
 		<otherRough>
-		  <![CDATA[[npc.Name] roughly [npc.verb(unzips)] [npc2.namePos] latex bra and [npc.verb(take)] it off.]]>
+		  <![CDATA[[npc.Name] roughly [npc.verb(unzip)] [npc2.namePos] latex bra and [npc.verb(take)] it off.]]>
 		</otherRough>
 	</displacementText>
 	

--- a/res/race/dsg/otter/subspecies/bookEntries.xml
+++ b/res/race/dsg/otter/subspecies/bookEntries.xml
@@ -3,14 +3,14 @@
 	
 	<htmlContent tag="OTTER_BASIC" author="Xuanlong"><![CDATA[
 	<p>
-		Otter-morphs prefer, but do not require, easy access to water and are thus mostly found along the coastal areas of the Endless Sea and the banks of the Hubur River although some may wander into Elis, the Foloi Fields, or Dominion. In riverine areas especially it is not uncommon for otters to set up transport or bridge-laying services. Rounded, low drag ears, long flexible bodies, and rudder-like tails distinguish them from other morphs.
+		Otter-morphs prefer, but do not require, easy access to water and are thus mostly found along the coastal areas of the Endless Sea and the banks of the Hubur River, although some may wander into Elis, the Foloi Fields, or Dominion. In riverine areas especially, it is not uncommon for otters to set up transport or bridge-laying services. Rounded, low drag ears, long flexible bodies, and rudder-like tails distinguish them from other morphs.
 	</p>
 	]]>
 	</htmlContent>
 
 	<htmlContent tag="OTTER_ADVANCED" author="Xuanlong"><![CDATA[
 	<p>	
-		While the individual personalities of hyena-morphs vary greatly from one individual to another, otter-morphs are stereotyped as eternally playful and unable to take anything seriously even while defending themselves. Although often genuine, this playfulness is sometimes a form of deception intended to get a an opponent to lower their guard or a stranger to reveal their true nature. Many a ne'er-do-well has attempted to victimize a seemingly oblivious otter-morph only to end up on the receiving end of a mighty tail slap.
+		While the individual personalities of otter-morphs vary greatly from one individual to another, otter-morphs are stereotyped as eternally playful and unable to take anything seriously even while defending themselves. Although often genuine, this playfulness is sometimes a form of deception intended to get an opponent to lower their guard or a stranger to reveal their true nature. Many a ne'er-do-well has attempted to victimize a seemingly oblivious otter-morph only to end up on the receiving end of a mighty tail slap.
 	</p>
 	<p>
 		Like most other races, otter-morphs are affected by arcane storms. When exposed to arcane lightning up close, they become uncharacteristically aggressive and will force themselves on others. Caution should be exercised around river crossings and ferries run by otter-morphs during these storms.

--- a/src/com/lilithsthrone/game/sex/positions/SexPositionUnique.java
+++ b/src/com/lilithsthrone/game/sex/positions/SexPositionUnique.java
@@ -193,9 +193,11 @@ public class SexPositionUnique {
 			} else if(Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_KNEELING_BETWEEN_LEGS)!=null) {
 				characters.add(Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_KNEELING_BETWEEN_LEGS));
 				isKneeling = true;
+			} else {
+				return "MISSIONARY_ALTAR_CULTIST: Invalid character positions!";
 			}
 
-			boolean playerIsOnTheAltar = characters.get(0).isPlayer();
+			// boolean playerIsOnTheAltar = characters.get(0).isPlayer();
 
 			StringBuilder desc = new StringBuilder();
 			desc.append("[npc.NameIs] lying back on top of the chapel's altar, and ");
@@ -239,13 +241,30 @@ public class SexPositionUnique {
 			null, Util.newArrayListOfValues(CultistSexActions.class)) {
 		@Override
 		public String getDescription(Map<GameCharacter, SexSlot> occupiedSlots) {//TODO
-			if(Main.sex.getSexPositionSlot(Main.game.getPlayer())==SexSlotUnique.MISSIONARY_ALTAR_SEALED_LYING_ON_ALTAR) {
-				return "You're lying back on top of the chapel's altar, and [npc.namePos] standing between your [pc.legs], ready to have some fun with you in the missionary position.";
-			} else if(Main.sex.getSexPositionSlot(Main.game.getPlayer())==SexSlotUnique.MISSIONARY_ALTAR_SEALED_STANDING_BETWEEN_LEGS) {
-				return "[npc.Name] is lying back on top of the chapel's altar, and you're standing between [npc.her] [npc.legs], ready to have some fun in the missionary position.";
+			List<GameCharacter> characters = new ArrayList<>();
+			boolean isKneeling = false;
+			// 0 - Lying on altar
+			// 1 - Standing OR kneeling, as determined by `kneeling`
+			characters.add(Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_SEALED_LYING_ON_ALTAR));
+			if (Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_SEALED_STANDING_BETWEEN_LEGS)!=null) {
+				characters.add(Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_SEALED_STANDING_BETWEEN_LEGS));
+			} else if(Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_SEALED_KNEELING_BETWEEN_LEGS)!=null) {
+				characters.add(Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_SEALED_KNEELING_BETWEEN_LEGS));
+				isKneeling = true;
 			} else {
-				return "[npc.Name] is lying back on top of the chapel's altar, and you're kneeling down between [npc.her] [npc.legs], ready to have some oral fun in the missionary position.";
+				return "MISSIONARY_ALTAR_SEALED_CULTIST: Invalid character positions!";
 			}
+
+			// boolean playerIsOnTheAltar = characters.get(0).isPlayer();
+
+			StringBuilder desc = new StringBuilder();
+			desc.append("[npc.NameIs] lying back on top of the chapel's altar, and ");
+			if (isKneeling) {
+				desc.append("[npc2.nameIs] kneeling down between [npc.hisHer] [npc.legs], ready to have some oral fun with [npc.himHer] in the missionary position.");
+			} else {
+				desc.append("[npc2.nameIs] standing between [npc.hisHer] [npc.legs], ready to have some fun with [npc.himHer] in the missionary position.");
+			}
+			return UtilText.parse(characters.get(0), characters.get(1), desc.toString());
 		}
 		@Override
 		public Map<SexSlot, Map<SexSlot, SexActionInteractions>> getSlotTargets() {

--- a/src/com/lilithsthrone/game/sex/positions/SexPositionUnique.java
+++ b/src/com/lilithsthrone/game/sex/positions/SexPositionUnique.java
@@ -178,20 +178,33 @@ public class SexPositionUnique {
 			true,
 			null, Util.newArrayListOfValues(CultistSexActions.class)) {
 		@Override
-		public String getDescription(Map<GameCharacter, SexSlot> occupiedSlots) {//TODO
-			if(Main.sex.getSexPositionSlot(Main.game.getPlayer())==SexSlotUnique.MISSIONARY_ALTAR_LYING_ON_ALTAR) {
-				if(Main.sex.getSexPositionSlot(Main.sex.getTargetedPartner(Main.game.getPlayer()))==SexSlotUnique.MISSIONARY_ALTAR_STANDING_BETWEEN_LEGS) {
-					return "You're lying back on top of the chapel's altar, and [npc.namePos] standing between your [pc.legs], ready to have some fun with you in the missionary position.";
-				} else {
-					return "You're lying back on top of the chapel's altar, and [npc.namePos] kneeling down between your [pc.legs], ready to have some oral fun with you in the missionary position.";
-				}
-				
-			} else if(Main.sex.getSexPositionSlot(Main.game.getPlayer())==SexSlotUnique.MISSIONARY_ALTAR_STANDING_BETWEEN_LEGS) {
-				return "[npc.Name] is lying back on top of the chapel's altar, and you're standing between [npc.her] [npc.legs], ready to have some fun in the missionary position.";
-				
-			} else {
-				return "[npc.Name] is lying back on top of the chapel's altar, and you're kneeling down between [npc.her] [npc.legs], ready to have some oral fun in the missionary position.";
+		public String getDescription(Map<GameCharacter, SexSlot> occupiedSlots) {
+			// I spent several hours trying to figure out where UtilText.parse input NPCs were set.
+			// I gave up and decided to do it in here so we *KNOW* which [npc] tags are doing what.
+			// There is precedent for doing this in in SexPosition.java. 
+			
+			List<GameCharacter> characters = new ArrayList<>();
+			boolean isKneeling = false;
+			// 0 - Lying on altar
+			// 1 - Standing OR kneeling, as determined by `kneeling`
+			characters.add(Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_LYING_ON_ALTAR));
+			if (Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_STANDING_BETWEEN_LEGS)!=null) {
+				characters.add(Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_STANDING_BETWEEN_LEGS));
+			} else if(Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_KNEELING_BETWEEN_LEGS)!=null) {
+				characters.add(Main.sex.getCharacterInPosition(SexSlotUnique.MISSIONARY_ALTAR_KNEELING_BETWEEN_LEGS));
+				isKneeling = true;
 			}
+
+			boolean playerIsOnTheAltar = characters.get(0).isPlayer();
+
+			StringBuilder desc = new StringBuilder();
+			desc.append("[npc.NameIs] lying back on top of the chapel's altar, and ");
+			if (isKneeling) {
+				desc.append("[npc2.nameIs] kneeling down between [npc.hisHer] [npc.legs], ready to have some oral fun with [npc.himHer] in the missionary position.");
+			} else {
+				desc.append("[npc2.nameIs] standing between [npc.hisHer] [npc.legs], ready to have some fun with [npc.himHer] in the missionary position.");
+			}
+			return UtilText.parse(characters.get(0), characters.get(1), desc.toString());
 		}
 		@Override
 		public Map<SexSlot, Map<SexSlot, SexActionInteractions>> getSlotTargets() {


### PR DESCRIPTION
This is just a collection of typo fixes.  I fix them as I come across them.  Feel free to suggest any you find.

# Changes
* Fixes `[npc] unzipses your latex bra and takes it off.`
* Fixes role-reversed witch scenes showing things like `You is lying back on top of the chapel's altar, and you're kneeling down between your legs, ready to have some oral fun in the missionary position.`  
  * This required rewriting a few SexPositions to be more internally consistent (at least to me), so please yell at me if I screwed something up.
* Fixes #1666
  * Otters are not hyena-morphs
  * Fixes `a an`
  * Adds a couple of commas. An additional grammar pass masy be needed, but I didn't want to overly screw with the writing style.

# Graphical Assets
No graphics have been changed, nor are any needed.

# Tests
Tested against 9464fda2436697af1edff6bfeb62932c75f23f49.

# Contact
I am available in the developer channel as Anonymous-BCFED#8233.  I keep odd hours, so if I'm not there, ping me and I'll get back to you when possible. Edits by maintainers are also allowed.