### PR TITLE
Documentation: Specify svgo version compatible with svgoConfig.yml

### DIFF
--- a/svgoConfig.yml
+++ b/svgoConfig.yml
@@ -1,7 +1,7 @@
 # Lilith's Throne SVGO configuration
 #
 # To use SVGO, Node.js (https://nodejs.org/en/) is required.
-# It can then be installed using "npm install -g svgo" from the command line.
+# It can then be installed using "npm install -g svgo@1.3.2" from the command line.
 #
 # Usage follows with "svgo --config=svgoConfig.yml target.svg", where absolute 
 # paths may be required if the config file or the target file are not located 


### PR DESCRIPTION
Newer versions of svgo don't support yaml configuration, and also no longer support some features enabled within this config (at least, that was true when I last checked like a year ago).

The pinned version (1.3.2) is the version I have personally used, and also is the most recent version that still supports yaml.

Discord: `@phlarx`