### PR TITLE
Correct GitHub URLs in Comments

### DIFF
--- a/res/clothing/dsg/foxscarf/foxscarf.xml
+++ b/res/clothing/dsg/foxscarf/foxscarf.xml
@@ -31,13 +31,13 @@
 		<!-- Use FEMININE for if this clothing is intended for feminine characters, MASCULINE for masculine, and ANDROGYNOUS if it's able to be worn by anyone without penalties. -->
 		<femininity>ANDROGYNOUS</femininity> 
 		
-		<!-- The slot that this clothing fits into. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+		<!-- The slot that this clothing fits into. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 		<slot>NECK</slot> 
 		
-		<!-- The rarity of this item. Anything less than EPIC may end up being modified in the code. Possible rarities are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+		<!-- The rarity of this item. Anything less than EPIC may end up being modified in the code. Possible rarities are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 		<rarity>UNCOMMON</rarity> 
 		
-		<!-- The set that this clothing belongs to. I will add a way to define your own sets, but for now, existing sets can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingSet.java -->
+		<!-- The set that this clothing belongs to. I will add a way to define your own sets, but for now, existing sets can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingSet.java -->
 		<clothingSet/> 
 		
 		<!-- The file path for this clothing's image. All images MUST BE .svg format. Colours to be used are described below, above the 'primaryColours' element. I use the free program 'InkScape' to make my .svg images.
@@ -57,24 +57,24 @@
 			<blockedParts>
 			
 				<!-- If this clothing is displaced in the following way (in this case, by being removed), then the 'blockedBodyParts', 'clothingAccessBlocked', and 'concealedSlots' will all be revealed. If multiple 'blockedParts' block or conceal the same slot, only one 'blockedParts' needs to be displaced to reveal it. (e.g. If a pair of trousers has 'UNZIPS' and 'PULLS_DOWN' displacementTypes, and both of these contain the 'concealedSlots' 'slot' 'PENIS', then the penis will be revealed if either UNZIPS or PULLS_DOWN is activated.)
-				A full list of displacementTypes can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+				A full list of displacementTypes can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
 				<displacementType>REMOVE_OR_EQUIP</displacementType> 
 				
-				<!-- The access required to perform this displacementType. clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+				<!-- The access required to perform this displacementType. clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
 				<clothingAccessRequired/>
 				
-				<!-- The body parts that are blocked by this 'displacementType'. bodyPart values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+				<!-- The body parts that are blocked by this 'displacementType'. bodyPart values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
 				<blockedBodyParts/>
 				
-				<!-- The access that this 'displacementType' blocks. Again, clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+				<!-- The access that this 'displacementType' blocks. Again, clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
 				<clothingAccessBlocked/>
 				
-				<!-- The slots that this 'displacementType' conceals. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+				<!-- The slots that this 'displacementType' conceals. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 				<concealedSlots/>
 			</blockedParts>
 		</blockedPartsList>
 		
-		<!-- Inventory slots that are incompatible with this clothing. The game's swimsuit makes use of this, and, while fitting into the 'CHEST' slot, also blocks 'GROIN' and 'STOMACH'. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+		<!-- Inventory slots that are incompatible with this clothing. The game's swimsuit makes use of this, and, while fitting into the 'CHEST' slot, also blocks 'GROIN' and 'STOMACH'. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 		<incompatibleSlots/> 
 		
 		<!-- Your clothing can be coloured any way you like, but if you'd like the player to be able to dye your clothing, you can specify available colours here. primaryColours, secondaryColours, and tertiaryColours can all spawn in as a default colour, while their 'Dye' counterparts are only available if the player chooses to dye the clothing in that colour. The game detects specific colour values, and recolours them to the value chosen by the player. These values are as follows:
@@ -110,13 +110,13 @@
 		<tertiaryColours values="JUST_WHITE"/> 
 		<tertiaryColoursDye values="ALL"/>
 		
-		<!-- These tags determine where in the world your clothing can be found. Possible tags are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<!-- These tags determine where in the world your clothing can be found. Possible tags are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 		<itemTags> 
 			<tag>SOLD_BY_NYAN</tag>
 		</itemTags>
 	</coreAtributes>
 
-	<!-- The following sections are for defining the descriptions of displacing or replacing your clothing. The attribute 'type' defines which DisplacementType your descriptions are applied to. For standard equipping and unequipping, use REMOVE_OR_EQUIP. Types can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+	<!-- The following sections are for defining the descriptions of displacing or replacing your clothing. The attribute 'type' defines which DisplacementType your descriptions are applied to. For standard equipping and unequipping, use REMOVE_OR_EQUIP. Types can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
 	
 	<!-- 'displacementText' is used for removal and displacement. -->
 	<displacementText type="REMOVE_OR_EQUIP">

--- a/res/clothing/dsg/foxscarf/foxscarf.xml
+++ b/res/clothing/dsg/foxscarf/foxscarf.xml
@@ -37,7 +37,8 @@
 		<!-- The rarity of this item. Anything less than EPIC may end up being modified in the code. Possible rarities are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 		<rarity>UNCOMMON</rarity> 
 		
-		<!-- The set that this clothing belongs to. I will add a way to define your own sets, but for now, existing sets can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingSet.java -->
+		<!-- For an annotated example on how custom sets are defined, please see the 'res/mods/innoxia/setBonuses/template.xml' file.
+		Alternatively, existing sets can be found in the 'res/setBonuses' folder. -->
 		<clothingSet/> 
 		
 		<!-- The file path for this clothing's image. All images MUST BE .svg format. Colours to be used are described below, above the 'primaryColours' element. I use the free program 'InkScape' to make my .svg images.

--- a/res/clothing/innoxia/anus/ribbed_dildo.xml
+++ b/res/clothing/innoxia/anus/ribbed_dildo.xml
@@ -71,7 +71,7 @@
 		<tertiaryColours/>
 		<tertiaryColoursDye/>
 	
-		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 			<tag>SOLD_BY_FINCH</tag>
 			<tag>ENABLE_SEX_EQUIP</tag>
 			<tag>TRANSPARENT</tag>

--- a/res/clothing/innoxia/buttPlugs/butt_plug.xml
+++ b/res/clothing/innoxia/buttPlugs/butt_plug.xml
@@ -39,7 +39,7 @@
 		<tertiaryColours/>
 		<tertiaryColoursDye/>
 	
-		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 			<tag>SOLD_BY_FINCH</tag>
 			<tag>PLUGS_ANUS</tag>
 			<tag>ENABLE_SEX_EQUIP</tag>

--- a/res/clothing/innoxia/buttPlugs/butt_plug_heart.xml
+++ b/res/clothing/innoxia/buttPlugs/butt_plug_heart.xml
@@ -39,7 +39,7 @@
 		<tertiaryColours/>
 		<tertiaryColoursDye/>
 	
-		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 			<tag>SOLD_BY_FINCH</tag>
 			<tag>PLUGS_ANUS</tag>
 			<tag>ENABLE_SEX_EQUIP</tag>

--- a/res/clothing/innoxia/buttPlugs/butt_plug_jewel.xml
+++ b/res/clothing/innoxia/buttPlugs/butt_plug_jewel.xml
@@ -39,7 +39,7 @@
 		<tertiaryColours/>
 		<tertiaryColoursDye/>
 	
-		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 			<tag>SOLD_BY_FINCH</tag>
 			<tag>PLUGS_ANUS</tag>
 			<tag>ENABLE_SEX_EQUIP</tag>

--- a/res/clothing/innoxia/buttPlugs/butt_plug_tail.xml
+++ b/res/clothing/innoxia/buttPlugs/butt_plug_tail.xml
@@ -44,7 +44,7 @@
 		<tertiaryColours values="ALL_METAL"/>
 		<tertiaryColoursDye/>
 	
-		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 			<tag>SOLD_BY_FINCH</tag>
 			<tag>PLUGS_ANUS</tag>
 			<tag>ENABLE_SEX_EQUIP</tag>

--- a/res/clothing/innoxia/milking/breast_pumps.xml
+++ b/res/clothing/innoxia/milking/breast_pumps.xml
@@ -63,7 +63,7 @@
 		<tertiaryColours/>
 		<tertiaryColoursDye/>
 	
-		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 			<tag>MILKING_EQUIPMENT</tag>
 			<tag>TRANSPARENT</tag>
 			<tag>ENABLE_SEX_EQUIP</tag>

--- a/res/clothing/innoxia/milking/penis_pump.xml
+++ b/res/clothing/innoxia/milking/penis_pump.xml
@@ -45,7 +45,7 @@
 		<tertiaryColours/>
 		<tertiaryColoursDye/>
 	
-		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 			<tag>MILKING_EQUIPMENT</tag>
 			<tag>TRANSPARENT</tag>
 			<tag>ENABLE_SEX_EQUIP</tag>

--- a/res/clothing/innoxia/milking/vagina_pump.xml
+++ b/res/clothing/innoxia/milking/vagina_pump.xml
@@ -47,7 +47,7 @@
 		</tertiaryColours>
 		<tertiaryColoursDye values="ALL"/>
 	
-		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 			<tag>MILKING_EQUIPMENT</tag>
 			<tag>TRANSPARENT</tag>
 			<tag>ENABLE_SEX_EQUIP</tag>

--- a/res/clothing/innoxia/vagina/insertable_dildo.xml
+++ b/res/clothing/innoxia/vagina/insertable_dildo.xml
@@ -46,7 +46,7 @@
 		<tertiaryColours/>
 		<tertiaryColoursDye/>
 	
