### PR TITLE
Bugfix: Prevent infinite loop when computing the visible clothing for a slot

### DIFF
--- a/src/com/lilithsthrone/game/inventory/CharacterInventory.java
+++ b/src/com/lilithsthrone/game/inventory/CharacterInventory.java
@@ -1112,24 +1112,29 @@ public class CharacterInventory implements XMLSaving {
 			visibleClothing.add(getClothingInSlot(slot));
 		}
 		
-		if(getInventorySlotsConcealed(character).get(slot)!=null) {
-			visibleClothing.addAll(getInventorySlotsConcealed(character).get(slot));
+		Map<InventorySlot, List<AbstractClothing>> slotsConcealed = getInventorySlotsConcealed(character);
+		if(slotsConcealed.get(slot)!=null) {
+			visibleClothing.addAll(slotsConcealed.get(slot));
 		}
 		
 		if(!visibleClothing.isEmpty()) {
-			List<InventorySlot> slotsToCheck = visibleClothing.stream().map(c -> c.getSlotEquippedTo()).collect(Collectors.toList());
+			Set<InventorySlot> slotsToCheck = visibleClothing.stream().map(AbstractClothing::getSlotEquippedTo).collect(Collectors.toSet());
+			Set<InventorySlot> slotsChecked = new HashSet<>();
 			
 			while(!slotsToCheck.isEmpty()) {
-				for(InventorySlot checkSlot : new ArrayList<>(slotsToCheck)) {
-					List<AbstractClothing> checkClothingSlot = getInventorySlotsConcealed(character).get(checkSlot);
-					if(checkClothingSlot!=null && !checkClothingSlot.isEmpty()) {
-						visibleClothing = visibleClothing.stream().filter(cl -> cl.getSlotEquippedTo()!=checkSlot).collect(Collectors.toList()); // Remove clothing which is concealed
-						for(AbstractClothing c : checkClothingSlot) {
-							visibleClothing.add(c);
+				InventorySlot checkSlot = slotsToCheck.iterator().next();
+				slotsToCheck.remove(checkSlot);
+				slotsChecked.add(checkSlot);
+				
+				List<AbstractClothing> checkClothingSlot = slotsConcealed.get(checkSlot);
+				if(checkClothingSlot!=null && !checkClothingSlot.isEmpty()) {
+					visibleClothing = visibleClothing.stream().filter(cl -> cl.getSlotEquippedTo()!=checkSlot).collect(Collectors.toList()); // Remove clothing which is concealed
+					for(AbstractClothing c : checkClothingSlot) {
+						visibleClothing.add(c);
+						if(!slotsChecked.contains(c.getSlotEquippedTo())) {
 							slotsToCheck.add(c.getSlotEquippedTo());
 						}
 					}
-					slotsToCheck.remove(checkSlot);
 				}
 			}
 		}


### PR DESCRIPTION
- What is the purpose of the pull request?

Determining the visible clothing for a slot has a possibility of getting stuck in an infinite loop.

- Give a brief description of what you changed or added.

In this change, the loop is prevented by:
1. using a set to grab the slots to scan
2. using a second set to keep track of already-visited slots

Also, stored `getInventorySlotsConcealed` to a var, so that it's only called once
I'm fairly sure there won't be any differences to the original implementation, in the results that are generated, but it's not impossible.

However, I also attempted to rewrite the entire function from scratch, though my implementation will produce differing results. Since the differences tend to imply that there's code in other functions that might need to change, too, I have not included that implementation here. It is visible here: https://github.com/innoxia/liliths-throne-public/compare/dev...CognitiveMist:visible-clothing-freeze-rewrite .

- Are any new graphical assets required?

Nope

- Has this change been tested? If so, mention the version number that the test was based on.

Yep, 0.4.9.5

- So we have a better idea of who you are, what is your Discord Handle?

`phlarx` (Cognitive Mist)