### PR TITLE
Bugfix: Normalize the default crit logic

### DIFF
--- a/src/com/lilithsthrone/game/combat/moves/AbstractCombatMove.java
+++ b/src/com/lilithsthrone/game/combat/moves/AbstractCombatMove.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.w3c.dom.Document;
 
@@ -849,7 +850,7 @@ public abstract class AbstractCombatMove {
     	if(fromExternalFile) {
         	return Util.newArrayListOfValues(criticalDescription);
     	}
-    	return Util.newArrayListOfValues("It's the third time being used.");
+        return Util.newArrayListOfValues("It's the third time being used this turn.");
     }
     
     public boolean canCrit(int turnIndex, GameCharacter source, GameCharacter target, List<GameCharacter> enemies, List<GameCharacter> allies) {
@@ -863,15 +864,16 @@ public abstract class AbstractCombatMove {
             return Boolean.valueOf(UtilText.parse(source, target, parseText).trim());
     		
     	} else {
-	    	// Normally moves crit on three hits in a row.
+	        // Normally moves crit on every third use per turn.
 	        int thisMoveSelected = 0;
-	        for(Value<GameCharacter, AbstractCombatMove> move : source.getSelectedMoves()) {
-	            if(move.getValue().getIdentifier() == this.getIdentifier()) {
+	        for(int i = 0; i < source.getSelectedMoves().size(); i++) {
+	            Value<GameCharacter, AbstractCombatMove> move = source.getSelectedMoves().get(i);
+	            if(Objects.equals(move.getValue().getIdentifier(), this.getIdentifier())) {
 	                thisMoveSelected++;
 	            }
-	        }
-	        if(thisMoveSelected>=3 && (turnIndex+1)%3==0) {
-	            return true;
+	            if(i == turnIndex) {
+	                return thisMoveSelected % 3 == 0;
+	            }
 	        }
 	        return false;
     	}


### PR DESCRIPTION
The default crit logic (crit on third use) was a bit ambiguous and unpredictable. This change fixes that.

For most players this logic change will go unnoticed, but I did adjust the default crit text to clarify that it is per-turn.

Below I have an example of what the issue is. I gave myself 10 AP for ease of communication. With 3AP, the difference is nothing, but if a player ever gets an effect that adds even 1 additional AP, then the issues could appear.

This change only affects moves that use the default crit logic; any moves that define their own logic are unaffected.

No new assets required.
Tested with version 0.4.5.5.

## Old behaviour:
Queued (2 attack crits, 0 block crits):
![image](https://user-images.githubusercontent.com/31363213/190941416-8bfb6178-ce4e-4a9d-8a62-8c8afeabae13.png)
Executed (3 attack crits, 0 block crits):
![image](https://user-images.githubusercontent.com/31363213/190941625-6793e071-5c3d-4471-ba6b-ad4a25d4a017.png)

## New behaviour:
Queued (1 attack crits, 2 block crits):
![image](https://user-images.githubusercontent.com/31363213/190941986-e53ea195-09e0-463d-b309-e8f0f0a927c4.png)
Executed (1 attack crits, 2 block crits):
![image](https://user-images.githubusercontent.com/31363213/190942129-776368f9-5079-436c-86cb-723d7fc21c37.png)