-		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 			<tag>SOLD_BY_FINCH</tag>
 			<tag>REQUIRES_VAGINA</tag>
 			<tag>PLUGS_VAGINA</tag>

--- a/res/clothing/irbynx/spikedCollar/punk_neck_metal_collar_spiked.xml
+++ b/res/clothing/irbynx/spikedCollar/punk_neck_metal_collar_spiked.xml
@@ -35,7 +35,8 @@
 		<!-- The rarity of this item. Anything less than EPIC may end up being modified in the code. Possible rarities are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 		<rarity>UNCOMMON</rarity> 
 		
-		<!-- The set that this clothing belongs to. I will add a way to define your own sets, but for now, existing sets can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingSet.java -->
+		<!-- For an annotated example on how custom sets are defined, please see the 'res/mods/innoxia/setBonuses/template.xml' file.
+		Alternatively, existing sets can be found in the 'res/setBonuses' folder. -->
 		<clothingSet/> 
 		
 		<!-- The file path for this clothing's image. All images MUST BE .svg format. Colours to be used are described below, above the 'primaryColours' element. I use the free program 'InkScape' to make my .svg images.

--- a/res/clothing/irbynx/spikedCollar/punk_neck_metal_collar_spiked.xml
+++ b/res/clothing/irbynx/spikedCollar/punk_neck_metal_collar_spiked.xml
@@ -29,13 +29,13 @@
 		<!-- Use FEMININE for if this clothing is intended for feminine characters, MASCULINE for masculine, and ANDROGYNOUS if it's able to be worn by anyone without penalties. -->
 		<femininity>ANDROGYNOUS</femininity> 
 		
-		<!-- The slot that this clothing fits into. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+		<!-- The slot that this clothing fits into. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 		<slot>NECK</slot> 
 		
-		<!-- The rarity of this item. Anything less than EPIC may end up being modified in the code. Possible rarities are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+		<!-- The rarity of this item. Anything less than EPIC may end up being modified in the code. Possible rarities are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 		<rarity>UNCOMMON</rarity> 
 		
-		<!-- The set that this clothing belongs to. I will add a way to define your own sets, but for now, existing sets can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingSet.java -->
+		<!-- The set that this clothing belongs to. I will add a way to define your own sets, but for now, existing sets can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingSet.java -->
 		<clothingSet/> 
 		
 		<!-- The file path for this clothing's image. All images MUST BE .svg format. Colours to be used are described below, above the 'primaryColours' element. I use the free program 'InkScape' to make my .svg images.
@@ -60,24 +60,24 @@
 			<blockedParts>
 			
 				<!-- If this clothing is displaced in the following way (in this case, by being removed), then the 'blockedBodyParts', 'clothingAccessBlocked', and 'concealedSlots' will all be revealed. If multiple 'blockedParts' block or conceal the same slot, only one 'blockedParts' needs to be displaced to reveal it. (e.g. If a pair of trousers has 'UNZIPS' and 'PULLS_DOWN' displacementTypes, and both of these contain the 'concealedSlots' 'slot' 'PENIS', then the penis will be revealed if either UNZIPS or PULLS_DOWN is activated.)
-				A full list of displacementTypes can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+				A full list of displacementTypes can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
 				<displacementType>REMOVE_OR_EQUIP</displacementType> 
 				
-				<!-- The access required to perform this displacementType. clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+				<!-- The access required to perform this displacementType. clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
 				<clothingAccessRequired/>
 				
-				<!-- The body parts that are blocked by this 'displacementType'. bodyPart values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+				<!-- The body parts that are blocked by this 'displacementType'. bodyPart values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
 				<blockedBodyParts/>
 				
-				<!-- The access that this 'displacementType' blocks. Again, clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+				<!-- The access that this 'displacementType' blocks. Again, clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
 				<clothingAccessBlocked/>
 				
-				<!-- The slots that this 'displacementType' conceals. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+				<!-- The slots that this 'displacementType' conceals. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 				<concealedSlots/>
 			</blockedParts>
 		</blockedPartsList>
 		
-		<!-- Inventory slots that are incompatible with this clothing. The game's swimsuit makes use of this, and, while fitting into the 'CHEST' slot, also blocks 'GROIN' and 'STOMACH'. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+		<!-- Inventory slots that are incompatible with this clothing. The game's swimsuit makes use of this, and, while fitting into the 'CHEST' slot, also blocks 'GROIN' and 'STOMACH'. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 		<incompatibleSlots/> 
 		
 		<!-- Your clothing can be coloured any way you like, but if you'd like the player to be able to dye your clothing, you can specify available colours here. primaryColours, secondaryColours, and tertiaryColours can all spawn in as a default colour, while their 'Dye' counterparts are only available if the player chooses to dye the clothing in that colour. The game detects specific colour values, and recolours them to the value chosen by the player. These values are as follows:
@@ -107,14 +107,14 @@
 		<secondaryColours values="JUST_GOLD"/>
 		<secondaryColoursDye values="ALL_METAL"/>
 		
-		<!-- These tags determine where in the world your clothing can be found. Possible tags are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<!-- These tags determine where in the world your clothing can be found. Possible tags are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 		<itemTags> 
 			<tag>SOLD_BY_FINCH</tag>
 			<tag>PROVIDES_KEY</tag>
 		</itemTags>
 	</coreAttributes>
 
-	<!-- The following sections are for defining the descriptions of displacing or replacing your clothing. The attribute 'type' defines which DisplacementType your descriptions are applied to. For standard equipping and unequipping, use REMOVE_OR_EQUIP. Types can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+	<!-- The following sections are for defining the descriptions of displacing or replacing your clothing. The attribute 'type' defines which DisplacementType your descriptions are applied to. For standard equipping and unequipping, use REMOVE_OR_EQUIP. Types can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
 	
 	<!-- 'displacementText' is used for removal and displacement. -->
 	<displacementText type="REMOVE_OR_EQUIP">

--- a/res/clothing/norin/anal_beads/anal_beads.xml
+++ b/res/clothing/norin/anal_beads/anal_beads.xml
@@ -10,8 +10,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>ANDROGYNOUS</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>ANUS</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>ANUS</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>anal_beads.svg</imageName>
     
@@ -22,13 +22,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>ANUS</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
           <bodyPart>ANUS</bodyPart>
         </blockedBodyParts>
         
@@ -48,7 +48,7 @@
     <tertiaryColours/>
     <tertiaryColoursDye/>
     
-    <itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+    <itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
       <tag>SOLD_BY_FINCH</tag>
       <tag>PLUGS_ANUS</tag>
       <tag>ENABLE_SEX_EQUIP</tag>

--- a/res/clothing/norin/dildos/realistic_dildo.xml
+++ b/res/clothing/norin/dildos/realistic_dildo.xml
@@ -17,7 +17,7 @@
 			<slot>MOUTH</slot>
 		</equipSlots>
 		
-		<rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+		<rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 		
 		<imageName>realistic_dildo.svg</imageName>
 
@@ -31,11 +31,11 @@
 		
 		<blockedPartsList slot="VAGINA">
 			<blockedParts>
-			  <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
-			  <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+			  <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+			  <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
 				<clothingAccess>VAGINA</clothingAccess>
 			  </clothingAccessRequired>
-			  <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+			  <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
 			  <clothingAccessBlocked/> <!-- clothingAccess -->
 			  <concealedSlots/> <!-- slot -->
 			</blockedParts>
@@ -80,7 +80,7 @@
 		<tertiaryColours/>
 		<tertiaryColoursDye/>
 		
-		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 			<tag>SOLD_BY_FINCH</tag>
 			<tag>ENABLE_SEX_EQUIP</tag>
 			<tag>TRANSPARENT</tag>

--- a/res/clothing/norin/piercings/bat_wings_barbells.xml
+++ b/res/clothing/norin/piercings/bat_wings_barbells.xml
@@ -10,8 +10,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>ANDROGYNOUS</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_NIPPLE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_NIPPLE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>bat_wings_barbells.svg</imageName>
     
@@ -22,13 +22,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>CHEST</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/piercings/caution_when_wet.xml
+++ b/res/clothing/norin/piercings/caution_when_wet.xml
@@ -10,8 +10,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_STOMACH</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>EPIC</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_STOMACH</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>EPIC</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>caution_when_wet.svg</imageName>
     
@@ -26,13 +26,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>WAIST</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         
@@ -54,7 +54,7 @@
     </tertiaryColours>
     <tertiaryColoursDye values ="ALL"/>
     
-    <itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+    <itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
       <tag>SOLD_BY_KATE</tag>
     </itemTags>
     

--- a/res/clothing/norin/piercings/heart_barbells.xml
+++ b/res/clothing/norin/piercings/heart_barbells.xml
@@ -10,8 +10,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_NIPPLE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_NIPPLE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>heart_barbells.svg</imageName>
     
