### PR TITLE
Fix serpent-tailed coatls being named coatl-lamias

### DIFF
--- a/res/race/dsg/dragon/subspecies/coatl.xml
+++ b/res/race/dsg/dragon/subspecies/coatl.xml
@@ -66,15 +66,24 @@
 		#IF(targetedBody.getWingType()!=WING_TYPE_dsg_dragon_wingFeathered)
 			[#targetedBody.setWingType(WING_TYPE_dsg_dragon_wingFeathered)]
 		#ENDIF
-		#IF(targetedBody.getWingSizeValue() < targetedBody.getLegConfiguration().getMinimumWingSizeForFlight(targetedBody).getValue())
-			[#targetedBody.setWingSize(targetedBody.getLegConfiguration().getMinimumWingSizeForFlight(targetedBody).getValue())]
+		#IF(targetedBody.getWingSizeValue() < targetedBody.getMinimumWingSizeValueForFlight())
+			[#targetedBody.setWingSizeToMinimumWingSizeForFlight()]
 		#ENDIF
 		#IF(targetedBody.getHornType()!=HORN_TYPE_NONE)
 			[#targetedBody.setHornType(HORN_TYPE_NONE)]
 		#ENDIF
-		#IF(targetedBody.getTailType()!=TAIL_TYPE_dsg_dragon_tailFeathered && !targetedBody.isFeral() && targetedBody.getLegConfiguration()!=LEG_CONFIGURATION_TAIL_LONG)
-			[#targetedBody.setTailType(TAIL_TYPE_dsg_dragon_tailFeathered)]
-		#ELSEIF(targetedBody.getTailType()!=TAIL_TYPE_NONE && (targetedBody.isFeral() || targetedBody.getLegConfiguration()==LEG_CONFIGURATION_TAIL_LONG))
+		#IF(!targetedBody.isFeral() && !targetedBody.getLegConfiguration().isOneOf(
+			LEG_CONFIGURATION_TAIL_LONG,
+			LEG_CONFIGURATION_BIPEDAL
+		))
+			[#targetedBody.applyLegConfigurationTransformation(LEG_TYPE_dsg_dragon_leg, LEG_CONFIGURATION_TAIL_LONG, true)]
+		#ENDIF
+		#IF(!targetedBody.isFeralOrHasLegConfiguration(LEG_CONFIGURATION_TAIL_LONG))
+			[#targetedBody.setTailType(targetedBody.randomTypeFrom(
+				TAIL_TYPE_dsg_dragon_tailFeathered,
+				TAIL_TYPE_dsg_dragon_tail
+			))]
+		#ELSE
 			[#targetedBody.setTailType(TAIL_TYPE_NONE)]
 		#ENDIF
 	]]></applySubspeciesChanges>
@@ -86,12 +95,20 @@
 	The race of the body that's being checked SHOULD NOT be accessed via targetedBody.getRace(), and should instead be accessed via using 'targetedRace'. -->
 	<subspeciesWeighting><![CDATA[
 		#IF(targetedRace==RACE_dsg_dragon && 
-		targetedBody.hasTongueModifier(TONGUE_MODIFIER_BIFURCATED) &&
-		targetedBody.getHairType()==HAIR_TYPE_dsg_dragon_hairFeathers &&
-		targetedBody.getHornType()==HORN_TYPE_NONE &&
-		(((targetedBody.getTailType()==TAIL_TYPE_dsg_dragon_tail || targetedBody.getTailType()==TAIL_TYPE_dsg_dragon_tailFeathered) && !targetedBody.isFeral() && targetedBody.getLegConfiguration()!=LEG_CONFIGURATION_TAIL_LONG) ||
-		(targetedBody.getTailType()==TAIL_TYPE_NONE && (targetedBody.isFeral() || targetedBody.getLegConfiguration()==LEG_CONFIGURATION_TAIL_LONG))) &&
-		targetedBody.getWingType()==WING_TYPE_dsg_dragon_wingFeathered)
+			targetedBody.hasTongueModifier(TONGUE_MODIFIER_BIFURCATED) &&
+			targetedBody.getHairType()==HAIR_TYPE_dsg_dragon_hairFeathers &&
+			targetedBody.getHornType()==HORN_TYPE_NONE &&
+			targetedBody.getWingType()==WING_TYPE_dsg_dragon_wingFeathered &&
+			(
+				(
+					targetedBody.getTailType().isOneOf(TAIL_TYPE_dsg_dragon_tail, TAIL_TYPE_dsg_dragon_tailFeathered) &&
+					!targetedBody.isFeralOrHasLegConfiguration(LEG_CONFIGURATION_TAIL_LONG)
+				) || (
+					targetedBody.getTailType()==TAIL_TYPE_NONE &&
+					targetedBody.isFeralOrHasLegConfiguration(LEG_CONFIGURATION_TAIL_LONG)
+				)
+			)
+		)
 			200
 		#ELSE
 			0
@@ -139,6 +156,14 @@
 			<pluralMaleName><![CDATA[coatl-boys]]></pluralMaleName>
 			<pluralFemaleName><![CDATA[coatl-girls]]></pluralFemaleName>
 		</namesDefault>
+		<names legConfiguration="TAIL_LONG">
+			<name><![CDATA[coatl-morph]]></name>
+			<namePlural><![CDATA[coatl-morphs]]></namePlural>
+			<singularMaleName><![CDATA[coatl-boy]]></singularMaleName>
+			<singularFemaleName><![CDATA[coatl-girl]]></singularFemaleName>
+			<pluralMaleName><![CDATA[coatl-boys]]></pluralMaleName>
+			<pluralFemaleName><![CDATA[coatl-girls]]></pluralFemaleName>
+		</names>
 	</nameAnthro>
 	
 	<!-- A brief description and identification requirements of this subspecies. -->
@@ -153,6 +178,14 @@
 			<pluralMaleName><![CDATA[quetzalcoatls]]></pluralMaleName>
 			<pluralFemaleName><![CDATA[quetzalcoatls]]></pluralFemaleName>
 		</namesDefault>
+		<names legConfiguration="TAIL_LONG">
+			<name><![CDATA[quetzalcoatl]]></name>
+			<namePlural><![CDATA[quetzalcoatls]]></namePlural>
+			<singularMaleName><![CDATA[quetzalcoatl]]></singularMaleName>
+			<singularFemaleName><![CDATA[quetzalcoatl]]></singularFemaleName>
+			<pluralMaleName><![CDATA[quetzalcoatls]]></pluralMaleName>
+			<pluralFemaleName><![CDATA[quetzalcoatls]]></pluralFemaleName>
+		</names>
 	</nameHalfDemon>
 	
 	<!-- Attributes related to this subspecies when in a feral form. -->

--- a/src/com/lilithsthrone/game/character/body/Body.java
+++ b/src/com/lilithsthrone/game/character/body/Body.java
@@ -3735,6 +3735,10 @@ public class Body implements XMLSaving {
 		return wing.getSizeValue();
 	}
 
+	public int getMinimumWingSizeValueForFlight() {
+		return leg.getLegConfiguration().getMinimumWingSizeForFlight(this).getValue();
+	}
+
 	public AbstractWingType getWingType() {
 		return wing.getType();
 	}
@@ -3937,6 +3941,14 @@ public class Body implements XMLSaving {
 
 	public String setWingSize(GameCharacter owner, int size) {
 		return this.wing.setSize(owner, size);
+	}
+
+	public String setWingSizeToMinimumWingSizeForFlight() {
+		return wing.setSize(null, getMinimumWingSizeValueForFlight());
+	}
+
+	public String setWingSizeToMinimumWingSizeForFlight(GameCharacter owner) {
+		return wing.setSize(owner, getMinimumWingSizeValueForFlight());
 	}
 
 	public String setWingType(AbstractWingType type) {
@@ -6294,7 +6306,11 @@ public class Body implements XMLSaving {
 	public boolean isFeral() {
 		return feral;
 	}
-	
+
+	public boolean isFeralOrHasLegConfiguration(LegConfiguration... values) {
+		return feral || leg.getLegConfiguration().isOneOf(values);
+	}
+
 	/**
 	 * @param subspecies Pass in the AbstractSubspecies to which this character should be transformed into a feral version of. Pass in null to transform back from feral to a standard anthro.
 	 */

--- a/src/com/lilithsthrone/game/character/body/valueEnums/LegConfiguration.java
+++ b/src/com/lilithsthrone/game/character/body/valueEnums/LegConfiguration.java
@@ -1,6 +1,7 @@
 package com.lilithsthrone.game.character.body.valueEnums;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.lilithsthrone.game.character.GameCharacter;
@@ -963,6 +964,10 @@ public enum LegConfiguration {
 
 	public boolean isThighSexAvailable() {
 		return true;
+	}
+
+	public boolean isOneOf(LegConfiguration... values) {
+		return Arrays.asList(values).contains(this);
 	}
 	
 	public int getNumberOfLegs() {


### PR DESCRIPTION
### What is the purpose of the pull request?
Serpent-tailed coatls were showing up as 'coatl-lamias'. Fixed that along with some more code-pretty for the coatl.xml.

### Give a brief description of what you changed or added.
- Added `<names legConfiguration="TAIL_LONG">` sections to the `coatl.xml` for `<nameAnthro>` and `<nameHalfDemon>`.
- Added `isOneOf(LegConfiguration... values)` to `LegConfiguration.java`.
- Added and implemented the following shorthands to the `Body.java`:
  - `getMinimumWingSizeValueForFlight()`
  - `setWingSizeToMinimumWingSizeForFlight()`
  - `setWingSizeToMinimumWingSizeForFlight(GameCharacter owner)`
  - `isFeralOrHasLegConfiguration(LegConfiguration... values)` which allows to check for one or more `LegConfiguration`s.
- Uncluttered and pretty-printed `<applySubspeciesChanges>` and `<subspeciesWeighting>` for the `coatl.xml`.
- Taur spawns are still borked for at least coatls, but I could achieve that at least a few coatl-taurs spawn properly as serpent-tailed.

### Are any new graphical assets required?
No.

### Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.4.6.6 Alpha

### So we have a better idea of who you are, what is your Discord Handle?
`@Stadler#3007`