### PR TITLE
Check feral attributes before setting body as feral

### DIFF
--- a/src/com/lilithsthrone/game/character/body/Body.java
+++ b/src/com/lilithsthrone/game/character/body/Body.java
@@ -6337,7 +6337,6 @@ public class Body implements XMLSaving {
 	 * @param subspecies Pass in the AbstractSubspecies to which this character should be transformed into a feral version of. Pass in null to transform back from feral to a standard anthro.
 	 */
 	public void setFeral(AbstractSubspecies subspecies) {
-		this.feral = subspecies!=null;
 		
 		FeralAttributes attributes = subspecies==null?null:subspecies.getFeralAttributes(this);
 		if(attributes==null) {
@@ -6345,6 +6344,7 @@ public class Body implements XMLSaving {
 			return;
 		}
 		
+		this.feral = subspecies!=null;
 		// Set body to full subspecies:
 		Main.game.getCharacterUtils().reassignBody(
 				null,


### PR DESCRIPTION
- What is the purpose of the pull request?
Changes the body setFeral method to not set the body as feral if the subspecies does not have feral attributes or is null. Reduces need to check for feral attributes before calling the setFeral method. Still outputs an error message to the log.
- Give a brief description of what you changed or added.
Moves setting of the feral boolean after the check for null subspecies or null feral attributes, in the Body.setFeral method.
- Are any new graphical assets required?
No new graphical assets.
- Has this change been tested? If so, mention the version number that the test was based on.
Tested on versions 0.4.7 to 0.4.8.3.
- So we have a better idea of who you are, what is your Discord Handle?
Sightglass#1408
- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