@@ -22,13 +22,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>CHEST</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/piercings/heart_clit.xml
+++ b/res/clothing/norin/piercings/heart_clit.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_VAGINA</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_VAGINA</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>heart_clit.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>GROIN</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/piercings/piercing_lip_flower.xml
+++ b/res/clothing/norin/piercings/piercing_lip_flower.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_LIP</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_LIP</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_lip_flower.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>HEAD</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/piercings/piercing_nipple_chain.xml
+++ b/res/clothing/norin/piercings/piercing_nipple_chain.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>ANDROGYNOUS</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_NIPPLE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_NIPPLE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_nipple_chain.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>CHEST</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/piercings/piercing_nipple_rings.xml
+++ b/res/clothing/norin/piercings/piercing_nipple_rings.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>ANDROGYNOUS</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_NIPPLE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_NIPPLE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_nipple_rings.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>CHEST</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/piercings/piercing_pentagram_navel.xml
+++ b/res/clothing/norin/piercings/piercing_pentagram_navel.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>ANDROGYNOUS</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_STOMACH</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_STOMACH</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_pentagram_navel.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>WAIST</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         
@@ -51,7 +51,7 @@
     <tertiaryColours/>
     <tertiaryColoursDye/>
     
-    <itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+    <itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
       <tag>SOLD_BY_KATE</tag>
     </itemTags>
     

--- a/res/clothing/norin/piercings/piercing_vagina_sex.xml
+++ b/res/clothing/norin/piercings/piercing_vagina_sex.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_VAGINA</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_VAGINA</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_vagina_sex.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>GROIN</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/piercings/piercing_vertical_hood.xml
+++ b/res/clothing/norin/piercings/piercing_vertical_hood.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_VAGINA</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_VAGINA</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_vertical_hood.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>GROIN</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/rose_piercings/piercing_lip_rose.xml
+++ b/res/clothing/norin/rose_piercings/piercing_lip_rose.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_LIP</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_LIP</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_lip_rose.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>HEAD</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/rose_piercings/piercing_navel_rose.xml
+++ b/res/clothing/norin/rose_piercings/piercing_navel_rose.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_STOMACH</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_STOMACH</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_navel_rose.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>WAIST</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         
@@ -49,7 +49,7 @@
     <tertiaryColours/>
     <tertiaryColoursDye/>
     
-    <itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+    <itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
       <tag>SOLD_BY_KATE</tag>
     </itemTags>
     

--- a/res/clothing/norin/rose_piercings/piercing_nose_rose.xml
+++ b/res/clothing/norin/rose_piercings/piercing_nose_rose.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_NOSE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_NOSE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_nose_rose.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>HEAD</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/sunflower_piercings/piercing_lip_sunflower.xml
+++ b/res/clothing/norin/sunflower_piercings/piercing_lip_sunflower.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_LIP</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_LIP</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_lip_sunflower.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>HEAD</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/sunflower_piercings/piercing_nose_sunflower.xml
+++ b/res/clothing/norin/sunflower_piercings/piercing_nose_sunflower.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_NOSE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_NOSE</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_nose_sunflower.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>HEAD</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         

--- a/res/clothing/norin/sunflower_piercings/piercing_sunflower_navel.xml
+++ b/res/clothing/norin/sunflower_piercings/piercing_sunflower_navel.xml
@@ -11,8 +11,8 @@
     
     <physicalResistance>0</physicalResistance>
     <femininity>FEMININE</femininity> <!-- FEMININE, MASCULINE ANDROGYNOUS -->
-    <slot>PIERCING_STOMACH</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+    <slot>PIERCING_STOMACH</slot> <!-- slot values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+    <rarity>COMMON</rarity> <!-- rarity values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
     
     <imageName>piercing_sunflower_navel.svg</imageName>
     
@@ -23,13 +23,13 @@
     <blockedPartsList>
       <blockedParts>
         
-        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+        <displacementType>REMOVE_OR_EQUIP</displacementType> <!-- displacementType values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
         
-        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+        <clothingAccessRequired> <!-- clothingAccess values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
           <clothingAccess>WAIST</clothingAccess>
         </clothingAccessRequired>
         
-        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+        <blockedBodyParts/> <!--bodyPart values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
         <clothingAccessBlocked/> <!-- clothingAccess -->
         <concealedSlots/> <!-- slot -->
         
@@ -51,7 +51,7 @@
     </tertiaryColours>
     <tertiaryColoursDye values="ALL"/>
     
-    <itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+    <itemTags> <!-- tag values: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
       <tag>SOLD_BY_KATE</tag>
     </itemTags>
     

--- a/res/images/characters/modding.txt
+++ b/res/images/characters/modding.txt
@@ -4,7 +4,7 @@ All images must be in PNG (.png) or JPEG (.jpg) format and are scaled down inter
 Animations in GIF (.gif) format are also supported. Note that large GIFs may slow down the game, which is why the animation is not played in tooltips and may not be over 10 MB in size.
 
 In order to add your own images to the game, you first need to figure out where to put the files. For unique NPCs, the folder has the same name as the class. For reference, check:
-https://github.com/Innoxia/liliths-throne-public/tree/master/src/com/lilithsthrone/game/character/npc
+https://github.com/Innoxia/liliths-throne-public/tree/dev/src/com/lilithsthrone/game/character/npc
 
 For generic characters (generated dynamically, e.g. slaves), you can create a "generic" folder (without quotation marks) and then create a subfolder using the in-game name of the character. The game will not check for duplicates, but reload images when you rename a character.
 

--- a/res/items/innoxia/pills/fertility.xml
+++ b/res/items/innoxia/pills/fertility.xml
@@ -38,7 +38,7 @@
 		<!-- 'true' if this item is consumed on use. Most items have this set to 'true'. -->
 		<consumedOnUse>true</consumedOnUse>
 		
-		<!-- The rarity of this item. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+		<!-- The rarity of this item. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 		<rarity>COMMON</rarity> 
 		
 		<!-- The file name of this item's image when in the character's inventory. The only supported file type is .svg. I use the free program "Inkscape" to make .svg images for the game.
@@ -124,7 +124,7 @@
 			</p>
 		]]></applyEffects>
 		
-		<!-- Special item tags that apply to this item. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<!-- Special item tags that apply to this item. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 		<itemTags>
 			<tag>ALL_AREAS_SPAWN</tag>
 			<tag>ATTRIBUTE_TF_ITEM</tag>

--- a/res/mods/innoxia/items/clothing/template/socks.xml
+++ b/res/mods/innoxia/items/clothing/template/socks.xml
@@ -43,18 +43,18 @@
 			- Example: Normal socks could be worn by both males and females without issue, so I set this to "ANDROGYNOUS". -->
 		<femininity>ANDROGYNOUS</femininity> 
 		
-		<!-- The slots that this clothing is able to be fit into. The game only supports up to 4 unique slots, so if you define more than 4, the rest of them won't show up in-game. These definitions preserve ordering, so use the top one for the most common slot to be fitted into. This is especially important for NPCs, as they will use the top slot for determining which slot this clothing should fit into.  Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java 
+		<!-- The slots that this clothing is able to be fit into. The game only supports up to 4 unique slots, so if you define more than 4, the rest of them won't show up in-game. These definitions preserve ordering, so use the top one for the most common slot to be fitted into. This is especially important for NPCs, as they will use the top slot for determining which slot this clothing should fit into.  Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java 
 			- Example: I defined "SOCK" as the top slot, as this is the intended slot for socks. As I also want the player to be able to equip socks onto their hands, I defined "HAND" as a secondary slot.-->
 		<equipSlots>
 			<slot>SOCK</slot>
 			<slot>HAND</slot>
 		</equipSlots>
 		
-		<!-- The rarity of this item. Anything less than EPIC may end up being modified in the code. Possible rarities are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java 
+		<!-- The rarity of this item. Anything less than EPIC may end up being modified in the code. Possible rarities are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java 
 			- Example: Socks are most definitely "COMMON", but I've defined these as "LEGENDARY" so as to prevent them from naturally spawning in the game.-->
 		<rarity>LEGENDARY</rarity> 
 		
-		<!-- The set that this clothing belongs to. I will add a way to define your own sets, but for now, existing sets can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingSet.java
+		<!-- The set that this clothing belongs to. I will add a way to define your own sets, but for now, existing sets can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingSet.java
 			- Example: These socks have no set. If you want to define one, just use the name of the set like: <clothingSet>BUTLER</clothingSet> -->
 		<clothingSet>innoxia_template</clothingSet>
 		
@@ -87,24 +87,24 @@
 			<blockedParts>
 			
 				<!-- If this clothing is displaced in the following way (in this case, by being removed), then the 'blockedBodyParts', 'clothingAccessBlocked', and 'concealedSlots' will all be revealed. If multiple 'blockedParts' block or conceal the same slot, only one 'blockedParts' needs to be displaced to reveal it. (e.g. If a pair of trousers has 'UNZIPS' and 'PULLS_DOWN' displacementTypes, and both of these contain the 'concealedSlots' 'slot' 'PENIS', then the penis will be revealed if either UNZIPS or PULLS_DOWN is activated.)
-				A full list of displacementTypes can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+				A full list of displacementTypes can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
 				<displacementType>REMOVE_OR_EQUIP</displacementType> 
 				
-				<!-- The access required to perform this displacementType. clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+				<!-- The access required to perform this displacementType. clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
 				<clothingAccessRequired> 
 					<clothingAccess>FEET</clothingAccess>
 				</clothingAccessRequired>
 				
-				<!-- The body parts that are blocked by this 'displacementType'. bodyPart values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
+				<!-- The body parts that are blocked by this 'displacementType'. bodyPart values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/CoverableArea.java -->
 				<blockedBodyParts>
 					<bodyPart>FEET</bodyPart>
 				</blockedBodyParts>
 				
