### PR TITLE
added the ability to choose which outfit you take from Brax's office.

### DIFF
--- a/res/txt/places/dominion/enforcerHQ/brax.xml
+++ b/res/txt/places/dominion/enforcerHQ/brax.xml
@@ -150,7 +150,7 @@
 		Contact address: <i>Scarlett's shop, Slaver Alley</i>
 	</p>
 	<p>
-		After reading it over a second time, you realise that you're going to have to make your way to Slaver Alley and see if you can find some way to buy Arthur. Taking one last look around [brax.namePos] office, you notice that there's a neatly-folded spare Enforcer's uniform lying on top of a cabinet. Deciding to punish [brax.name] a little more for falling for such an obvious trick, <b>you take the spare uniform and add it to your inventory</b>.
+		After reading it over a second time, you realise that you're going to have to make your way to Slaver Alley and see if you can find some way to buy Arthur. Taking one last look around [brax.namePos] office, you notice that there's two neatly-folded spare Enforcer's uniforms lying on top of a cabinet. To punish [brax.name] a little more for falling for such an obvious trick, <b>you could take a spare uniform and add it to your inventory</b>.
 	</p>
 	]]>
 	</htmlContent>
@@ -308,7 +308,7 @@
 		Making more vague promises, you step back out into the corridor, breathing a sigh of relief as you pull the door firmly shut behind you. Turning to leave by the same route as which you arrived, you quickly set off towards the exit.
 	</p>
 	<p>
-		As you pass an empty office, you look in and notice that there's a neatly-folded spare uniform lying on top of a cabinet. Deciding that you need a little compensation after being forcefully kissed by [brax.name], <b>you take the spare uniform and add it to your inventory on your way out</b>.
+		As you pass an empty office, you look in and notice that there's a neatly-folded spare uniform lying on top of a cabinet. Deciding that you need a little compensation after being forcefully kissed by [brax.name], <b>you take one of the spare uniforms and add it to your inventory on your way out</b>.
 	</p>
 	]]>
 	</htmlContent>
@@ -426,7 +426,7 @@
 		You really don't feel like having sex with the guy who just tried to beat you up. Instead, you push Brax back into his chair, tutting in disapproval as he lets out a desperate whine.
 	</p>
 	<p>
-		Taking one last look around Brax's office, you notice that there's a neatly-folded spare uniform lying on top of a cabinet. Deciding to punish Brax a little more for trying to beat you up, <b>you take the spare uniform and add it to your inventory</b>.
+		Taking one last look around Brax's office, you notice that there are two neatly-folded spare uniforms lying on top of a cabinet. <b>You could take one and add it to your inventory</b>.
 	</p>
 	]]>
 	</htmlContent>
@@ -598,7 +598,7 @@
 			Although you've been thrown out without so much as a goodbye, you feel a big smile spreading across your face. You found out where Arthur is, and what's more, you got to have a good fuck with that hunk of a wolf-boy.
 		</p>
 		<p>
-			As you walk out from behind the Enforcer HQ, you see that an open crate, full of spare uniforms, is sitting outside a side door. The crate is too big to fit through the doorway, and the person in charge of bringing them inside isn't anywhere to be seen. Deciding that you want a little memento of your time with Brax, <b>you take a spare uniform and add it to your inventory as you continue on your way</b>.
+			As you walk out from behind the Enforcer HQ, you see that an open crate, full of spare uniforms, is sitting outside a side door. The crate is too big to fit through the doorway, and the person in charge of bringing them inside isn't anywhere to be seen. Deciding that you want a little memento of your time with Brax, <b>you pick a spare uniform to add it to your inventory</b> as you continue on your way.
 		</p>
 	#ELSE
 		<p>
@@ -615,7 +615,7 @@
 		Brax is completely exhausted, and collapses harmlessly to the floor as he passes out. Letting out a triumphant laugh, you look down at your latest sexual conquest, smirking in satisfaction as you see the happy smile covering his unconscious face.
 	</p>
 	<p>
-		Taking one last look around Brax's office, you notice that there's a neatly-folded spare uniform lying on top of a cabinet. Deciding that you want a little memento of your time with Brax, <b>you take the spare uniform and add it to your inventory</b>, before heading downstairs and back outside.
+		Taking one last look around Brax's office, you notice that there's a neatly-folded spare uniform lying on top of a cabinet. Thinking of how you could have a little memento of your time with Brax, <b>you think to take a spare uniform</b> before heading downstairs and back outside.
 	</p>
 	]]>
 	</htmlContent>

