### PR TITLE
Adding 'feral' to pregnancy and litters lists

### DIFF
--- a/src/com/lilithsthrone/game/character/Litter.java
+++ b/src/com/lilithsthrone/game/character/Litter.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character;
 import com.lilithsthrone.controller.xmlParsing.XMLUtil;
 import com.lilithsthrone.game.character.npc.misc.OffspringSeed;
 import com.lilithsthrone.game.character.race.AbstractSubspecies;
+import com.lilithsthrone.game.character.race.RaceStage;
 import com.lilithsthrone.game.character.race.Subspecies;
 import com.lilithsthrone.main.Main;
 import com.lilithsthrone.utils.Util;
@@ -426,21 +427,34 @@ public class Litter implements XMLSaving {
 	
 	public void generateBirthedDescription() {
 		Map<String, Integer> sons = new HashMap<>();
+		Map<String, Integer> feralSons = new HashMap<>();
 		Map<String, Integer> daughters = new HashMap<>();
+		Map<String, Integer> feralDaughters = new HashMap<>();
+		String feralString = "<b style='color:" + RaceStage.FERAL.getColour().toWebHexString() + ";'>" + RaceStage.FERAL.getName() + "</b>";
 		
 		for(String id : this.getOffspring()) {
 			try {
 				
-				OffspringSeed character = Main.game.getOffspringSeedById(id);
-				AbstractSubspecies subspecies = character.getSubspecies();
-				if(character.isFeminine()) {
-					String nameId = subspecies.getSingularFemaleName(character.getBody())+"|"+subspecies.getPluralFemaleName(character.getBody());
-					daughters.putIfAbsent(nameId, 0);
-					daughters.put(nameId, daughters.get(nameId)+1);
+				OffspringSeed offspring = Main.game.getOffspringSeedById(id);
+				AbstractSubspecies subspecies = offspring.getSubspecies();
+				if(offspring.isFeminine()) {
+					String nameId = subspecies.getSingularFemaleName(offspring.getBody())+"|"+subspecies.getPluralFemaleName(offspring.getBody());
+					if(offspring.isFeral()) {
+						feralDaughters.putIfAbsent(nameId, 0);
+						feralDaughters.put(nameId, feralDaughters.get(nameId)+1);
+					} else {
+						daughters.putIfAbsent(nameId, 0);
+						daughters.put(nameId, daughters.get(nameId)+1);
+					}
 				} else {
-					String nameId = subspecies.getSingularMaleName(character.getBody())+"|"+subspecies.getPluralMaleName(character.getBody());
-					sons.putIfAbsent(nameId, 0);
-					sons.put(nameId, sons.get(nameId)+1);
+					String nameId = subspecies.getSingularMaleName(offspring.getBody())+"|"+subspecies.getPluralMaleName(offspring.getBody());
+					if(offspring.isFeral()) {
+						feralSons.putIfAbsent(nameId, 0);
+						feralSons.put(nameId, feralSons.get(nameId)+1);
+					} else {
+						sons.putIfAbsent(nameId, 0);
+						sons.put(nameId, sons.get(nameId)+1);
+					}
 				}
 			} catch (Exception e) {
 			}
@@ -455,8 +469,22 @@ public class Litter implements XMLSaving {
 							: entry.getKey().split("\\|")[0])
 						+"</b>");
 		}
+		for(Entry<String, Integer> entry : feralSons.entrySet()) {
+			entries.add("<b>"+Util.intToString(entry.getValue())+"</b> "+feralString+" <b style='color:"+ PresetColour.MASCULINE.toWebHexString()+ ";'>"
+						+(entry.getValue() > 1
+							? entry.getKey().split("\\|")[1]
+							: entry.getKey().split("\\|")[0])
+						+"</b>");
+		}
 		for(Entry<String, Integer> entry : daughters.entrySet()) {
 			entries.add("<b>"+Util.intToString(entry.getValue())+"</b> <b style='color:"+ PresetColour.FEMININE.toWebHexString()+ ";'>"
+						+(entry.getValue() > 1
+							? entry.getKey().split("\\|")[1]
+							: entry.getKey().split("\\|")[0])
+						+"</b>");
+		}
+		for(Entry<String, Integer> entry : feralDaughters.entrySet()) {
+			entries.add("<b>"+Util.intToString(entry.getValue())+"</b> "+feralString+" <b style='color:"+ PresetColour.FEMININE.toWebHexString()+ ";'>"
 						+(entry.getValue() > 1
 							? entry.getKey().split("\\|")[1]
 							: entry.getKey().split("\\|")[0])

--- a/src/com/lilithsthrone/game/character/npc/misc/OffspringSeed.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/OffspringSeed.java
@@ -567,6 +567,9 @@ public class OffspringSeed implements XMLSaving {
 	
 	public AbstractSubspecies getSubspecies() { return subspecies; }
 	
+	public boolean isFeral() {
+		return getBody().isFeral();
+	}
 	public boolean isFeminine() {
 		return body==null || body.isFeminine();
 	}

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/LilayaBirthing.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/LilayaBirthing.java
@@ -14,6 +14,7 @@ import com.lilithsthrone.game.character.npc.dominion.Lilaya;
 import com.lilithsthrone.game.character.npc.misc.OffspringSeed;
 import com.lilithsthrone.game.character.quests.Quest;
 import com.lilithsthrone.game.character.quests.QuestLine;
+import com.lilithsthrone.game.character.race.RaceStage;
 import com.lilithsthrone.game.dialogue.DialogueFlagValue;
 import com.lilithsthrone.game.dialogue.DialogueNode;
 import com.lilithsthrone.game.dialogue.responses.Response;
@@ -553,6 +554,7 @@ public class LilayaBirthing {
 						UtilText.nodeContentSB.append("<br/>"
 								+ Util.capitaliseSentence(UtilText.generateSingularDeterminer(descriptor))+" "+descriptor
 								+ " <i style='color:"+offspring.getGender().getColour().toWebHexString()+";'>"+offspring.getGender().getName()+"</i>"
+								+ (offspring.isFeral() ? " <i style='color:"+RaceStage.FERAL.getColour().toWebHexString()+";'>"+RaceStage.FERAL.getName()+"</i>" : "")
 								+ " <i style='color:"+offspring.getSubspecies().getColour(offspring).toWebHexString()+";'>"+UtilText.parse(offspring,"[npc.race]")+"</i>");
 						
 					} else {
@@ -560,6 +562,7 @@ public class LilayaBirthing {
 						String descriptor = getOffspringDescriptor(offspring);
 						UtilText.nodeContentSB.append("<br/>"
 								+ Util.capitaliseSentence(UtilText.generateSingularDeterminer(descriptor))+" "+descriptor
+								+ (offspring.isFeral() ? " <i style='color:"+RaceStage.FERAL.getColour().toWebHexString()+";'>"+RaceStage.FERAL.getName()+"</i>" : "")
 								+ " <i style='color:"+offspring.getSubspecies().getColour(null).toWebHexString()+";'>"+offspring.getSubspecies().getName(offspring.getBody())+"</i>"
 								+ " <i style='color:"+offspring.getGender().getColour().toWebHexString()+";'>"+offspring.getGenderName()+"</i>");
 					}

--- a/src/com/lilithsthrone/game/dialogue/utils/OffspringMapDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/OffspringMapDialogue.java
@@ -7,6 +7,7 @@ import com.lilithsthrone.game.character.npc.NPC;
 import com.lilithsthrone.game.character.npc.misc.NPCOffspring;
 import com.lilithsthrone.game.character.npc.misc.OffspringSeed;
 import com.lilithsthrone.game.character.race.Race;
+import com.lilithsthrone.game.character.race.RaceStage;
 import com.lilithsthrone.game.character.race.Subspecies;
 import com.lilithsthrone.game.dialogue.DialogueNode;
 import com.lilithsthrone.game.dialogue.encounters.AbstractEncounter;
@@ -96,8 +97,8 @@ public class OffspringMapDialogue {
 					if(os.getFather()==null && !os.getFatherName().equals("???")) {
 						unknownFatherName = os.getFatherName();
 					}
-					
-					UtilText.nodeContentSB.append(" (<span style='color:"+os.getSubspecies().getColour(null).toWebHexString()+";'>"+Util.capitaliseSentence(os.getSubspecies().getName(os.getBody()))+"</span>)"
+
+					UtilText.nodeContentSB.append(" ("+(os.isFeral()?"<span style='color:"+RaceStage.FERAL.getColour().toWebHexString()+";'>"+Util.capitaliseSentence(RaceStage.FERAL.getName())+"</span> ":"")+"<span style='color:"+os.getSubspecies().getColour(null).toWebHexString()+";'>"+Util.capitaliseSentence(os.getSubspecies().getName(os.getBody()))+"</span>)"
 							+ " Mother: "+(os.getMother()==null?unknownMotherName:(os.getMother().isPlayer()?"[style.colourExcellent(You)]":os.getMother().getName(true)))
 							+ " Father: "+(os.getFather()==null?unknownFatherName:(os.getFather().isPlayer()?"[style.colourExcellent(You)]":os.getFather().getName(true)))
 							+ "<br/>");

--- a/src/com/lilithsthrone/game/dialogue/utils/PhoneDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/PhoneDialogue.java
@@ -91,6 +91,7 @@ public class PhoneDialogue {
 	
 	private static class offspringTableLineSubject {
 		boolean female;
+		boolean is_feral;
 		String child_name;
 		String race_color;
 		String species_name;
@@ -101,6 +102,7 @@ public class PhoneDialogue {
 
 		offspringTableLineSubject(NPC npc) {
 			this.female = npc.isFeminine();
+			this.is_feral = npc.isFeral();
 			this.child_name = npc.getName(true);
 			this.race_color = npc.getRace().getColour().toWebHexString();
 			this.species_name = this.female
@@ -144,6 +146,7 @@ public class PhoneDialogue {
 
 		offspringTableLineSubject(OffspringSeed os) {
 			this.female = os.isFeminine();
+			this.is_feral = os.isFeral();
 			this.child_name = "Unknown";
 			this.race_color = os.getRace().getColour().toWebHexString();
 			this.species_name = this.female
@@ -2009,6 +2012,7 @@ public class PhoneDialogue {
 
 		private void offspringTableLine(StringBuilder output, offspringTableLineSubject subject, boolean evenRow, boolean includeIncubationColumn) {
 			String color = subject.female ? PresetColour.FEMININE.toWebHexString() : PresetColour.MASCULINE.toWebHexString();
+			String feralString = "<span style='color:" + RaceStage.FERAL.getColour().toWebHexString() + ";'>" + Util.capitaliseSentence(RaceStage.FERAL.getName()) + "</span> ";
 			
 			String innerEntryStyle = "background:transparent; margin:0; padding:0; width:"+(includeIncubationColumn?"15":"20")+"%;";
 			String innerEntryStyle2 = "background:transparent; margin:0; padding:0; width:15%;";
@@ -2023,8 +2027,9 @@ public class PhoneDialogue {
 				output.append("</div>");
 	
 				output.append("<div class='container-full-width' style='"+innerEntryStyle2+"'>");
+					output.append(subject.is_feral ? feralString : "");
 					output.append("<span style='color:").append(subject.race_color).append(";'>");
-						output.append(subject.species_name);
+						output.append(subject.is_feral ? subject.species_name.toLowerCase() : subject.species_name);
 					output.append("</span>");
 				output.append("</div>");
 	


### PR DESCRIPTION
- What is the purpose of the pull request?
Added 'feral' to litters when giving birth, viewing pregnancy stats or the offspring map.

- Give a brief description of what you changed or added.
When giving birth, looking at the pregnancy stats or at the offspring map you didn't see, if your offspring were feral or not. Only when offspring spawned on their corresponding map. This PR is to resolve that issue.

Screenshots:
![grafik](https://user-images.githubusercontent.com/13157984/196003009-fd031597-8657-4a7f-bb9f-3c2201c19ff2.png) ![grafik](https://user-images.githubusercontent.com/13157984/196002999-e1d162ca-8630-41a6-af8d-d28ebc0dc199.png)
![grafik](https://user-images.githubusercontent.com/13157984/196003054-576e8bca-a02e-4caf-8b3a-959392a77e94.png)

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.4.6.6 Alpha

- So we have a better idea of who you are, what is your Discord Handle?
Stadler#3007