-				<!-- The access that this 'displacementType' blocks. Again, clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
+				<!-- The access that this 'displacementType' blocks. Again, clothingAccess values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingAccess.java -->
 				<clothingAccessBlocked/> <!-- Use the tag 'clothingAccess' for values inserted here. -->
 				
-				<!-- The slots that this 'displacementType' conceals. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-				<!-- You can also use a preset list by adding an attribute named "values" to this element (an example - "CS Example" - is in the blockedParts section below this one). The preset lists that you can use are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/PresetConcealmentLists.java -->
+				<!-- The slots that this 'displacementType' conceals. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+				<!-- You can also use a preset list by adding an attribute named "values" to this element (an example - "CS Example" - is in the blockedParts section below this one). The preset lists that you can use are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/PresetConcealmentLists.java -->
 				<concealedSlots/> <!-- Use the tag 'slot' for values inserted here. -->
 			</blockedParts>
 		</blockedPartsList>
@@ -123,7 +123,7 @@
 			</blockedParts>
 		</blockedPartsList>
 		
-		<!-- Inventory slots that are incompatible with this clothing. The game's swimsuit makes use of this, and, while fitting into the 'CHEST' slot, also blocks 'GROIN' and 'STOMACH'. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java 
+		<!-- Inventory slots that are incompatible with this clothing. The game's swimsuit makes use of this, and, while fitting into the 'CHEST' slot, also blocks 'GROIN' and 'STOMACH'. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java 
 			- Example: You need to define an "incompatibleSlots" element for each slot that the clothing can be equipped into, so here, I've defined an empty one for "SOCK", and another empty one for "HAND".
 			- Example 2: If you want to add slots, then use the element like so (which would block the FINGER slot when equipped into the WRIST slot): 
 				<incompatibleSlots slot="WRIST">
@@ -232,7 +232,7 @@
 		
 		<!-- These tags determine where in the world your clothing can be found, and what special attributes your clothing should have.
 			There are several ItemTags which start with 'FITS', which are used to check for whether clothing is suitable for certain body parts (such as hoof or wing compatibility).
-			Possible tags are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+			Possible tags are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 		<itemTags> <!-- itemTags without a 'slot' defined will have these tags added to every equippable slot. Should only be used for generic tags like those related to which vendors sell it. -->
 			<tag>NOT_FOR_SALE</tag>
 		</itemTags>
@@ -274,7 +274,7 @@
 	<sexAttributesOther/> <!-- These are the sex attributes applicable to someone who is interacting with the wearer (i.e. the penetration/orifice which is available for people other than the wearer. Mainly used for strap-on dildos.) -->
 	
 	
-	<!-- The following sections are for defining the descriptions of displacing or replacing your clothing. The attribute 'type' defines which DisplacementType your descriptions are applied to. For standard equipping and unequipping, use REMOVE_OR_EQUIP. Types can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
+	<!-- The following sections are for defining the descriptions of displacing or replacing your clothing. The attribute 'type' defines which DisplacementType your descriptions are applied to. For standard equipping and unequipping, use REMOVE_OR_EQUIP. Types can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/DisplacementType.java -->
 	<!-- - Example: This is the equip text for when socks are equipped to the "SOCK" slot:-->
 	<replacementText slot="SOCK" type="REMOVE_OR_EQUIP">
 		<self>

--- a/res/mods/innoxia/items/clothing/template/socks.xml
+++ b/res/mods/innoxia/items/clothing/template/socks.xml
@@ -54,8 +54,8 @@
 			- Example: Socks are most definitely "COMMON", but I've defined these as "LEGENDARY" so as to prevent them from naturally spawning in the game.-->
 		<rarity>LEGENDARY</rarity> 
 		
-		<!-- The set that this clothing belongs to. I will add a way to define your own sets, but for now, existing sets can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingSet.java
-			- Example: These socks have no set. If you want to define one, just use the name of the set like: <clothingSet>BUTLER</clothingSet> -->
+		<!-- For an annotated example on how custom sets are defined, please see the 'res/mods/innoxia/setBonuses/template.xml' file.
+		Alternatively, existing sets can be found in the 'res/setBonuses' folder. -->
 		<clothingSet>innoxia_template</clothingSet>
 		
 		<!-- The file paths for this clothing's image. All images MUST BE .svg format. Colours to be used are described below, above the 'primaryColours' element. I use the free program 'InkScape' to make my .svg images. .svg images scale perfectly up and down to any size, so, while it should be a square, it doesn't really matter what size your canvas is (although I use 256x256 as a personal preference).

--- a/res/mods/innoxia/items/tattoos/heartWomb/heart_womb.xml
+++ b/res/mods/innoxia/items/tattoos/heartWomb/heart_womb.xml
@@ -43,7 +43,7 @@
 		 -->
 		<imageName>heart_womb.svg</imageName> 
 		
-		<!-- Inventory slots that this tattoo can be assigned to. Leave blank to allow all slots to be used. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+		<!-- Inventory slots that this tattoo can be assigned to. Leave blank to allow all slots to be used. Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 		<slotAvailability> 
 			<slot>GROIN</slot>
 		</slotAvailability> 

--- a/res/mods/innoxia/outfits/casualDates/dress_toys.xml
+++ b/res/mods/innoxia/outfits/casualDates/dress_toys.xml
@@ -12,14 +12,14 @@
 		<!-- The femininity needed for someone to generate this outfit. MASCULINE, ANDROGYNOUS, and FEMININE are the three acceptable values. ANDROGYNOUS means anyone can use this outfit, while the other two are self-explanatory.-->
 		<femininity>FEMININE</femininity>
 
-		<!-- The regions in which this outfit may be used for randomly generated characters. You can leave this empty, or delete the element entirely, if you do not want this outfit to be restricted based on WorldRegion (so it can be used anywhere). Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/world/WorldRegion.java -->
+		<!-- The regions in which this outfit may be used for randomly generated characters. You can leave this empty, or delete the element entirely, if you do not want this outfit to be restricted based on WorldRegion (so it can be used anywhere). Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/world/WorldRegion.java -->
 		<!-- If a region is present, the outfit can appear in any WorldType in that region. If there are also worldTypes elements, these will apply in addition to those of the WorldRegion. Only if both types are empty will the outfit apply anywhere. -->
 		<worldRegions>
 			<region>DOMINION</region>
 			<region>SUBMISSION</region>
 		</worldRegions>
 
-		<!-- The worlds (places/maps) in which this outfit may be used for randomly generated characters. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/world/WorldType.java -->
+		<!-- The worlds (places/maps) in which this outfit may be used for randomly generated characters. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/world/WorldType.java -->
 		<worldTypes>
 			<world>DOMINION</world>
 			<world>SUBMISSION</world>
@@ -36,9 +36,9 @@
 		</acceptableLegConfigurations>
 		
 		<!-- The condition that needs to be satisfied for someone to generate this outfit. "npc.hasFetish(FETISH_EXHIBITIONIST)" should probably always be taken into account. This conditional instance does NOT support the "clothingConditionalX" elements.
-		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/GameCharacter.java 
-		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/Game.java
-		And also here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
+		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/GameCharacter.java 
+		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/Game.java
+		And also here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
 		The method "initScriptEngine()" in UtiLText.java shows you what you can get a handle on.-->
 		<conditional><![CDATA[!npc.hasFetish(FETISH_EXHIBITIONIST) && npc.hasFetish(FETISH_MASTURBATION) && npc.getFetishDesire(FETISH_SUBMISSIVE).isPositive()]]></conditional>
 		
@@ -102,14 +102,14 @@
 		
 		<!-- "genericClothingType" elements automatically populate the possible clothing lists with all clothing in the game that satisfies the conditionals.-->
 		<genericClothingType>
-			<itemTags> <!-- If tags are defined, then only clothing with the provided tags will be included for random selection. May be left empty. Accepted values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+			<itemTags> <!-- If tags are defined, then only clothing with the provided tags will be included for random selection. May be left empty. Accepted values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 				<tag>DRESS</tag><!-- All items in the game marked as a "DRESS" will be included for random selection.-->
 			</itemTags>
 			<acceptableFemininities> <!-- If femininities are defined (MASCULINE, ANDROGYNOUS, or FEMININE), then only clothing suitable for this femininity will be included for random selection. -->
 				<femininity>FEMININE</femininity>
 			</acceptableFemininities>
-			<slot/> <!-- If a slot (of type InventorySlot) is defined, then only clothing that fits into this slot will be included for random selection. Use the Enum values as defined in https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
-			<rarity>COMMON</rarity>  <!-- If a rarity is defined, then only clothing that has this rarity will be included for random selection. Accepted values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+			<slot/> <!-- If a slot (of type InventorySlot) is defined, then only clothing that fits into this slot will be included for random selection. Use the Enum values as defined in https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+			<rarity>COMMON</rarity>  <!-- If a rarity is defined, then only clothing that has this rarity will be included for random selection. Accepted values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 			<conditional/> <!-- If a condition is defined, then only clothing that satisfies this condition will be included for random selection. Wrap the conditional statement in CDATA tags if used. -->
 			<primaryColours>
 				<colour>presetColourGroup1</colour>

--- a/res/mods/innoxia/outfits/casualDates/dress_toys.xml
+++ b/res/mods/innoxia/outfits/casualDates/dress_toys.xml
@@ -25,7 +25,7 @@
 			<world>SUBMISSION</world>
 		</worldTypes>
 		
