### PR TITLE
Bugfix: intermittent failure on "New Game"

### DIFF
--- a/src/com/lilithsthrone/world/Generation.java
+++ b/src/com/lilithsthrone/world/Generation.java
@@ -34,7 +34,12 @@ public class Generation extends Task<Boolean> {
 			if (debug) {
 				System.out.println(wt);
 			}
-			Main.game.getWorlds().put(wt, worldGeneration(wt));
+			try {
+				Main.game.getWorlds().put(wt, worldGeneration(wt));
+			} catch (Exception e) {
+				System.err.println("Exception while generating world type! " + wt.getId());
+				e.printStackTrace(System.err);
+			}
 			updateProgress(count.incrementAndGet(), maxSize);
 		});
 		return true;

--- a/src/com/lilithsthrone/world/places/GenericPlace.java
+++ b/src/com/lilithsthrone/world/places/GenericPlace.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.w3c.dom.Document;
@@ -31,25 +32,21 @@ public class GenericPlace implements XMLSaving {
 	private AbstractPlaceType placeType;
 	private Set<AbstractPlaceUpgrade> placeUpgrades;
 	
-	public static Map<AbstractPlaceType, Integer> placeCountMap = new HashMap<>();
+	public static Map<AbstractPlaceType, Integer> placeCountMap = new ConcurrentHashMap<>();
 
 	public GenericPlace(AbstractPlaceType placeType) {
 		this.placeType=placeType;
-		placeUpgrades = new HashSet<>();
-		
-		if(placeCountMap.containsKey(placeType)) {
-			placeCountMap.put(placeType, placeCountMap.get(placeType)+1);
-		} else {
-			placeCountMap.put(placeType, 1);
-		}
+		this.placeUpgrades = new HashSet<>();
 		
 		if(placeType!=null) {
-			if(placeType.getPlaceNameAppendFormat(placeCountMap.get(placeType))!=null && !placeType.getPlaceNameAppendFormat(placeCountMap.get(placeType)).isEmpty()) {
-				this.name = placeType.getName() + placeType.getPlaceNameAppendFormat(placeCountMap.get(placeType));
+			placeCountMap.put(placeType, placeCountMap.getOrDefault(placeType, 0) + 1);
+
+			String placeNameExtra = placeType.getPlaceNameAppendFormat(placeCountMap.get(placeType));
+			if (placeNameExtra != null && !placeNameExtra.isEmpty()) {
+				this.name = placeType.getName() + placeNameExtra;
 			}
-			for(AbstractPlaceUpgrade pu : placeType.getStartingPlaceUpgrades()) {
-				placeUpgrades.add(pu);
-			}
+
+			placeUpgrades.addAll(placeType.getStartingPlaceUpgrades());
 			
 		} else {
 			this.name = "";


### PR DESCRIPTION
A random failure could occur due to the place count map being static, but not thread-safe 

- Switched to concurrent map for place counting
- Moved place counting after null check (necessary for ConcurrentHashMap usage)
- Added try/catch around world type construction (to reveal any other potential errors in the area, while preventing a soft-lock)

Tested on a dev build of the 0.4.7 release
Discord: Phlarx#1765