### PR TITLE
[Bugfix] Command_unknown in sex text

### DIFF
--- a/res/txt/characters/offspring/occupant.xml
+++ b/res/txt/characters/offspring/occupant.xml
@@ -576,9 +576,9 @@
 		</p>
 		<p>
 			#IF(!npc2.isTaur())
-				With agreement from [npc.your] [npc.relation(pc)], [npc2.name] takes hold of your [pc.hips] and pulls you down onto your knees as [npc2.she] drops down behind you.
+				With agreement from your [npc.relation(pc)], [npc2.name] takes hold of your [pc.hips] and pulls you down onto your knees as [npc2.she] drops down behind you.
 			#ELSE
-				With agreement from [npc.your] [npc.relation(pc)], [npc2.name] takes hold of your [pc.hips] and pushes you down onto your knees, before stepping forwards and positioning [npc2.her] [npc2.legConfiguration] body over the top of you, ready to mount you.
+				With agreement from your [npc.relation(pc)], [npc2.name] takes hold of your [pc.hips] and pushes you down onto your knees, before stepping forwards and positioning [npc2.her] [npc2.legConfiguration] body over the top of you, ready to mount you.
 			#ENDIF
 		</p>
 		<p>


### PR DESCRIPTION
<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
Command_unknown error in starting dialogue from the spitroasted(front) with one occupant offspring and one non-offspring. This option is available with companions turned on.

- Give a brief description of what you changed or added.
Seemed that "your" was accidentally tried as a command and so changed it to just text.
- Are any new graphical assets required?
no
- Has this change been tested? If so, mention the version number that the test was based on.
0.4.6
- So we have a better idea of who you are, what is your Discord Handle?
Duskit#6985
- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
First time i did something like this so I'm a bit nervous on whether i did this pull request right. 