-		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/OutfitType.java -->
+		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/outfit/OutfitType.java -->
 		<outfitTypes>
 		  <type>CASUAL_DATE</type> <!-- At the time of creation (v0.3.0.6), only the MUGGER outfitType is used in the game. All outfit types will be added eventually. -->
 		</outfitTypes>

--- a/res/mods/innoxia/race/hyena/racialBody.xml
+++ b/res/mods/innoxia/race/hyena/racialBody.xml
@@ -130,7 +130,7 @@
 	<breastType>innoxia_hyena_breast</breastType>
 	
 	<!-- The shape which this race's breasts can be.
-	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/BreastShape.java
+	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/valueEnums/BreastShape.java
 	Alternatively, you can leave 'breastShapes' empty and use the boolean attribute 'udderShapes' to automatically select all udder shapes or all non-udder shapes.
 	e.g. Instead of what's defined below, you could use:
 	<breastShapes udderShapes="false"/>

--- a/res/mods/innoxia/setBonuses/template.xml
+++ b/res/mods/innoxia/setBonuses/template.xml
@@ -17,7 +17,7 @@
 	It's usually best to fill out this section with each slot that can be fitted with an item of this set's clothing.
 	As this set only has 1 item in it, this section does nothing (as an item set can only ever be activated with at least 1 item of clothing/weapon equipped), and is just for demonstrative purposes.
 	For  afully-functioning example, please refer to 'res/setBonuses/innoxia/enforcer.xml'
-	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 	<blockedSlotsCountingTowardsFullSet>
 		<slot>SOCK</slot>
 	</blockedSlotsCountingTowardsFullSet>

--- a/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_dress.xml
+++ b/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_dress.xml
@@ -25,9 +25,9 @@
 		</acceptableLegConfigurations>
 		
 		<!-- The condition that needs to be satisfied for someone to generate this outfit. "npc.hasFetish(FETISH_EXHIBITIONIST)" should probably always be taken into account. This conditional instance does NOT support the "clothingConditionalX" elements.
-		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/GameCharacter.java 
-		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/Game.java
-		And also here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
+		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/GameCharacter.java 
+		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/Game.java
+		And also here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
 		The method "initScriptEngine()" in UtiLText.java shows you what you can get a handle on.-->
 		<conditional><![CDATA[npc.hasOccupationTag(OCCUPATION_TAG_ENFORCER_ORICL)]]></conditional>
 		

--- a/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_dress.xml
+++ b/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_dress.xml
@@ -14,7 +14,7 @@
 		
 		<worldTypes/>
 		
-		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/OutfitType.java -->
+		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/outfit/OutfitType.java -->
 		<outfitTypes>
 		  <type>JOB_SMART</type> <!-- At the time of creation (v0.3.0.6), only the MUGGER outfitType is used in the game. All outfit types will be added eventually. -->
 		</outfitTypes>

--- a/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_tactical_heavy.xml
+++ b/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_tactical_heavy.xml
@@ -25,9 +25,9 @@
 		</acceptableLegConfigurations>
 		
 		<!-- The condition that needs to be satisfied for someone to generate this outfit. "npc.hasFetish(FETISH_EXHIBITIONIST)" should probably always be taken into account. This conditional instance does NOT support the "clothingConditionalX" elements.
-		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/GameCharacter.java 
-		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/Game.java
-		And also here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
+		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/GameCharacter.java 
+		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/Game.java
+		And also here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
 		The method "initScriptEngine()" in UtiLText.java shows you what you can get a handle on.-->
 		<conditional><![CDATA[npc.hasOccupationTag(OCCUPATION_TAG_ENFORCER_ORICL)]]></conditional>
 		

--- a/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_tactical_heavy.xml
+++ b/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_tactical_heavy.xml
@@ -14,7 +14,7 @@
 		
 		<worldTypes/>
 		
-		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/OutfitType.java -->
+		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/outfit/OutfitType.java -->
 		<outfitTypes>
 		  <type>JOB_LABOUR</type> <!-- At the time of creation (v0.3.0.6), only the MUGGER outfitType is used in the game. All outfit types will be added eventually. -->
 		</outfitTypes>

--- a/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_tactical_light.xml
+++ b/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_tactical_light.xml
@@ -14,7 +14,7 @@
 		
 		<worldTypes/>
 		
-		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/OutfitType.java -->
+		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/outfit/OutfitType.java -->
 		<outfitTypes>
 		  <type>ATHLETIC</type> <!-- At the time of creation (v0.3.0.6), only the MUGGER outfitType is used in the game. All outfit types will be added eventually. -->
 		</outfitTypes>

--- a/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_tactical_light.xml
+++ b/res/outfits/dsg/enforcerOricl/enf_dominion_oricl_tactical_light.xml
@@ -25,9 +25,9 @@
 		</acceptableLegConfigurations>
 		
 		<!-- The condition that needs to be satisfied for someone to generate this outfit. "npc.hasFetish(FETISH_EXHIBITIONIST)" should probably always be taken into account. This conditional instance does NOT support the "clothingConditionalX" elements.
-		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/GameCharacter.java 
-		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/Game.java
-		And also here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
+		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/GameCharacter.java 
+		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/Game.java
+		And also here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
 		The method "initScriptEngine()" in UtiLText.java shows you what you can get a handle on.-->
 		<conditional><![CDATA[npc.hasOccupationTag(OCCUPATION_TAG_ENFORCER_ORICL)]]></conditional>
 		

--- a/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_dress.xml
+++ b/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_dress.xml
@@ -25,9 +25,9 @@
 		</acceptableLegConfigurations>
 		
 		<!-- The condition that needs to be satisfied for someone to generate this outfit. "npc.hasFetish(FETISH_EXHIBITIONIST)" should probably always be taken into account. This conditional instance does NOT support the "clothingConditionalX" elements.
-		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/GameCharacter.java 
-		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/Game.java
-		And also here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
+		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/GameCharacter.java 
+		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/Game.java
+		And also here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
 		The method "initScriptEngine()" in UtiLText.java shows you what you can get a handle on.-->
 		<conditional><![CDATA[npc.hasOccupationTag(OCCUPATION_TAG_ENFORCER_PATROL)]]></conditional>
 		

--- a/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_dress.xml
+++ b/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_dress.xml
@@ -14,7 +14,7 @@
 		
 		<worldTypes/>
 		
-		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/OutfitType.java -->
+		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/outfit/OutfitType.java -->
 		<outfitTypes>
 		  <type>JOB_SMART</type> <!-- At the time of creation (v0.3.0.6), only the MUGGER outfitType is used in the game. All outfit types will be added eventually. -->
 		</outfitTypes>

--- a/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_patrol.xml
+++ b/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_patrol.xml
@@ -14,7 +14,7 @@
 		
 		<worldTypes/>
 		
-		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/OutfitType.java -->
+		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/outfit/OutfitType.java -->
 		<outfitTypes>
 		  <type>ATHLETIC</type> <!-- At the time of creation (v0.3.0.6), only the MUGGER outfitType is used in the game. All outfit types will be added eventually. -->
 		</outfitTypes>

--- a/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_patrol.xml
+++ b/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_patrol.xml
@@ -28,9 +28,9 @@
 		</acceptableLegConfigurations>
 		
 		<!-- The condition that needs to be satisfied for someone to generate this outfit. "npc.hasFetish(FETISH_EXHIBITIONIST)" should probably always be taken into account. This conditional instance does NOT support the "clothingConditionalX" elements.
-		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/GameCharacter.java 
-		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/Game.java
-		And also here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
+		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/GameCharacter.java 
+		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/Game.java
+		And also here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
 		The method "initScriptEngine()" in UtiLText.java shows you what you can get a handle on.-->
 		<conditional><![CDATA[npc.hasOccupationTag(OCCUPATION_TAG_ENFORCER_PATROL)]]></conditional>
 		

--- a/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_riot.xml
+++ b/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_riot.xml
@@ -25,9 +25,9 @@
 		</acceptableLegConfigurations>
 		
 		<!-- The condition that needs to be satisfied for someone to generate this outfit. "npc.hasFetish(FETISH_EXHIBITIONIST)" should probably always be taken into account. This conditional instance does NOT support the "clothingConditionalX" elements.
-		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/GameCharacter.java 
-		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/Game.java
-		And also here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
+		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/GameCharacter.java 
+		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/Game.java
+		And also here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
 		The method "initScriptEngine()" in UtiLText.java shows you what you can get a handle on.-->
 		<conditional><![CDATA[npc.hasOccupationTag(OCCUPATION_TAG_ENFORCER_PATROL)]]></conditional>
 		

--- a/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_riot.xml
+++ b/res/outfits/dsg/enforcerPatrol/enf_dominion_patrol_riot.xml
@@ -14,7 +14,7 @@
 		
 		<worldTypes/>
 		
-		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/OutfitType.java -->
+		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/outfit/OutfitType.java -->
 		<outfitTypes>
 		  <type>JOB_LABOUR</type> <!-- At the time of creation (v0.3.0.6), only the MUGGER outfitType is used in the game. All outfit types will be added eventually. -->
 		</outfitTypes>

--- a/res/outfits/dsg/enforcerSword/enf_dominion_sword_dress.xml
+++ b/res/outfits/dsg/enforcerSword/enf_dominion_sword_dress.xml
@@ -25,9 +25,9 @@
 		</acceptableLegConfigurations>
 		
 		<!-- The condition that needs to be satisfied for someone to generate this outfit. "npc.hasFetish(FETISH_EXHIBITIONIST)" should probably always be taken into account. This conditional instance does NOT support the "clothingConditionalX" elements.
