### PR TITLE
Improve Maven Compatibility Across JDK Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,53 +69,65 @@
 				<maven.compiler.release>17</maven.compiler.release>
 			</properties>
 		</profile>
+		<profile>
+			<id>external-javafx</id>
+			<activation>
+				<jdk>[11,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-base</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${target.platform}</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-fxml</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${target.platform}</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-web</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${target.platform}</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-graphics</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${target.platform}</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-controls</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${target.platform}</classifier>
+				</dependency>
+				<dependency>
+					<groupId>org.openjfx</groupId>
+					<artifactId>javafx-media</artifactId>
+					<version>${javafx.version}</version>
+					<classifier>${target.platform}</classifier>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>external-nashorn</id>
+			<activation>
+				<jdk>[11,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.openjdk.nashorn</groupId>
+					<artifactId>nashorn-core</artifactId>
+					<version>${nashorn.version}</version>
+				</dependency>
+			</dependencies>
+		</profile>
 	</profiles>
 
-	<dependencies>
-
-		<dependency>
-			<groupId>org.openjfx</groupId>
-			<artifactId>javafx-base</artifactId>
-			<version>${javafx.version}</version>
-			<classifier>${target.platform}</classifier>
-		</dependency>
-		<dependency>
-			<groupId>org.openjfx</groupId>
-			<artifactId>javafx-fxml</artifactId>
-			<version>${javafx.version}</version>
-			<classifier>${target.platform}</classifier>
-		</dependency>
-		<dependency>
-			<groupId>org.openjfx</groupId>
-			<artifactId>javafx-web</artifactId>
-			<version>${javafx.version}</version>
-			<classifier>${target.platform}</classifier>
-		</dependency>
-		<dependency>
-			<groupId>org.openjfx</groupId>
-			<artifactId>javafx-graphics</artifactId>
-			<version>${javafx.version}</version>
-			<classifier>${target.platform}</classifier>
-		</dependency>
-		<dependency>
-			<groupId>org.openjfx</groupId>
-			<artifactId>javafx-controls</artifactId>
-			<version>${javafx.version}</version>
-			<classifier>${target.platform}</classifier>
-		</dependency>
-		<dependency>
-			<groupId>org.openjfx</groupId>
-			<artifactId>javafx-media</artifactId>
-			<version>${javafx.version}</version>
-			<classifier>${target.platform}</classifier>
-		</dependency>
-
-		<dependency>
-			<groupId>org.openjdk.nashorn</groupId>
-			<artifactId>nashorn-core</artifactId>
-			<version>${nashorn.version}</version>
-		</dependency>
-	</dependencies>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<resources>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<name>Lilith's Throne</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.release>17</maven.compiler.release>
+		<maven.compiler.release>11</maven.compiler.release>
 		<javafx.version>18.0.2</javafx.version>
 		<nashorn.version>15.4</nashorn.version>
 		<javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
@@ -38,6 +38,35 @@
 			<properties>
 				<target.platform>linux</target.platform>
 				<exclude.platform>win</exclude.platform>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk8</id>
+			<activation>
+				<jdk>1.8</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.release>${maven.compiler}</maven.compiler.release>
+				<maven.compiler.source>1.8</maven.compiler.source>
+				<maven.compiler.target>1.8</maven.compiler.target>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk11</id>
+			<activation>
+				<jdk>11</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.release>11</maven.compiler.release>
+			</properties>
+		</profile>
+		<profile>
+			<id>jdk17</id>
+			<activation>
+				<jdk>17</jdk>
+			</activation>
+			<properties>
+				<maven.compiler.release>17</maven.compiler.release>
 			</properties>
 		</profile>
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,10 @@
 							<outputFile>${project.build.directory}/${project.name} (${target.platform})/${project.name}-${project.version}.jar</outputFile>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>com.lilithsthrone.Launcher</mainClass>
+									<manifestEntries>
+										<Built-By>REDACTED</Built-By>
+										<Main-Class>com.lilithsthrone.Launcher</Main-Class>
+									</manifestEntries>
 								</transformer>
 							</transformers>
 							<artifactSet>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,11 @@
 		<javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>
 		<maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
 		<maven-compile-plugin.version>3.10.1</maven-compile-plugin.version>
+		<maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+		<internalNashornImport>import jdk.nashorn.</internalNashornImport>
+		<externalNashornImport>import org.openjdk.nashorn.</externalNashornImport>
+		<defaultNashornImport>${internalNashornImport}</defaultNashornImport>
+		<correctNashornImport>${internalNashornImport}</correctNashornImport>
 	</properties>
 
 	<profiles>
@@ -118,6 +123,9 @@
 			<activation>
 				<jdk>[11,)</jdk>
 			</activation>
+			<properties>
+				<correctNashornImport>${externalNashornImport}</correctNashornImport>
+			</properties>
 			<dependencies>
 				<dependency>
 					<groupId>org.openjdk.nashorn</groupId>
@@ -156,6 +164,36 @@
 				<configuration>
 					<mainClass>com.lilithsthrone.main.Main</mainClass>
 				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<version>${maven-antrun-plugin.version}</version>
+				<executions>
+					<execution>
+						<phase>process-sources</phase>
+						<id>correct-imports</id>
+						<configuration>
+						<target>
+							<replace token= "${defaultNashornImport}" value="${correctNashornImport}" file="src/com/lilithsthrone/game/dialogue/utils/UtilText.java"/>
+						</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+					<execution>
+						<phase>prepare-package</phase>
+						<id>restore-imports</id>
+						<configuration>
+						<target>
+							<replace token= "${correctNashornImport}" value="${defaultNashornImport}" file="src/com/lilithsthrone/game/dialogue/utils/UtilText.java"/>
+						</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,17 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>profile-mac</id>
+			<activation>
+				<os>
+					<family>Mac</family>
+				</os>
+			</activation>
+			<properties>
+				<target.platform>mac</target.platform>
+			</properties>
+		</profile>
+		<profile>
 			<id>jdk8</id>
 			<activation>
 				<jdk>1.8</jdk>

--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -221,11 +221,9 @@ import com.lilithsthrone.world.places.AbstractPlaceUpgrade;
 import com.lilithsthrone.world.places.PlaceType;
 import com.lilithsthrone.world.places.PlaceUpgrade;
 
+// Prepend 'org.open' to these if using JDK11+
 import jdk.nashorn.api.scripting.NashornScriptEngine;
 import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
-// Use the following imports when using the org.openjdk.nashorn dependency:
-//import org.openjdk.nashorn.api.scripting.NashornScriptEngine;
-//import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
 
 /**
  * @since 0.1.0


### PR DESCRIPTION
### What is the purpose of the pull request?
It's currently impossible to compile from source without changing files (pom.xml or UtilText.java) unless you use a non-Maven compilation method (i.e. Eclipse) on JDK8. As such, this PR aims to allow Maven-based compilation on any reasonable Java version without requiring any changes.

### Give a brief description of what you changed or added.
- JDK version is now checked when compiling with Maven (even via a supporting IDE).
- JDK8 specific pom.xml changes are applied if needed (e.g. maven.compiler.source/target).
- JDK8-style internal Nashorn imports are swapped out at compile-time if needed, then swapped back afterwards.
- External JavaFX and Nashorn dependencies are only downloaded if running JDK11+.
- Provides explicit support for all LTS JDK versions (8,11,17) and implicit support for JDK11+.

### Are any new graphical assets required?
No, this doesn't require any new graphical assets.

### Has this change been tested? If so, mention the version number that the test was based on.
This has been tested and confirmed working with the following setups:
- Maven
    - JDK8
    - JDK11
    - JDK17
- IntelliJ IDEA
    - JDK8
    - JDK11
    - JDK17
- Eclipse Oxygen
    - JDK8

All of the above testing was performed using version 0.4.7 of the game (specifically commit 4e645da98afdd6189f4eb52d46f04e3391e4f58f).

### So we have a better idea of who you are, what is your Discord Handle?
NoHornyOnMain#5417