### PR TITLE
Cache compiled Javascript objects.

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/UtilText.java
@@ -9777,6 +9777,7 @@ public class UtilText {
 	
 	public static void resetParsingEngine() {
 		engine = null;
+		memo.clear();
 		specialParsingStrings = new ArrayList<>();
 	}
 	
@@ -9814,6 +9815,7 @@ public class UtilText {
 	public static void initScriptEngine() {
 		// http://hg.openjdk.java.net/jdk8/jdk8/nashorn/rev/eb7b8340ce3a
 		engine = factory.getScriptEngine("-strict", "--no-java", "--no-syntax-extensions");//, "-scripting");
+		memo.clear(); // cached scripts may reference the previous engine; drop them
 		try {
 			engine.getBindings(ScriptContext.ENGINE_SCOPE).remove("exit");
 			engine.getBindings(ScriptContext.ENGINE_SCOPE).remove("quit");
@@ -10956,12 +10958,8 @@ public class UtilText {
 	}
 	
 	
-	// Memoization improvement attempts follow from here:
-	
-//	private static final Map<String, CompiledScript> memo = new HashMap<>();
-//	private static final int memo_limit = 500;
-	// NOTE: This was causing a bug where upon loading a saved game, the player's race wasn't being recalculated properly for some reason.
-	// It seems to have been fixed by changing return script.eval(); to return script.eval(((NashornScriptEngine)engine).getContext());
+	private static final Map<String, CompiledScript> memo = new HashMap<>();
+	private static final int memo_limit = 500;
 	/**
 	 * Added in PR#1442 to increase performance by adding a memoization cache to compile scripting engine scripts.
 	 * <br/>- Adds a cache intended to hold compiled forms of script engine scripts.
@@ -10973,27 +10971,18 @@ public class UtilText {
 	 * @throws ScriptException
 	 */
 	private static Object evaluate(String command) throws ScriptException {
-		// Commented out in 0.4.0.10 as it was continuing to throw parsing errors
-		// Unable to reliably replicate the bug - sometimes everything worked fine, sometimes the #VAR parsing sections would fail to parse completely
-		
-//		CompiledScript script;
-//		if (!memo.containsKey(command)) {
-//			script = ((NashornScriptEngine)engine).compile(command);
-//			if (memo.size() < memo_limit) {
-//				memo.put(command, script);
-//				if (memo.size() == memo_limit) {
-//					System.err.println("Memo has reached capacity! Additional script commands will not be memoized.");
-//				}
-//			}
-//		} else {
-//			script = memo.get(command);
-//		}
-//		return script.eval(((NashornScriptEngine)engine).getContext());
-//		//return script.eval();
-		
-		
-		// This is the old code which works but is slow:
-		CompiledScript script = ((NashornScriptEngine)engine).compile(command);
+		CompiledScript script;
+		if (!memo.containsKey(command)) {
+			script = ((NashornScriptEngine)engine).compile(command);
+			if (memo.size() < memo_limit) {
+				memo.put(command, script);
+				if (memo.size() == memo_limit) {
+					System.err.println("Memo has reached capacity! Additional script commands will not be memoized.");
+				}
+			}
+		} else {
+			script = memo.get(command);
+		}
 		return script.eval();
 	}
 }


### PR DESCRIPTION
This makes significant improvements to the speed of UtilsText.evaluate - in my measurement, with a save with around a hundred children and a bunch of script-heavy mods installed, it cut about 60% of the _script evaluation_ time out of resting until the following morning. Sadly, this only amounts to a few percent of the overall time spent working out resting, but every bit helps.

This improvement also applies to the multitude of other situations where scripts are run, incrementally improving performance of walking around, opening the inventory, enchanting and dying objects, sex and combat, and numerous other areas of the game. It's not a _huge_ improvement, but it's noticeable.

This implementation is exactly the implementation that was removed in 81a1fc0b14 (version 4.1.0), with one key difference: the cache of compiled scripts is cleared whenever the script engine is changed or cleared. The issues you were having with it sometimes failing to run scripts were _likely_ due to a compiled script object carrying over a save reload or other situation where the script engine gets discarded, leading to scripts being run in engine A while variables were being set in engine B.

I've been running with this patch locally for a while and it seems stable.

You can reach me on Discord as `tarbh_uisge`.