-		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/GameCharacter.java 
-		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/Game.java
-		And also here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
+		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/GameCharacter.java 
+		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/Game.java
+		And also here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
 		The method "initScriptEngine()" in UtiLText.java shows you what you can get a handle on.-->
 		<conditional><![CDATA[npc.hasOccupationTag(OCCUPATION_TAG_ENFORCER_SWORD)]]></conditional>
 		

--- a/res/outfits/dsg/enforcerSword/enf_dominion_sword_dress.xml
+++ b/res/outfits/dsg/enforcerSword/enf_dominion_sword_dress.xml
@@ -14,7 +14,7 @@
 		
 		<worldTypes/>
 		
-		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/OutfitType.java -->
+		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/outfit/OutfitType.java -->
 		<outfitTypes>
 		  <type>JOB_SMART</type> <!-- At the time of creation (v0.3.0.6), only the MUGGER outfitType is used in the game. All outfit types will be added eventually. -->
 		</outfitTypes>

--- a/res/outfits/dsg/enforcerSword/enf_dominion_sword_tactical_heavy.xml
+++ b/res/outfits/dsg/enforcerSword/enf_dominion_sword_tactical_heavy.xml
@@ -24,9 +24,9 @@
 		</acceptableLegConfigurations>
 		
 		<!-- The condition that needs to be satisfied for someone to generate this outfit. "npc.hasFetish(FETISH_EXHIBITIONIST)" should probably always be taken into account. This conditional instance does NOT support the "clothingConditionalX" elements.
-		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/GameCharacter.java 
-		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/Game.java
-		And also here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
+		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/GameCharacter.java 
+		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/Game.java
+		And also here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
 		The method "initScriptEngine()" in UtiLText.java shows you what you can get a handle on.-->
 		<conditional><![CDATA[npc.hasOccupationTag(OCCUPATION_TAG_ENFORCER_SWORD)]]></conditional>
 		

--- a/res/outfits/dsg/enforcerSword/enf_dominion_sword_tactical_heavy.xml
+++ b/res/outfits/dsg/enforcerSword/enf_dominion_sword_tactical_heavy.xml
@@ -13,7 +13,7 @@
 		<femininity>ANDROGYNOUS</femininity>
 		
 		<worldTypes/>
-		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/OutfitType.java -->
+		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/outfit/OutfitType.java -->
 		<outfitTypes>
 		  <type>JOB_LABOUR</type> <!-- At the time of creation (v0.3.0.6), only the MUGGER outfitType is used in the game. All outfit types will be added eventually. -->
 		</outfitTypes>

--- a/res/outfits/dsg/enforcerSword/enf_dominion_sword_tactical_light.xml
+++ b/res/outfits/dsg/enforcerSword/enf_dominion_sword_tactical_light.xml
@@ -25,9 +25,9 @@
 		</acceptableLegConfigurations>
 		
 		<!-- The condition that needs to be satisfied for someone to generate this outfit. "npc.hasFetish(FETISH_EXHIBITIONIST)" should probably always be taken into account. This conditional instance does NOT support the "clothingConditionalX" elements.
-		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/character/GameCharacter.java 
-		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/Game.java
-		And also here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
+		Accepted method calls for the "npc" can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/GameCharacter.java 
+		Accepted method calls for the main game (using the "game" tag) can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/Game.java
+		And also here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/dialogue/utils/UtilText.java 
 		The method "initScriptEngine()" in UtiLText.java shows you what you can get a handle on.-->
 		<conditional><![CDATA[npc.hasOccupationTag(OCCUPATION_TAG_ENFORCER_SWORD)]]></conditional>
 		

--- a/res/outfits/dsg/enforcerSword/enf_dominion_sword_tactical_light.xml
+++ b/res/outfits/dsg/enforcerSword/enf_dominion_sword_tactical_light.xml
@@ -14,7 +14,7 @@
 		
 		<worldTypes/>
 		
-		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/OutfitType.java -->
+		<!-- Outfit types that this outfit can be used in. For a list of acceptable OutfitTypes, consult: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/outfit/OutfitType.java -->
 		<outfitTypes>
 		  <type>ATHLETIC</type> <!-- At the time of creation (v0.3.0.6), only the MUGGER outfitType is used in the game. All outfit types will be added eventually. -->
 		</outfitTypes>

--- a/res/race/dsg/bear/racialBody.xml
+++ b/res/race/dsg/bear/racialBody.xml
@@ -126,7 +126,7 @@
 	<breastType>dsg_bear_breast</breastType>
 	
 	<!-- The shape which this race's breasts can be.
-	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/BreastShape.java
+	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/valueEnums/BreastShape.java
 	Alternatively, you can leave 'breastShapes' empty and use the boolean attribute 'udderShapes' to automatically select all udder shapes or all non-udder shapes.
 	e.g. Instead of what's defined below, you could use:
 	<breastShapes udderShapes="false"/>

--- a/res/race/dsg/dragon/bodyParts/wing.xml
+++ b/res/race/dsg/dragon/bodyParts/wing.xml
@@ -4,7 +4,7 @@
 	
 	<!-- IMPORTANT!!!
 	Instead of making a new wing type, you should almost certainly be using the pre-defined wing types FEATHERED or LEATHERY
-	These can be seen here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/yypes/WingType.java -->
+	These can be seen here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/WingType.java -->
 	
 	<!-- If you want to see the part of the code where this type is defined, then please look here:
 	https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractWingType.java -->

--- a/res/race/dsg/dragon/bodyParts/wingFeathered.xml
+++ b/res/race/dsg/dragon/bodyParts/wingFeathered.xml
@@ -4,7 +4,7 @@
 	
 	<!-- IMPORTANT!!!
 	Instead of making a new wing type, you should almost certainly be using the pre-defined wing types FEATHERED or LEATHERY
-	These can be seen here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/yypes/WingType.java -->
+	These can be seen here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/WingType.java -->
 	
 	<!-- If you want to see the part of the code where this type is defined, then please look here:
 	https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractWingType.java -->

--- a/res/race/dsg/dragon/racialBody.xml
+++ b/res/race/dsg/dragon/racialBody.xml
@@ -124,7 +124,7 @@
 	<breastType>dsg_dragon_breast</breastType>
 	
 	<!-- The shape which this race's breasts can be.
-	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/BreastShape.java
+	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/valueEnums/BreastShape.java
 	Alternatively, you can leave 'breastShapes' empty and use the boolean attribute 'udderShapes' to automatically select all udder shapes or all non-udder shapes.
 	e.g. Instead of what's defined below, you could use:
 	<breastShapes udderShapes="false"/>

--- a/res/race/dsg/ferret/racialBody.xml
+++ b/res/race/dsg/ferret/racialBody.xml
@@ -122,7 +122,7 @@
 	<breastType>dsg_ferret_breast</breastType>
 	
 	<!-- The shape which this race's breasts can be.
-	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/BreastShape.java
+	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/valueEnums/BreastShape.java
 	Alternatively, you can leave 'breastShapes' empty and use the boolean attribute 'udderShapes' to automatically select all udder shapes or all non-udder shapes.
 	e.g. Instead of what's defined below, you could use:
 	<breastShapes udderShapes="false"/>

--- a/res/race/dsg/gryphon/bodyParts/wing.xml
+++ b/res/race/dsg/gryphon/bodyParts/wing.xml
@@ -4,7 +4,7 @@
 	
 	<!-- IMPORTANT!!!
 	Instead of making a new wing type, you should almost certainly be using the pre-defined wing types FEATHERED or LEATHERY
-	These can be seen here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/yypes/WingType.java -->
+	These can be seen here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/WingType.java -->
 	
 	<!-- If you want to see the part of the code where this type is defined, then please look here:
 	https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/abstractTypes/AbstractWingType.java -->

--- a/res/race/dsg/gryphon/racialBody.xml
+++ b/res/race/dsg/gryphon/racialBody.xml
@@ -124,7 +124,7 @@
 	<breastType>dsg_gryphon_breast</breastType>
 	
 	<!-- The shape which this race's breasts can be.
-	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/BreastShape.java
+	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/valueEnums/BreastShape.java
 	Alternatively, you can leave 'breastShapes' empty and use the boolean attribute 'udderShapes' to automatically select all udder shapes or all non-udder shapes.
 	e.g. Instead of what's defined below, you could use:
 	<breastShapes udderShapes="false"/>

--- a/res/race/dsg/otter/racialBody.xml
+++ b/res/race/dsg/otter/racialBody.xml
@@ -122,7 +122,7 @@
 	<breastType>dsg_otter_breast</breastType>
 	
 	<!-- The shape which this race's breasts can be.
-	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/BreastShape.java
+	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/valueEnums/BreastShape.java
 	Alternatively, you can leave 'breastShapes' empty and use the boolean attribute 'udderShapes' to automatically select all udder shapes or all non-udder shapes.
 	e.g. Instead of what's defined below, you could use:
 	<breastShapes udderShapes="false"/>

--- a/res/race/dsg/raccoon/racialBody.xml
+++ b/res/race/dsg/raccoon/racialBody.xml
@@ -123,7 +123,7 @@
 	<breastType>dsg_raccoon_breast</breastType>
 	
 	<!-- The shape which this race's breasts can be.
