### PR TITLE
Seal removal tweak

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Lab.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Lab.java
@@ -389,16 +389,16 @@ public class Lab {
 		}
 		
 		if(Main.game.getPlayer().isQuestCompleted(QuestLine.SIDE_ENCHANTMENT_DISCOVERY)
-				&& Main.game.getPlayer().getClothingCurrentlyEquipped().stream().anyMatch(c -> c.isSelfTransformationInhibiting())
-				&& Main.game.getPlayer().getClothingCurrentlyEquipped().stream().anyMatch(c -> c.isSealed())) {
+				&& Main.game.getPlayer().getClothingCurrentlyEquipped().stream().anyMatch(c -> (c.isSelfTransformationInhibiting() && c.isSealed()))
 			generatedResponses.add(new Response("Sealed problem",
 					"Tell Lilaya that you have some enchanted clothing sealed onto you, and that due to another enchantment on some of your clothing, you cannot remove it."
-							+ "<br/>[style.italicsMinorGood(Lilaya will unseal all your clothing!)]",
+							+ "<br/>[style.italicsMinorGood(Lilaya will unseal all of your sealed servitude clothing!)]",
 						LAB_JINX_REMOVAL){
 				@Override
 				public void effects() {
 					for(AbstractClothing clothing : new ArrayList<>(Main.game.getPlayer().getClothingCurrentlyEquipped())) {
-						clothing.setSealed(false);
+						if(clothing.isSealed()) && (clothing.isSelfTransformationInhibiting()):
+							clothing.setSealed(false);
 					}
 				}
 			});

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Lab.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Lab.java
@@ -397,8 +397,9 @@ public class Lab {
 				@Override
 				public void effects() {
 					for(AbstractClothing clothing : new ArrayList<>(Main.game.getPlayer().getClothingCurrentlyEquipped())) {
-						if(clothing.isSealed()) && (clothing.isSelfTransformationInhibiting()):
+						if(clothing.isSealed()) && (clothing.isSelfTransformationInhibiting()) {
 							clothing.setSealed(false);
+						}
 					}
 				}
 			});

--- a/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Lab.java
+++ b/src/com/lilithsthrone/game/dialogue/places/dominion/lilayashome/Lab.java
@@ -389,7 +389,7 @@ public class Lab {
 		}
 		
 		if(Main.game.getPlayer().isQuestCompleted(QuestLine.SIDE_ENCHANTMENT_DISCOVERY)
-				&& Main.game.getPlayer().getClothingCurrentlyEquipped().stream().anyMatch(c -> (c.isSelfTransformationInhibiting() && c.isSealed()))
+				&& Main.game.getPlayer().getClothingCurrentlyEquipped().stream().anyMatch(c -> (c.isSelfTransformationInhibiting() && c.isSealed())) {
 			generatedResponses.add(new Response("Sealed problem",
 					"Tell Lilaya that you have some enchanted clothing sealed onto you, and that due to another enchantment on some of your clothing, you cannot remove it."
 							+ "<br/>[style.italicsMinorGood(Lilaya will unseal all of your sealed servitude clothing!)]",


### PR DESCRIPTION
Simple tweak to make the seal removal system somewhat less exploitable by making it so creating clothing with servitude + seal on it doesn't give the player a free pass to get out of all bound items.

Pretty self explanatory. Change has not been tested because I don't have a Java environment set up to do it. Discord tag is Siev#4561 if you wanna yell at me for doing it wrong, my Java is very rusty =p
