### PR TITLE
Bump pom.xml version tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>innoxia</groupId>
 	<artifactId>lilithsthrone</artifactId>
 	<packaging>jar</packaging>
-	<version>0.4.6.3</version>
+	<version>0.4.7</version>
 	<name>Lilith's Throne</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
I've updated the pom.xml version number to 0.4.7, the number of the current public release.

Should the version tag in pom.xml be bumped for each version?  If so, this PR does it for this release but it should be added to the release process for each version moving forward.  I only noticed when I built it from source myself and it output Lilith's Throne-0.4.6.3.jar.