### PR TITLE
Calculate subspecies weights within race first

### DIFF
--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -828,7 +828,7 @@ public abstract class AbstractSubspecies {
 		
 		int highestWeighting = 0;
 		int newWeighting;
-		// Primary: Look for subspecies within race
+		// Look for subspecies within race
 		for(AbstractSubspecies sub : Subspecies.getSubspeciesOfRace(race)) {
 			newWeighting = sub.getSubspeciesWeighting(body, race);
 			if(newWeighting>highestWeighting
@@ -837,26 +837,13 @@ public abstract class AbstractSubspecies {
 				highestWeighting = newWeighting;
 			}
 		}
-		/*// Backup: Calculate body race from part weighting
-		if(subspecies==null && Main.game.isStarted()) {
-			AbstractRace raceFromPartWeighting = body.getRaceFromPartWeighting();
-			highestWeighting = 0;
-			for(AbstractSubspecies sub : Subspecies.getSubspeciesOfRace(raceFromPartWeighting)) {
-				newWeighting = sub.getSubspeciesWeighting(body, raceFromPartWeighting);
-				if(newWeighting>highestWeighting
-						&& (!body.isFeral() || sub.isFeralConfigurationAvailable())) {
-					subspecies = sub;
-					highestWeighting = newWeighting;
-				}
-			}
-		}*/
-		// Last resort: Search through all subspecies
+		// If that fails, search through all subspecies
 		if(subspecies==null && Main.game.isStarted()) {
 			highestWeighting = 0;
 			for(AbstractSubspecies sub : Subspecies.getAllSubspecies()) {
 				newWeighting = sub.getSubspeciesWeighting(body, race);
 				if(newWeighting>highestWeighting
-						&& (!body.isFeral() || sub.isFeralConfigurationAvailable())) {
+						&& (!body.isFeral() || sub.isFeralConfigurationAvailable(body))) {
 					subspecies = sub;
 					highestWeighting = newWeighting;
 				}

--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -828,12 +828,38 @@ public abstract class AbstractSubspecies {
 		
 		int highestWeighting = 0;
 		int newWeighting;
-		for(AbstractSubspecies sub : Subspecies.getAllSubspecies()) {
+		// Primary: Look for subspecies within race
+		for(AbstractSubspecies sub : Subspecies.getSubspeciesOfRace(race)) {
 			newWeighting = sub.getSubspeciesWeighting(body, race);
 			if(newWeighting>highestWeighting
 					&& (!body.isFeral() || sub.isFeralConfigurationAvailable(body))) {
 				subspecies = sub;
 				highestWeighting = newWeighting;
+			}
+		}
+		/*// Backup: Calculate body race from part weighting
+		if(subspecies==null && Main.game.isStarted()) {
+			AbstractRace raceFromPartWeighting = body.getRaceFromPartWeighting();
+			highestWeighting = 0;
+			for(AbstractSubspecies sub : Subspecies.getSubspeciesOfRace(raceFromPartWeighting)) {
+				newWeighting = sub.getSubspeciesWeighting(body, raceFromPartWeighting);
+				if(newWeighting>highestWeighting
+						&& (!body.isFeral() || sub.isFeralConfigurationAvailable())) {
+					subspecies = sub;
+					highestWeighting = newWeighting;
+				}
+			}
+		}*/
+		// Last resort: Search through all subspecies
+		if(subspecies==null && Main.game.isStarted()) {
+			highestWeighting = 0;
+			for(AbstractSubspecies sub : Subspecies.getAllSubspecies()) {
+				newWeighting = sub.getSubspeciesWeighting(body, race);
+				if(newWeighting>highestWeighting
+						&& (!body.isFeral() || sub.isFeralConfigurationAvailable())) {
+					subspecies = sub;
+					highestWeighting = newWeighting;
+				}
 			}
 		}
 		if(subspecies==null) {


### PR DESCRIPTION
This pull request modifies "getSubspeciesFromBody" in AbstractSubspecies to calculate subspecies weights only within the NPC's race. This makes loading save files significantly faster, especially for large saves in games with many modded subspecies, since fewer subspecies weights need to be parsed and calculated for each NPC. 

If the modified loop fails to find an highest weight among the race's subspecies, it will calculate weights for all subspecies, as in the original code. 
No new graphical assets are required.

This code has been tested for the following versions:
- 0.4.7
- 0.4.7.5

The speed improvement was tested using a save file with ~9500 npcs and 204 subspecies. The time required to load the file using the unmodified game was 7 minutes, while the modified game took about 40 seconds.

Discord ID: Sightglass#1408
