### PR TITLE
Enable setting furry level for salamander spawns

### DIFF
--- a/res/race/mintychip/salamander/race.xml
+++ b/res/race/mintychip/salamander/race.xml
@@ -90,12 +90,12 @@
 	<!-- In a new game using completely default settings, what level of 'furry' should this race be for females and males.
 	Provided that you allow the player to adjust this via the content settings, this value isn't really too important, and should probably be left as 'NORMAL' unless there's a specific reason to change it.
 	Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/race/FurryPreference.java -->
-	<defaultFemininePreference>REDUCED</defaultFemininePreference>
-	<defaultMasculinePreference>REDUCED</defaultMasculinePreference>
+	<defaultFemininePreference>NORMAL</defaultFemininePreference>
+	<defaultMasculinePreference>NORMAL</defaultMasculinePreference>
 	
 	<!-- Whether or not the player can change this race's default furry level via the content settings screen.
 	This should probably be left as 'true', but if you want to make a race like harpies, which requires all newly-spawned characters to be created at a 'NORMAL' level of FurryPreference, then set this to false. -->
-	<affectedByFurryPreference>FALSE</affectedByFurryPreference>
+	<affectedByFurryPreference>true</affectedByFurryPreference>
 	
 	<!-- The weighting of this race's fetishes.
 		Newly-spawned characters of this race will have their starting fetishes affected by the weightings defined in this section. -->

--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -1823,7 +1823,7 @@ public abstract class AbstractSubspecies {
 	 * @return true if this subspecies can have its FurryPreference modified in the furry preferences options screen.
 	 */
 	public boolean isFurryPreferencesEnabled() {
-		return !this.hasFlag(SubspeciesFlag.DISABLE_FURRY_PREFERENCE);
+		return race.isAffectedByFurryPreference() && !hasFlag(SubspeciesFlag.DISABLE_FURRY_PREFERENCE);
 	}
 
 	/**


### PR DESCRIPTION
### What is the purpose of the pull request?
Allow setting the furry level for salamander spawns.

### Give a brief description of what you changed or added.
I couldn't set the furry level of salamander spawns. After a brief talk with @MintyChip, he told me, that this was a leftover from debugging and not intended. Additionally the setting wasn't greyed out, when `<affectedByFurryPreference>` was set to false. Fixed both in this PR.

### Are any new graphical assets required?
No.

### Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.4.6.6 Alpha

### So we have a better idea of who you are, what is your Discord Handle?
`@Stadler#3007`