### PR TITLE
Fix to slime, half-demon backgrounds

### DIFF
--- a/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
+++ b/src/com/lilithsthrone/game/character/race/AbstractSubspecies.java
@@ -112,6 +112,7 @@ public abstract class AbstractSubspecies {
 	
 	protected String SVGString;
 	protected String SVGStringUncoloured;
+        protected String SVGStringUncolouredNoBackground;
 	protected String SVGStringNoBackground;
 	protected String SVGStringDesaturated;
 	protected String slimeSVGString;
@@ -1638,6 +1639,7 @@ public abstract class AbstractSubspecies {
 						getTertiaryColour(),
 						"<div style='"+fullDivStyle+"'>"+SVGStringUncoloured+"</div>");
 				
+                                SVGStringUncolouredNoBackground = "<div style='"+fullDivStyle+"'>"+SVGStringUncoloured+"</div>";
 				SVGStringUncoloured = SVGStringBackground + "<div style='"+fullDivStyle+"'>"+SVGStringUncoloured+"</div>";
 				
 				slimeSVGString = SvgUtil.colourReplacement(Subspecies.getIdFromSubspecies(this),
@@ -1645,21 +1647,21 @@ public abstract class AbstractSubspecies {
 						PresetColour.RACE_SLIME,
 						PresetColour.RACE_SLIME,
 						"<div style='"+fullDivStyle+"'>" + SVGImages.SVG_IMAGE_PROVIDER.getRaceBackgroundSlime()+"</div>"
-						+ "<div style='"+fullDivStyle+"'>"+SVGStringUncoloured+"</div>");
+						+ "<div style='"+fullDivStyle+"'>"+SVGStringUncolouredNoBackground+"</div>");
 
 				halfDemonSVGString = SvgUtil.colourReplacement(Subspecies.getIdFromSubspecies(this),
 						PresetColour.RACE_HALF_DEMON,
 						PresetColour.RACE_HALF_DEMON,
 						PresetColour.RACE_HALF_DEMON,
 						"<div style='"+fullDivStyle+"'>" + SVGImages.SVG_IMAGE_PROVIDER.getRaceBackgroundDemon()+"</div>"
-						+ "<div style='"+fullDivStyle+"'>"+SVGStringUncoloured+"</div>");
+						+ "<div style='"+fullDivStyle+"'>"+SVGStringUncolouredNoBackground+"</div>");
 
 				demonSVGString = SvgUtil.colourReplacement(Subspecies.getIdFromSubspecies(this),
 						PresetColour.RACE_DEMON,
 						PresetColour.RACE_DEMON,
 						PresetColour.RACE_DEMON,
 						"<div style='"+fullDivStyle+"'>" + SVGImages.SVG_IMAGE_PROVIDER.getRaceBackgroundDemon()+"</div>"
-						+ "<div style='"+fullDivStyle+"'>"+SVGStringUncoloured+"</div>");
+						+ "<div style='"+fullDivStyle+"'>"+SVGStringUncolouredNoBackground+"</div>");
 				
 				SVGStringDesaturated = SvgUtil.colourReplacement(Subspecies.getIdFromSubspecies(this),
 						PresetColour.BASE_GREY,


### PR DESCRIPTION
- What is the purpose of the pull request?
Fixes missing background textures in slime and half-demon race icons.
- Give a brief description of what you changed or added.
Add a new uncolored, icon-only SVG string, which is layered over the slime or half-demon background. Previously, the icon and a background were put over, which covered up the slime splat or demon pentagram background underneath.
- Are any new graphical assets required?
No new assets required
- Has this change been tested? If so, mention the version number that the test was based on.
Tested on v0.4.8.3
- So we have a better idea of who you are, what is your Discord Handle?
Sightglass#1408