-	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/BreastShape.java
+	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/valueEnums/BreastShape.java
 	Alternatively, you can leave 'breastShapes' empty and use the boolean attribute 'udderShapes' to automatically select all udder shapes or all non-udder shapes.
 	e.g. Instead of what's defined below, you could use:
 	<breastShapes udderShapes="false"/>

--- a/res/race/dsg/shark/racialBody.xml
+++ b/res/race/dsg/shark/racialBody.xml
@@ -123,7 +123,7 @@
 	<breastType>dsg_shark_breast</breastType>
 	
 	<!-- The shape which this race's breasts can be.
-	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/BreastShape.java
+	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/valueEnums/BreastShape.java
 	Alternatively, you can leave 'breastShapes' empty and use the boolean attribute 'udderShapes' to automatically select all udder shapes or all non-udder shapes.
 	e.g. Instead of what's defined below, you could use:
 	<breastShapes udderShapes="false"/>

--- a/res/race/mintychip/salamander/racialBody.xml
+++ b/res/race/mintychip/salamander/racialBody.xml
@@ -125,7 +125,7 @@
 	<breastType>mintychip_salamander_breast</breastType>
 	
 	<!-- The shape which this race's breasts can be.
-	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/types/BreastShape.java
+	You can define shapes individually, as shown below, using values from this list: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/character/body/valueEnums/BreastShape.java
 	Alternatively, you can leave 'breastShapes' empty and use the boolean attribute 'udderShapes' to automatically select all udder shapes or all non-udder shapes.
 	e.g. Instead of what's defined below, you could use:
 	<breastShapes udderShapes="false"/>

--- a/res/setBonuses/dsg/enforcer_patrol.xml
+++ b/res/setBonuses/dsg/enforcer_patrol.xml
@@ -17,7 +17,7 @@
 	It's usually best to fill out this section with each slot that can be fitted with an item of this set's clothing.
 	As this set only has 1 item in it, this section does nothing (as an item set can only ever be activated with at least 1 item of clothing/weapon equipped), and is just for demonstrative purposes.
 	For  afully-functioning example, please refer to 'res/setBonuses/innoxia/enforcer.xml'
-	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 	<blockedSlotsCountingTowardsFullSet>
 		<slot>TORSO_OVER</slot>
 		<slot>HIPS</slot>

--- a/res/setBonuses/dsg/enforcer_riot.xml
+++ b/res/setBonuses/dsg/enforcer_riot.xml
@@ -17,7 +17,7 @@
 	It's usually best to fill out this section with each slot that can be fitted with an item of this set's clothing.
 	As this set only has 1 item in it, this section does nothing (as an item set can only ever be activated with at least 1 item of clothing/weapon equipped), and is just for demonstrative purposes.
 	For  afully-functioning example, please refer to 'res/setBonuses/innoxia/enforcer.xml'
-	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 	<blockedSlotsCountingTowardsFullSet>
 		<slot>TORSO_OVER</slot>
 		<slot>HIPS</slot>

--- a/res/setBonuses/dsg/enforcer_service.xml
+++ b/res/setBonuses/dsg/enforcer_service.xml
@@ -17,7 +17,7 @@
 	It's usually best to fill out this section with each slot that can be fitted with an item of this set's clothing.
 	As this set only has 1 item in it, this section does nothing (as an item set can only ever be activated with at least 1 item of clothing/weapon equipped), and is just for demonstrative purposes.
 	For  afully-functioning example, please refer to 'res/setBonuses/innoxia/enforcer.xml'
-	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 	<blockedSlotsCountingTowardsFullSet>
 		<slot>TORSO_OVER</slot>
 		<slot>LEG</slot>

--- a/res/setBonuses/dsg/enforcer_tactical_heavy.xml
+++ b/res/setBonuses/dsg/enforcer_tactical_heavy.xml
@@ -17,7 +17,7 @@
 	It's usually best to fill out this section with each slot that can be fitted with an item of this set's clothing.
 	As this set only has 1 item in it, this section does nothing (as an item set can only ever be activated with at least 1 item of clothing/weapon equipped), and is just for demonstrative purposes.
 	For  afully-functioning example, please refer to 'res/setBonuses/innoxia/enforcer.xml'
-	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 	<blockedSlotsCountingTowardsFullSet>
 		<slot>TORSO_OVER</slot>
 		<slot>HIPS</slot>

--- a/res/setBonuses/dsg/enforcer_tactical_light.xml
+++ b/res/setBonuses/dsg/enforcer_tactical_light.xml
@@ -17,7 +17,7 @@
 	It's usually best to fill out this section with each slot that can be fitted with an item of this set's clothing.
 	As this set only has 1 item in it, this section does nothing (as an item set can only ever be activated with at least 1 item of clothing/weapon equipped), and is just for demonstrative purposes.
 	For  afully-functioning example, please refer to 'res/setBonuses/innoxia/enforcer.xml'
-	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
+	Possible slots are found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/InventorySlot.java -->
 	<blockedSlotsCountingTowardsFullSet>
 		<slot>TORSO_OVER</slot>
 		<slot>HIPS</slot>

--- a/res/sex/innoxia/managers/meraxis/duel/masturbation.xml
+++ b/res/sex/innoxia/managers/meraxis/duel/masturbation.xml
@@ -30,7 +30,7 @@
 		OrgasmBehaviours: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/sex/managers/OrgasmBehaviour.java
 		OrgasmCumTargets: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/sex/OrgasmCumTarget.java
 		ResponseTags: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/dialogue/responses/ResponseTag.java
-		SexActions (you can see how ids are generated in this class): https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/sex/SexActions/SexActionManager.java
+		SexActions (you can see how ids are generated in this class): https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/sex/sexActions/SexActionManager.java
 		SexAreaOrifices (should be prefaced with 'ORIFICE_'): https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/sex/SexAreaOrifice.java
 		SexAreaPenetrations (should be prefaced with 'PENETRATION_'): https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/sex/SexAreaPenetration.java
 		SexControls: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/sex/SexControl.java

--- a/res/weapons/innoxia/arcanistStaff/arcanist_staff.xml
+++ b/res/weapons/innoxia/arcanistStaff/arcanist_staff.xml
@@ -31,7 +31,7 @@
 		As this tooltip is only ever seen from the player's perspective, you can always write in the first-person narrative. (Still use npc2 for the target, though.)-->
 		<attackTooltipDescription>Whack [npc2.name] with your staff.</attackTooltipDescription>
 		
-		<!-- The rarity of this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+		<!-- The rarity of this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 		<rarity>RARE</rarity> 
 		
 		<!-- The description that's used when equipping this weapon. The description should be generic, able to be used by both the player and NPCs. Just make sure to use the tag "[npc.verb()]" whenever using a verb, which will then, for example, parse like this:
@@ -58,10 +58,10 @@
 		<!-- How many arcane essences are required, and drained, by firing this weapon. Ranged weapons should usually use the value 1, while melee weapons should usually be 0. -->
 		<arcaneCost>0</arcaneCost> 
 		
-		<!-- The variance in base damage when this weapon is actually used to attack. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/combat/DamageVariance.java -->
+		<!-- The variance in base damage when this weapon is actually used to attack. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/DamageVariance.java -->
 		<damageVariance>MEDIUM</damageVariance> 
 		
-		<!-- The available damage types that this weapon can spawn in with. Values can be found here (MISC should not be used): https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/combat/DamageType.java -->
+		<!-- The available damage types that this weapon can spawn in with. Values can be found here (MISC should not be used): https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/DamageType.java -->
 		<availableDamageTypes>
 			<damageType>PHYSICAL</damageType>
 			<damageType>ICE</damageType>
@@ -74,7 +74,7 @@
 			<spell>FIREBALL</spell>
 		</spells>
 		
-		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/combat/Spell.java -->
+		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/Spell.java -->
 		<spells/>
 		
 		<!-- The effects that this weapon spawns in with. Remember that the player can remove/change/add effects. To know what to put in here, it would probably be easiest to enchant clothing in your game, save the game, then copy over that clothing's 'effects' in your save file.
@@ -116,7 +116,7 @@
 		<secondaryColours/> 
 		<secondaryColoursDye/>
 		
-		<!-- Special item tags that apply to this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<!-- Special item tags that apply to this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 		<itemTags/>
 		
 	</coreAttributes>

--- a/res/weapons/innoxia/arcanistStaff/arcanist_staff.xml
+++ b/res/weapons/innoxia/arcanistStaff/arcanist_staff.xml
@@ -74,7 +74,7 @@
 			<spell>FIREBALL</spell>
 		</spells>
 		
-		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/Spell.java -->
+		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/spells/Spell.java -->
 		<spells/>
 		
 		<!-- The effects that this weapon spawns in with. Remember that the player can remove/change/add effects. To know what to put in here, it would probably be easiest to enchant clothing in your game, save the game, then copy over that clothing's 'effects' in your save file.

--- a/res/weapons/innoxia/dagger/dagger.xml
+++ b/res/weapons/innoxia/dagger/dagger.xml
@@ -146,8 +146,8 @@
 			<move damageType="FIRE">EXAMPLE_MOVE_4</move>
 		...
 		
-		Values for combat moves can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/CMWeaponSpecials.java
-		There will be a way to add modded combat moves soon! -->
+		Values for combat moves can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/moves/CMWeaponSpecials.java
+		For an annotated example on how custom combat moves are defined, please see the 'res/mods/innoxia/combatMove/hyena_bone_crush.xml' file. -->
 		<combatMoves/>
 		
 		<!-- The effects that this weapon spawns in with. Remember that the player can remove/change/add effects. To know what to put in here, it would probably be easiest to enchant a weapon in your game, save the game, then copy over that weapon's 'effects' in your save file.