--- a/src/com/lilithsthrone/game/character/quests/Quest.java
+++ b/src/com/lilithsthrone/game/character/quests/Quest.java
@@ -37,7 +37,7 @@ import com.lilithsthrone.world.places.PlaceType;
 
 /**
  * @since 0.1.0
- * @version 0.4.4.1
+ * @version 0.4.6.3
  * @author Innoxia
  */
 public enum Quest {
@@ -121,7 +121,7 @@ public enum Quest {
 		@Override
 		public void applySkipQuestEffects() {
 			BraxOffice.setBraxsPostQuestStatus(false);
-			BraxOffice.givePlayerEnforcerUniform(null);
+			BraxOffice.givePlayerEnforcerUniform(null,-1);
 		}
 	},
 

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/enforcerHQ/BraxOffice.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/enforcerHQ/BraxOffice.java
@@ -38,7 +38,7 @@ import com.lilithsthrone.world.places.PlaceType;
 
 /**
  * @since 0.1.0
- * @version 0.3.5
+ * @version 0.4.6.3
  * @author Innoxia
  */
 public class BraxOffice {
@@ -54,13 +54,13 @@ public class BraxOffice {
 		if(applyPlayerLocationChange) {
 			Main.game.getPlayer().setLocation(WorldType.DOMINION, PlaceType.DOMINION_ENFORCER_HQ, false);
 		}
-	}
+	};
 	
-	public static void givePlayerEnforcerUniform(StringBuilder sb) {
+	public static void givePlayerEnforcerUniform(StringBuilder sb, int outfitFem) {
 		if(sb==null) {
 			sb = new StringBuilder();
 		}
-		if(Main.game.getPlayer().isFeminine()) {
+		if(outfitFem==1) {
 			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_servequipset_enfskirt", PresetColour.CLOTHING_BLACK, false), false));
 			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_ptrlequipset_flsldshirt", PresetColour.CLOTHING_PINK, false), false));
 			
@@ -76,7 +76,7 @@ public class BraxOffice {
 			hat.setSticker("badge", "badge_dominion");
 			sb.append(Main.game.getPlayer().addClothing(hat, false));
 			
-		} else {
+		} else if(outfitFem==0) {
 			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_servequipset_enfdslacks", PresetColour.CLOTHING_BLACK, false), false));
 			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_ptrlequipset_lsldshirt", PresetColour.CLOTHING_BLUE, false), false));
 			
@@ -91,6 +91,29 @@ public class BraxOffice {
 			AbstractClothing hat = Main.game.getItemGen().generateClothing("dsg_eep_ptrlequipset_pcap", PresetColour.CLOTHING_BLACK, false);
 			hat.setSticker("badge", "badge_dominion");
 			sb.append(Main.game.getPlayer().addClothing(hat, false));
+		} else {
+			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_servequipset_enfskirt", PresetColour.CLOTHING_BLACK, false), false));
+			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_ptrlequipset_flsldshirt", PresetColour.CLOTHING_PINK, false), false));
+			
+			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_servequipset_enfdslacks", PresetColour.CLOTHING_BLACK, false), false));
+			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_ptrlequipset_lsldshirt", PresetColour.CLOTHING_BLUE, false), false));
+			
+			AbstractClothing jacket = Main.game.getItemGen().generateClothing("dsg_eep_servequipset_enfdjacket", PresetColour.CLOTHING_BLACK, PresetColour.CLOTHING_PINK, PresetColour.CLOTHING_GOLD, false);
+			jacket.setSticker("collar", "tab_pc");
+			jacket.setSticker("name", "name_pc");
+			sb.append(Main.game.getPlayer().addClothing(jacket, false));
+			
+			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_servequipset_enfdbelt", PresetColour.CLOTHING_DESATURATED_BROWN, false), false));
+			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_servequipset_enfpumps", PresetColour.CLOTHING_BLACK, false), false));
+			sb.append(Main.game.getPlayer().addClothing(Main.game.getItemGen().generateClothing("dsg_eep_tacequipset_cboots", PresetColour.CLOTHING_BLACK, false), false));
+			
+			AbstractClothing hat = Main.game.getItemGen().generateClothing("dsg_eep_ptrlequipset_bwhat", PresetColour.CLOTHING_BLACK, false);
+			hat.setSticker("badge", "badge_dominion");
+			sb.append(Main.game.getPlayer().addClothing(hat, false));
+			
+			hat = Main.game.getItemGen().generateClothing("dsg_eep_ptrlequipset_pcap", PresetColour.CLOTHING_BLACK, false);
+			hat.setSticker("badge", "badge_dominion");
+			sb.append(Main.game.getPlayer().addClothing(hat, false));
 		}
 
 		TransformativePotion tfPotion = Main.game.getNpc(Brax.class).generateTransformativePotion(Main.game.getPlayer());
@@ -99,7 +122,7 @@ public class BraxOffice {
 			tfPotion.getEffects().stream().map(x -> x.getEffect()).collect(Collectors.toList()));
 		potion.setName("Brax's Surprise");
 		sb.append(Main.game.getPlayer().addItem(potion, false));
-	}
+	};
 	
 	public static final DialogueNode INTERIOR_BRAX = new DialogueNode("[brax.namePos] Office", "-", true) {
 		@Override
@@ -239,7 +262,6 @@ public class BraxOffice {
 					@Override
 					public void effects(){
 						Main.game.getTextEndStringBuilder().append(Main.game.getPlayer().setQuestProgress(QuestLine.MAIN, Quest.MAIN_1_D_SLAVERY));
-						givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder());
 					}
 				};
 					
@@ -262,13 +284,22 @@ public class BraxOffice {
 		@Override
 		public Response getResponse(int responseTab, int index) {
 			if (index == 1) {
-				return new Response("Exit", "Leave the Enforcer HQ.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
+				return new Response("Fem. Uniform", "Take the feminine uniform and leave the Enforcer HQ.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
 					@Override
 					public void effects() {
+						givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder(),1);
 						setBraxsPostQuestStatus(true);
 					}
 				};
 				
+			} else if (index == 2) {
+				return new Response("Masc. Uniform", "Take the masculine uniform and leave the Enforcer HQ.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
+					@Override
+					public void effects() {
+						givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder(),0);
+						setBraxsPostQuestStatus(true);
+					}
+				};
 			} else {
 				return null;
 			}
@@ -332,10 +363,7 @@ public class BraxOffice {
 		public Response getResponse(int responseTab, int index) {
 			if (index == 1) {
 				return new Response("Escape", "Push [brax.name] off of you and make a quick excuse before running away.", INTERIOR_BRAX_GETTING_TEASED_ESCAPE) {
-					@Override
-					public void effects() {
-						givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder());
-					}
+					
 				};
 					
 			} else if (index == 2) {
@@ -377,17 +405,27 @@ public class BraxOffice {
 		@Override
 		public Response getResponse(int responseTab, int index) {
 			if (index == 1) {
-				return new Response("Exit", "Leave the Enforcer HQ.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
+				return new Response("Fem. Uniform", "You take the feminine uniform and leave the enforcer HQ.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
 					@Override
 					public void effects() {
+						givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder(),1);
 						setBraxsPostQuestStatus(true);
 					}
 				};
 				
-			} else {
+			} else if (index == 2) {
+				return new Response("Masc. Uniform", "You take the manly uniform and leave the enforcer HQ.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
+					@Override
+					public void effects() {
+						givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder(),0);
+						setBraxsPostQuestStatus(true);
+					}
+				};
+			} 
+			else {
 				return null;
 			}
-		}
+		};
 	};
 	
 	
@@ -410,10 +448,7 @@ public class BraxOffice {
 		public Response getResponse(int responseTab, int index) {
 			if (index == 1) {
 				return new Response("Leave", "You really don't want to have sex with Brax. Leave his office and continue on your way.", AFTER_COMBAT_VICTORY_NO_SEX){
-					@Override
-					public void effects() {
-						givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder());
-					}
+					
 				};
 				
 			} else if (index == 2) {
@@ -449,7 +484,6 @@ public class BraxOffice {
 	};
 	
 	public static final DialogueNode AFTER_COMBAT_VICTORY_NO_SEX = new DialogueNode("", "", true, true) {
-
 		@Override
 		public String getContent() {
 			return UtilText.parseFromXMLFile("places/dominion/enforcerHQ/brax", "AFTER_COMBAT_VICTORY_NO_SEX");
@@ -458,13 +492,22 @@ public class BraxOffice {
 		@Override
 		public Response getResponse(int responseTab, int index) {
 			if (index == 1) {
-				return new Response("Outside", "You find yourself back outside once more, but this time, with new knowledge of Arthur's location.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
+				return new Response("Fem. Uniform", "You take the feminine uniform and find yourself back outside once more, but this time, with new knowledge of Arthur's location.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
 					@Override
 					public void effects() {
+						givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder(),1);
 						setBraxsPostQuestStatus(true);
 					}
 				};
 				
+			} else if (index == 2) {
+				return new Response("Masc. Uniform", "You take the manly uniform and find yourself outside once more, but this time, with new knowledge of Arthur's location.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
+					@Override
+					public void effects() {
+						givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder(),0);
+						setBraxsPostQuestStatus(true);
+					}
+				};
 			} else {
 				return null;
 			}
@@ -592,13 +635,6 @@ public class BraxOffice {
 
 	public static final DialogueNode AFTER_SUBMISSIVE_SEX = new DialogueNode("Brax is done", "Brax has finished having his fun with you.", true) {
 		@Override
-		public void applyPreParsingEffects() {
-			if(Main.game.getPlayer().isQuestProgressGreaterThan(QuestLine.MAIN, Quest.MAIN_1_C_WOLFS_DEN)) {
-				givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder());
-			}
-		}
-		
-		@Override
 		public int getSecondsPassed() {
 			return 30*60;
 		}
@@ -610,30 +646,43 @@ public class BraxOffice {
 		
 		@Override
 		public Response getResponse(int responseTab, int index) {
-			if (index == 1) {
-				return new Response("Carry on", "Get up and carry on your way.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
-					@Override
-					public void effects() {
-						if(Main.game.getPlayer().isQuestProgressGreaterThan(QuestLine.MAIN, Quest.MAIN_1_C_WOLFS_DEN)) {
+			if (Main.game.getPlayer().isQuestProgressGreaterThan(QuestLine.MAIN, Quest.MAIN_1_C_WOLFS_DEN)) {
+				if (index == 1) {
+					return new Response ("Fem. Uniform", "You take the feminine uniform and continue on your way.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
+						@Override
+						public void effects() {
+							givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder(),1);
 							setBraxsPostQuestStatus(true);
-							
-						} else {
+						}
+					};
+				} else if (index == 2) {
+					return new Response("Masc. Uniform", "You take the masculine uniform and continue on your way.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
+						public void effects( ) {
+							givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder(),0);
+							setBraxsPostQuestStatus(true);
+						}
+					};
+				} else {
+					return null;
+				}
+			} else {
+				if (index == 1) {
+					return new Response("Carry on", "Get up and carry on your way.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
+						@Override
+						public void effects() {
 							Main.game.getPlayer().setLocation(WorldType.DOMINION, PlaceType.DOMINION_ENFORCER_HQ, false);
 						}
-					}
-				};
+					};
 				
-			} else {
-				return null;
+				} else {
+					return null;
+				}
 			}
 		}
 	};
 
 	public static final DialogueNode AFTER_DOMINANT_SEX = new DialogueNode("Brax collapses", "Brax collapses and you return to his office.", true) {
-		@Override
-		public void applyPreParsingEffects() {
-			givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder());
-		}
+		
 		
 		@Override
 		public String getContent() {
@@ -643,9 +692,19 @@ public class BraxOffice {
 		@Override
 		public Response getResponse(int responseTab, int index) {
 			if (index == 1) {
-				return new Response("Outside", "You find yourself back outside once more, but this time, with new knowledge of Arthur's location.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
+				return new Response("Fem. Uniform", "You take the feminine uniform and find yourself back outside once more, but this time, with new knowledge of Arthur's location.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
 					@Override
 					public void effects() {
+						givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder(), 1);
+						setBraxsPostQuestStatus(true);
+					}
+				};
+				
+			} else if (index == 2) {
+				return new Response("Masc. Uniform", "You take the manly uniform and find yourself back outside once more, but this time, with new knowledge of Arthur's location.", PlaceType.DOMINION_ENFORCER_HQ.getDialogue(false)) {
+					@Override
+					public void effects() {
+						givePlayerEnforcerUniform(Main.game.getTextEndStringBuilder(), 0);
 						setBraxsPostQuestStatus(true);
 					}
 				};


### PR DESCRIPTION
- What is the purpose of the pull request?
To make it so players can obtain the outfit of their choice, regardless of if they're feminine or not.
(Edit: Also, if the debug menu is used to obtain a uniform, it'll give both sets, but only one belt and jacket.)

- Give a brief description of what you changed or added.
Changed the BraxOffice.java file and more specifically the function that gives players a uniform, had to make slight alterations to brax.xml and Quest.java

- Has this change been tested? If so, mention the version number that the test was based on.
I tested it on 4.6.5, though I typed the wrong version number on the two java files I altered. I tested the bluff, wolf tease(sub and dom), and fight options.

- So we have a better idea of who you are, what is your Discord Handle?
Nonnymouse#5520