### PR TITLE
Fix game crashing on leap day (Feb 29th)

### DIFF
--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -415,7 +415,7 @@ public class Game implements XMLSaving {
 		characterUtils = new CharacterUtils();
 		OccupantManagementDialogue.resetImportantCells();
 		startingDate = LocalDateTime.of(
-				2019, // LocalDateTime.now().getYear(),
+				2020, // LocalDateTime.now().getYear(),
 				LocalDateTime.now().getMonth(),
 				LocalDateTime.now().getDayOfMonth(),
 				00,


### PR DESCRIPTION
Since 0.4.8, the `startingDate` has been hardcoded to use the same date as real-life but with the year changed to 2019.
https://github.com/Innoxia/liliths-throne-public/blob/ed687f320265075ec5c365470265bbae046beeb4/src/com/lilithsthrone/game/Game.java#L417-L422
Because 2019 is not a leap year, this can cause issue when launching the game on a leap day (February 29th).
```
Exception in thread "main" java.lang.RuntimeException: Exception in Application start method
	at com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:901)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication$2(LauncherImpl.java:196)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.time.DateTimeException: Invalid date 'February 29' as '2019' is not a leap year
	at java.base/java.time.LocalDate.create(LocalDate.java:459)
	at java.base/java.time.LocalDate.of(LocalDate.java:253)
	at java.base/java.time.LocalDateTime.of(LocalDateTime.java:238)
	at com.lilithsthrone.game.Game.<init>(Game.java:417)
	at com.lilithsthrone.main.Main.start(Main.java:489)
	at com.sun.javafx.application.LauncherImpl.lambda$launchApplication1$9(LauncherImpl.java:847)
	at com.sun.javafx.application.PlatformImpl.lambda$runAndWait$12(PlatformImpl.java:484)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$10(PlatformImpl.java:457)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$11(PlatformImpl.java:456)
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:96)
	at com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
	at com.sun.glass.ui.win.WinApplication.lambda$runLoop$3(WinApplication.java:184)
	... 1 more

```
This patch fixed this issue by changing the year to 2020, which IS a leap year.
This issue can alternatively be fixed by changing Feb 29 to Feb 28 if (for story-telling or whatever reason) the year being 2019 is absolutely required.
Or the real-life year can just be used instead.
