### PR TITLE
Add Maven profiles to auto detect which OS the build is running on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,35 @@
 		<javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
 		<maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
 		<maven-compile-plugin.version>3.10.1</maven-compile-plugin.version>
-		<target.platform>linux</target.platform>
-		<exclude.platform>win</exclude.platform>
 	</properties>
+
+	<profiles>
+		<profile>
+			<id>profile-windows</id>
+			<activation>
+				<os>
+					<family>Windows</family>
+				</os>
+			</activation>
+			<properties>
+				<target.platform>win</target.platform>
+				<exclude.platform>linux</exclude.platform>
+			</properties>
+		</profile>
+		<profile>
+			<id>profile-linux</id>
+			<activation>
+				<os>
+					<family>Linux</family>
+				</os>
+			</activation>
+			<properties>
+				<target.platform>linux</target.platform>
+				<exclude.platform>win</exclude.platform>
+			</properties>
+		</profile>
+	</profiles>
+
 	<dependencies>
 
 		<dependency>


### PR DESCRIPTION
<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
Auto configure which JavaFX to include based on which OS the build is running on.
- Give a brief description of what you changed or added.
Added two profiles to Maven to cover the OS specific parts of JavaFX
- Are any new graphical assets required?
No
- Has this change been tested? If so, mention the version number that the test was based on.
Tested on Windows 
- So we have a better idea of who you are, what is your Discord Handle?
@Alaco on Discord