--- a/res/weapons/innoxia/dagger/dagger.xml
+++ b/res/weapons/innoxia/dagger/dagger.xml
@@ -127,7 +127,7 @@
 		...
 		Note that the damageType does not have to correspond to the spell's school (so FIRE can unlock ICE_SHARD, etc.).
 		
-		Values for spells can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/Spell.java -->
+		Values for spells can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/spells/Spell.java -->
 		<spells/>
 		
 		<!-- The combat moves that are unlocked when equipping this weapon. IF you want to add any, use the format:

--- a/res/weapons/innoxia/dagger/dagger.xml
+++ b/res/weapons/innoxia/dagger/dagger.xml
@@ -59,7 +59,7 @@
 		<!-- The rarity of this weapon.
 			You should likely leave this as COMMON, as the game automatically varies the rarity of COMMON items based on their enchantments and whether or not they're part of a set.
 			If you define a rarity other than COMMON, then your defined rarity will always be the same for this weapon no matter what enchantments it has.
-			Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+			Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 		<rarity>COMMON</rarity>
 		
 		<!-- What set this weapon is a part of. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingSet.java -->

--- a/res/weapons/innoxia/dagger/dagger.xml
+++ b/res/weapons/innoxia/dagger/dagger.xml
@@ -62,7 +62,8 @@
 			Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 		<rarity>COMMON</rarity>
 		
-		<!-- What set this weapon is a part of. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/clothing/ClothingSet.java -->
+		<!-- For an annotated example on how custom sets are defined, please see the 'res/mods/innoxia/setBonuses/template.xml' file.
+		Alternatively, existing sets can be found in the 'res/setBonuses' folder. -->
 		<weaponSet/> 
 		
 		<!-- The description that's used when equipping this weapon. The description should be generic, able to be used by both the player and NPCs. Just make sure to use the tag "[npc.verb()]" whenever using a verb, which will then, for example, parse like this:

--- a/res/weapons/innoxia/pipe/pipe.xml
+++ b/res/weapons/innoxia/pipe/pipe.xml
@@ -74,7 +74,7 @@
 			<spell>FIREBALL</spell>
 		</spells>
 		
-		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/Spell.java -->
+		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/spells/Spell.java -->
 		<spells/>
 		
 		<!-- The effects that this weapon spawns in with. Remember that the player can remove/change/add effects. To know what to put in here, it would probably be easiest to enchant clothing in your game, save the game, then copy over that clothing's 'effects' in your save file.

--- a/res/weapons/innoxia/pipe/pipe.xml
+++ b/res/weapons/innoxia/pipe/pipe.xml
@@ -31,7 +31,7 @@
 		As this tooltip is only ever seen from the player's perspective, you can always write in the first-person narrative. (Still use npc2 for the target, though.)-->
 		<attackTooltipDescription>Whack [npc2.name] with your metal pipe.</attackTooltipDescription>
 		
-		<!-- The rarity of this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+		<!-- The rarity of this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 		<rarity>COMMON</rarity> 
 		
 		<!-- The description that's used when equipping this weapon. The description should be generic, able to be used by both the player and NPCs. Just make sure to use the tag "[npc.verb()]" whenever using a verb, which will then, for example, parse like this:
@@ -58,10 +58,10 @@
 		<!-- How many arcane essences are required, and drained, by firing this weapon. Ranged weapons should usually use the value 1, while melee weapons should usually be 0. -->
 		<arcaneCost>0</arcaneCost> 
 		
-		<!-- The variance in base damage when this weapon is actually used to attack. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/combat/DamageVariance.java -->
+		<!-- The variance in base damage when this weapon is actually used to attack. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/DamageVariance.java -->
 		<damageVariance>MEDIUM</damageVariance> 
 		
-		<!-- The available damage types that this weapon can spawn in with. Values can be found here (MISC should not be used): https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/combat/DamageType.java -->
+		<!-- The available damage types that this weapon can spawn in with. Values can be found here (MISC should not be used): https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/DamageType.java -->
 		<availableDamageTypes>
 			<damageType>PHYSICAL</damageType>
 			<damageType>ICE</damageType>
@@ -74,7 +74,7 @@
 			<spell>FIREBALL</spell>
 		</spells>
 		
-		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/combat/Spell.java -->
+		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/Spell.java -->
 		<spells/>
 		
 		<!-- The effects that this weapon spawns in with. Remember that the player can remove/change/add effects. To know what to put in here, it would probably be easiest to enchant clothing in your game, save the game, then copy over that clothing's 'effects' in your save file.
@@ -112,7 +112,7 @@
 		<secondaryColours/> 
 		<secondaryColoursDye/>
 		
-		<!-- Special item tags that apply to this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<!-- Special item tags that apply to this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 		<itemTags> 
 			<tag>SUBMISSION_TUNNEL_SPAWN</tag>
 			<tag>DOMINION_ALLEYWAY_SPAWN</tag>

--- a/res/weapons/innoxia/shield/crude_wooden.xml
+++ b/res/weapons/innoxia/shield/crude_wooden.xml
@@ -31,7 +31,7 @@
 		As this tooltip is only ever seen from the player's perspective, you can always write in the first-person narrative. (Still use npc2 for the target, though.)-->
 		<attackTooltipDescription>Bash [npc2.name] with your crude shield.</attackTooltipDescription>
 		
-		<!-- The rarity of this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/Rarity.java -->
+		<!-- The rarity of this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/Rarity.java -->
 		<rarity>COMMON</rarity> 
 		
 		<!-- The description that's used when equipping this weapon. The description should be generic, able to be used by both the player and NPCs. Just make sure to use the tag "[npc.verb()]" whenever using a verb, which will then, for example, parse like this:
@@ -61,10 +61,10 @@
 		<!-- How many arcane essences are required, and drained, by firing this weapon. Ranged weapons should usually use the value 1, while melee weapons should usually be 0. -->
 		<arcaneCost>0</arcaneCost> 
 		
-		<!-- The variance in base damage when this weapon is actually used to attack. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/combat/DamageVariance.java -->
+		<!-- The variance in base damage when this weapon is actually used to attack. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/DamageVariance.java -->
 		<damageVariance>LOW</damageVariance> 
 		
-		<!-- The available damage types that this weapon can spawn in with. Values can be found here (MISC should not be used): https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/combat/DamageType.java -->
+		<!-- The available damage types that this weapon can spawn in with. Values can be found here (MISC should not be used): https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/DamageType.java -->
 		<availableDamageTypes>
 			<damageType>PHYSICAL</damageType>
 			<damageType>ICE</damageType>
@@ -77,7 +77,7 @@
 			<spell>FIREBALL</spell>
 		</spells>
 		
-		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/combat/Spell.java -->
+		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/Spell.java -->
 		<spells/>
 		
 		<!-- The effects that this weapon spawns in with. Remember that the player can remove/change/add effects. To know what to put in here, it would probably be easiest to enchant clothing in your game, save the game, then copy over that clothing's 'effects' in your save file.
@@ -121,7 +121,7 @@
 		<secondaryColours values = "JUST_STEEL"/> 
 		<secondaryColoursDye values="ALL_METAL"/>
 		
-		<!-- Special item tags that apply to this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/master/src/com/lilithsthrone/game/inventory/ItemTag.java -->
+		<!-- Special item tags that apply to this weapon. Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/inventory/ItemTag.java -->
 		<itemTags/>
 		
 	</coreAttributes>

--- a/res/weapons/innoxia/shield/crude_wooden.xml
+++ b/res/weapons/innoxia/shield/crude_wooden.xml
@@ -77,7 +77,7 @@
 			<spell>FIREBALL</spell>
 		</spells>
 		
-		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/Spell.java -->
+		Values can be found here: https://github.com/Innoxia/liliths-throne-public/blob/dev/src/com/lilithsthrone/game/combat/spells/Spell.java -->
 		<spells/>
 		
 		<!-- The effects that this weapon spawns in with. Remember that the player can remove/change/add effects. To know what to put in here, it would probably be easiest to enchant clothing in your game, save the game, then copy over that clothing's 'effects' in your save file.


### PR DESCRIPTION
### What is the purpose of the pull request?
The aim of this PR is to fix all of the broken URLs in the repository. This consists of two types of changes.

Firstly, all of the GitHub URLs found in various parts of the `res` folder have been updated to point to the new default branch (`dev` rather than `master`) if they didn't already. As `master` is no longer being updated, the files these URLs lead to are sometimes out of date, which can be misleading for those using them.

Secondly, after converting all `master` links to `dev` links, any URLs that either responded with a 404 error or didn't respond at all have been corrected where reasonable.

### Give a brief description of what you changed or added.
- Every instance of a URL beginning with `https://github.com/Innoxia/liliths-throne-public/blob/master/` was altered to instead begin with `https://github.com/Innoxia/liliths-throne-public/blob/dev/`.
- Almost every URL that gave a 404 response or no response at all has been corrected.

### Are any new graphical assets required?
No, this doesn't require any new graphical assets.

### Has this change been tested? If so, mention the version number that the test was based on.
This PR only changes comments, not code. I have, however, verified that the game still functions with these changes on version 0.4.7 of the game (specifically commit 4e645da98afdd6189f4eb52d46f04e3391e4f58f).

### So we have a better idea of who you are, what is your Discord Handle?
NoHornyOnMain#5417