### PR TITLE
Improve Tattoo SVG Functionality

### DIFF
--- a/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipInventoryEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipInventoryEventListener.java
@@ -1513,12 +1513,14 @@ public class TooltipInventoryEventListener implements EventListener {
 		tooltipSB.append("</div>");
 		
 		// Picture:
-		tooltipSB.append("<div class='container-half-width' style='width:calc(33.3% - 16px);'>"
-						+ tattoo.getSVGImage(
-								equippedToCharacter==null
-									?Main.game.getPlayer()
-									:equippedToCharacter)
-					+ "</div>");
+		tooltipSB.append("<div class='item-image'>"
+								+ "<div class='item-image-content'>"
+									+ tattoo.getSVGImage(
+										equippedToCharacter==null
+											?Main.game.getPlayer()
+											:equippedToCharacter)
+								+ "</div>"
+							+ "</div>");
 
 		tooltipSB.append("</div>");
 


### PR DESCRIPTION
### What is the purpose of the pull request?
To update tattoos with the improved SVG functionality that was added to items a while ago.

### Give a brief description of what you changed or added.
The following functionality was added to tattoos defined in external XML files:
- Use multiple SVGs in one tattoo, with layer ordering determined by the zLayer parameter.
- Resize and rotate individual SVGs within the tattoo's XML file.
- Use 'raw' SVG paths rather than ones relative to the XML's parent folder.

These were added without breaking the functionality of existing tattoos (i.e. all of these new features are optional).

### Are any new graphical assets required?
No, this doesn't require any new graphical assets.

### Has this change been tested? If so, mention the version number that the test was based on.
Yes, it's been tested on version 0.4.6.9 (specifically commit [d17845eb28de58f8ebbf497ddd7128c669966954](https://github.com/Innoxia/liliths-throne-public/commit/d17845eb28de58f8ebbf497ddd7128c669966954)).

### So we have a better idea of who you are, what is your Discord Handle?
NoHornyOnMain#5417