### PR TITLE
Enhancement: Better parser state error reporting

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -1027,6 +1027,10 @@ public class UtilText {
 			for (int i = 0; i < input.length(); i++) {
 				char c = input.charAt(i);
 				
+				if(c == 'g' && substringMatchesInReverseAtIndex(input, "<svg", i)) {
+					i = input.indexOf("</svg>", i) + 6; // 6 == "</svg>".length()
+				}
+
 				if(usingConditionalBrackets) {
 					if(input.charAt(i)=='(') {
 						conditionalOpenBrackets++;

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -1317,14 +1317,26 @@ public class UtilText {
 				}
 				errMsg.append(startIndex);
 				if(target != null) {
-					errMsg.append(" Target: "+target);
+					errMsg.append(" Target: '" + target + "'");
 				}
 				if(command != null) {
-					errMsg.append(" Command: "+command);
+					errMsg.append(" Command: '" + command + "'");
 				}
-				errMsg.append(" "+input.substring(startIndex, Math.min(input.length()-1, startIndex+20)));
+				{
+					int errContext = 30;
+					errMsg.append("\nContext:  " + input.substring(Math.max(0, startIndex - errContext), Math.min(input.length(), startIndex + errContext)));
+					errMsg.append("\nLocation: " + "-".repeat(Math.min(errContext, startIndex)) + "^");
+				}
 				System.err.println(errMsg);
 				parsingCharactersForSpeech = parsingCharactersForSpeechSaved;
+				switch(input.charAt(startIndex)) {
+					// Replace the problematic character with its html entity, so that the error does
+					// not propagate further.
+					case '#':
+						return input.substring(0, startIndex) + "&#35;" + input.substring(startIndex+1);
+					case '[':
+						return input.substring(0, startIndex) + "&#91;" + input.substring(startIndex+1);
+				}
 				return input;
 			}
 			if (startedParsingSegmentAt < input.length()) {

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -1027,8 +1027,10 @@ public class UtilText {
 			for (int i = 0; i < input.length(); i++) {
 				char c = input.charAt(i);
 				
+				// Advance the parser index to the final `>` if we encounter an SVG
 				if(c == 'g' && substringMatchesInReverseAtIndex(input, "<svg", i)) {
-					i = input.indexOf("</svg>", i) + 6; // 6 == "</svg>".length()
+					i = input.indexOf("</svg>", i) + 5; // 5 == "</svg>".length() - 1
+					continue;
 				}
 
 				if(usingConditionalBrackets) {


### PR DESCRIPTION
Improves error reporting for parser state errors.
- Add textual context before the error, as well as after, and increased context from 20 to 30 chars
- Fix the max string length calcuation, so the last char isn't dropped
- Add ascii art pointer to the error location within the context
- Add quotes around the target and command, to make the empty-string more obvious
- Replace the error with an equivalent html entity, so that the error does not propagate further

Additionally, skips svg files within the parsed input per discussion in discord: https://discord.com/channels/302617912949211136/337330311694254121/1011959089154228316
<hr/>

Example malformed xml (note the extra `[` near the end):
```xml
<description><![CDATA[This spear carries the light of destruction coming down from the heavens.[.]]></description> 
```
<hr/>

Existing error message looks like:
```
Error in parsing: Missing ] for [ at 73 Target:  [
Error in parsing: Missing ] for [ at 596757 Target:  [.</div><div class='
```
Note that the error triggers twice and the second time, it is almost 600000 characters deep! This is because the second time, I think it is parsing the entire debug item spawning page (so most pages will be much smaller, of course), but also might allow the error to 'leak out', interfering with other parser statements.

With this, the weapon tooltip looks strange:
![image](https://user-images.githubusercontent.com/31363213/185896986-651aae54-7496-4c52-add1-4dde07e7467c.png)
<hr/>

New error message looks like:
```
Error in parsing: Missing ] for [ at 73 Target: ''
Context:   coming down from the heavens.[.
Location: ------------------------------^
```
Note that the error only happens once, and it includes context before the `[`, as well as the final `.` that was missing in the previous version.

And the weapon tooltip:
![image](https://user-images.githubusercontent.com/31363213/185896149-10779212-4d10-4b4e-aba3-807252395414.png)
<hr/>

No new graphical assets required. Tested on version 0.4.5.
Discord Handle: Phlarx#1765
