### PR TITLE
Bugfix: initialize stickers for clothing that fits in multiple slots

### DIFF
--- a/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
+++ b/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java
@@ -893,18 +893,21 @@ public abstract class AbstractClothingType extends AbstractCoreType {
 									path = clothingXMLFile.getParentFile().getAbsolutePath() + "/"+ svgPathElement.getTextContent();
 									svgImageFound = true;
 								}
-								InventorySlot slot = this.getEquipSlots().get(0);
+								InventorySlot slot = null;
 								if(!svgPathElement.getAttribute("slot").isEmpty()) {
 									slot = InventorySlot.valueOf(svgPathElement.getAttribute("slot"));
 								}
-								stickerSvgPaths.putIfAbsent(slot, new HashMap<>());
-								
 								int zLayer = stickerZLayer;
 								if(!svgPathElement.getAttribute("zLayer").isEmpty()) {
 									zLayer = Integer.valueOf(svgPathElement.getAttribute("zLayer"));
 //									System.out.println(zLayer);
 								}
-								stickerSvgPaths.get(slot).put(zLayer, path);
+								for (InventorySlot equipSlot : this.getEquipSlots()) {
+									stickerSvgPaths.putIfAbsent(equipSlot, new HashMap<>());
+									if(slot == null || slot == equipSlot) {
+										stickerSvgPaths.get(equipSlot).put(zLayer, path);
+									}
+								}
 							}
 							if(!svgImageFound && stickerElement.getAttribute("colourSelected").isEmpty()) {
 								colourSelected = PresetColour.TEXT_GREY;


### PR DESCRIPTION
A clothing item with multiple slots will only set up the stickers for the first slot ([AbstractClothingType:896](https://github.com/Innoxia/liliths-throne-public/blob/d24c6531dad0a2d5c8c145c0fd30d317a06a8820/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java#L896)), but when looking for stickers to render, it will use the currently-equipped-to slot instead of the first slot ([AbstractClothingType:2293](https://github.com/Innoxia/liliths-throne-public/blob/d24c6531dad0a2d5c8c145c0fd30d317a06a8820/src/com/lilithsthrone/game/inventory/clothing/AbstractClothingType.java#L2293)).

This change applies all stickers to all slots, with a few important details:
- If a sticker specifies a slot, only that slot gets it
- If a slot has no applicable stickers, it will still have an empty list entered into the map (to prevent the NPE)

Bug first reported in discord here:
https://discord.com/channels/302617912949211136/446038411791433729/1041830431219273799
And an example mod (that causes issues when equipping to fingers or penis piercing) here:
https://discord.com/channels/302617912949211136/446038411791433729/1041848203483557948

Tested on 0.4.6.7