### PR TITLE
Bugfix: Minor fixes from recent discord bug report

### DIFF
--- a/res/txt/places/dominion/lilayasHome/lab.xml
+++ b/res/txt/places/dominion/lilayasHome/lab.xml
@@ -1018,7 +1018,7 @@
 			<p>
 				Once again, you find yourself surrounded by the shimmering pink outline of your arcane aura. This time, however, you see a strange ball of energy orbiting your body, which looks to be the same sort of size as the shard of energy that you remember shooting into you. Looking up at Lilaya, you see that her cheeks have completely drained of colour, and she's looking down at you with an extremely worried expression on her face.
 			</p>
-		#ELSEIF(SPECIAL_PARSE_0=="false")
+		#ELSEIF([#SPECIAL_PARSE_0]=="false")
 			<p>
 				[pc.speech(That's good to hear, so what would I need to do if it happens again?)] you ask.
 			</p>

--- a/res/txt/places/dominion/lilayasHome/lab.xml
+++ b/res/txt/places/dominion/lilayasHome/lab.xml
@@ -1018,7 +1018,7 @@
 			<p>
 				Once again, you find yourself surrounded by the shimmering pink outline of your arcane aura. This time, however, you see a strange ball of energy orbiting your body, which looks to be the same sort of size as the shard of energy that you remember shooting into you. Looking up at Lilaya, you see that her cheeks have completely drained of colour, and she's looking down at you with an extremely worried expression on her face.
 			</p>
-		#ELSEIF([#SPECIAL_PARSE_0]=="false")
+		#ELSEIF(!pc.isAnyEquippedClothingSealed())
 			<p>
 				[pc.speech(That's good to hear, so what would I need to do if it happens again?)] you ask.
 			</p>

--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -409,7 +409,7 @@ public abstract class GameCharacter implements XMLSaving {
 	
 	
 	// Pregnancy:
-	protected List<String> pregnancyReactions;
+	protected Set<String> pregnancyReactions;
 	protected long timeProgressedToFinalPregnancyStage;
 	protected Map<SexAreaOrifice, Long> timeProgressedToFinalIncubationStage;
 	protected List<PregnancyPossibility> potentialPartnersAsMother;
@@ -689,7 +689,7 @@ public abstract class GameCharacter implements XMLSaving {
 		
 		fluidsStoredMap = new HashMap<>();
 		
-		pregnancyReactions = new ArrayList<>();
+		pregnancyReactions = new HashSet<>();
 		
 		timeProgressedToFinalPregnancyStage = 1;
 		timeProgressedToFinalIncubationStage = new HashMap<>();
@@ -21266,7 +21266,7 @@ public abstract class GameCharacter implements XMLSaving {
 			for(Litter fatherCopy : pregnantLitter.getFather().getLittersFathered()) {
 				if(!fatherCopy.getId().isEmpty() && fatherCopy.getId().equals(pregnantLitter.getId())) {
 					fatherCopy.setBirthDate(Main.game.getDateNow());
-					continue;
+					break;
 				}
 			}
 		}

--- a/src/com/lilithsthrone/game/character/body/Leg.java
+++ b/src/com/lilithsthrone/game/character/body/Leg.java
@@ -162,10 +162,10 @@ public class Leg implements BodyPartInterface {
 		if(!Main.game.isStarted() || owner==null) {
 			this.type = type;
 			this.footStructure = type.getDefaultFootStructure(this.getLegConfiguration());
-			if(Main.game.isStarted() && !type.isLegConfigurationAvailable(this.getLegConfiguration())) {
-				this.getType().applyLegConfigurationTransformation(owner, RacialBody.valueOfRace(type.getRace()).getLegConfiguration(), true, true);
-			}
 			if(owner!=null) {
+				if(Main.game.isStarted() && !type.isLegConfigurationAvailable(this.getLegConfiguration())) {
+					this.getType().applyLegConfigurationTransformation(owner, RacialBody.valueOfRace(type.getRace()).getLegConfiguration(), true, true);
+				}
 				owner.postTransformationCalculation();
 			}
 			return "";


### PR DESCRIPTION
- Convert `pregnancyReactions` to a Set
- Change `continue` to `break` in one place
- Prevent generating leg configuration TF text for a character that is null (via `Body.applyLegConfigurationTransformation`)
- Fix one case of incorrect SPECIAL_PARSE_0 usage (this is the only example I found within the code base)

Original bug report info (not actually a bug): https://discord.com/channels/302617912949211136/789126893658963988/1245837478485823612
All items discovered by me while investigating that report.

Tested 0.4.9.9, `@phlarx`