### PR TITLE
[Bugfix] Slave Dialogue

### DIFF
--- a/res/txt/characters/offspring/slave.xml
+++ b/res/txt/characters/offspring/slave.xml
@@ -80,27 +80,6 @@
 	<htmlContent tag="SEX_START"><![CDATA[
 	#IF(npc.hasSlavePermissionSetting(SLAVE_PERMISSION_SETTING_GENERAL_CRAWLING))
 		<p>
-			[pc.speech(I know what it is you want,)] you tease, stepping forwards and reaching out to take hold of [npc.namePos] [npc.hips+]. [pc.speech(You just want your [pc.mistress] to give you some attention, don't you?)]
-		</p>
-		<p>
-			#IF(npc.getAffectionLevelBasic(pc)==AFFECTION_BASIC_DISLIKE)
-				[npc.speech(Eugh, I hate you so much...)] [npc.name] remarks, scowling at you for a moment before hungrily gazing up and down over your body and stating, [npc.speech(I guess I have no choice in the matter, do I? Anyway, a good hate-fuck wouldn't be so bad...)]
-			#ELSE
-				#IF(npc.isFeminine())
-					[npc.speech(Yes, [pc.name],)] [npc.name] sensually replies, biting [npc.her] [npc.lip] and letting out a horny moan as [npc.she] leans into you, [npc.speech(Please, I want you...)]
-				#ELSE
-					[npc.speech(Yes, [pc.name],)] [npc.name] replies, smiling at you and letting out a hungry groan as [npc.she] leans into you, [npc.speech(Please, I want you...)]
-				#ENDIF
-			#ENDIF
-		</p>
-		<p>
-			As [npc.namePos] warm body presses against yours, you dominantly pull [npc.herHim] in against you and kiss [npc.herHim] fully on the [npc.lips]. Opening [npc.her] mouth to allow your [pc.tongue] to slide in over [npc.hers], [npc.name] lets out a happy, muffled [npc.moan] as the two of you start making out with one another.
-		</p>
-		<p>
-			After just a moment, you find yourself wanting more than just a kiss, and after pulling back, you [pc.moan], [pc.speech(I've got an hour or two to spare, let's make the most of it...)]
-		</p>
-	#ELSE
-		<p>
 			[pc.speech(I know what it is you want,)] you tease, looking down at [npc.name], who, thanks to your order of having to crawl everywhere [npc.she] goes, is on all fours before you. [pc.speech(You just want your [pc.mistress] to give you some attention, don't you?)]
 		</p>
 		<p>
@@ -123,6 +102,27 @@
 		</p>
 		<p>
 			Eager to do as [npc.she] asks, you prepare to start fucking your slave on the floor of [npc.her] room...
+		</p>
+	#ELSE
+		<p>
+			[pc.speech(I know what it is you want,)] you tease, stepping forwards and reaching out to take hold of [npc.namePos] [npc.hips+]. [pc.speech(You just want your [pc.mistress] to give you some attention, don't you?)]
+		</p>
+		<p>
+			#IF(npc.getAffectionLevelBasic(pc)==AFFECTION_BASIC_DISLIKE)
+				[npc.speech(Eugh, I hate you so much...)] [npc.name] remarks, scowling at you for a moment before hungrily gazing up and down over your body and stating, [npc.speech(I guess I have no choice in the matter, do I? Anyway, a good hate-fuck wouldn't be so bad...)]
+			#ELSE
+				#IF(npc.isFeminine())
+					[npc.speech(Yes, [pc.name],)] [npc.name] sensually replies, biting [npc.her] [npc.lip] and letting out a horny moan as [npc.she] leans into you, [npc.speech(Please, I want you...)]
+				#ELSE
+					[npc.speech(Yes, [pc.name],)] [npc.name] replies, smiling at you and letting out a hungry groan as [npc.she] leans into you, [npc.speech(Please, I want you...)]
+				#ENDIF
+			#ENDIF
+		</p>
+		<p>
+			As [npc.namePos] warm body presses against yours, you dominantly pull [npc.herHim] in against you and kiss [npc.herHim] fully on the [npc.lips]. Opening [npc.her] mouth to allow your [pc.tongue] to slide in over [npc.hers], [npc.name] lets out a happy, muffled [npc.moan] as the two of you start making out with one another.
+		</p>
+		<p>
+			After just a moment, you find yourself wanting more than just a kiss, and after pulling back, you [pc.moan], [pc.speech(I've got an hour or two to spare, let's make the most of it...)]
 		</p>
 	#ENDIF
 	]]>


### PR DESCRIPTION
- What is the purpose of the pull request?
Fixing a single bugfix.

- Give a brief description of what you changed or added.
Bugfix was due to incorrect if-else check, reversing the outcomes as a result. Occurred only in offspring slave's pre-sex dialogue.

- Are any new graphical assets required?
No.

- Has this change been tested? If so, mention the version number that the test was based on.
Yes. 1 test, to check that test works correctly.

- So we have a better idea of who you are, what is your Discord Handle?
Lis (Argalis#2179 (Discord ID = 276726951434125332))

- If you want quick feedback, you can use Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
I understand.


The bug occurred in `res/txt/characters/offspring/slave.xml`
Only for case of SEX_START tag, for starting normal sex not in the milking room nor rape.
After **IF** check for if slave is crawling for TRUE case it was set to perform dialogue, that should be triggered only for non-crawling slaves and so for FALSE it triggers crawling dialogue.
Simply switched all the dialogues inside If Else sections (without changing IF condition, of course).