### PR TITLE
Enhancement: Store minimap zoom level in the game properties

### DIFF
--- a/src/com/lilithsthrone/game/Properties.java
+++ b/src/com/lilithsthrone/game/Properties.java
@@ -763,6 +763,9 @@ public class Properties {
 					if(Main.isVersionOlderThan(versionNumber, "0.4.9.6")) {
 						values.add(PropertyValue.lipLispContent);
 					}
+					if(Main.isVersionOlderThan(versionNumber, "0.4.10.1")) {
+						values.add(PropertyValue.mapZoomedIn);
+					}
 					
 					
 				} else {

--- a/src/com/lilithsthrone/game/PropertyValue.java
+++ b/src/com/lilithsthrone/game/PropertyValue.java
@@ -93,7 +93,8 @@ public enum PropertyValue {
 	newWeaponDiscovered(false),
 	newClothingDiscovered(false),
 	newItemDiscovered(false),
-	newRaceDiscovered(false);
+	newRaceDiscovered(false),
+	mapZoomedIn(true);
 
 	private boolean defaultValue;
 	private boolean fetishRelated;

--- a/src/com/lilithsthrone/rendering/RenderingEngine.java
+++ b/src/com/lilithsthrone/rendering/RenderingEngine.java
@@ -83,7 +83,6 @@ import com.lilithsthrone.world.population.Population;
 public enum RenderingEngine {
 	ENGINE;
 	
-	private static boolean zoomedIn = true;
 	private static boolean renderedDisabledMap = false;
 
 	private static int pageLeft = 0;
@@ -2122,10 +2121,10 @@ public enum RenderingEngine {
 //			renderedDisabledMap = true;
 //		}
 
-		int mapSize = zoomedIn ? 2 : 3;
-		float unit = zoomedIn ? 18f : 13.25f;
+		int mapSize = isZoomedIn() ? 2 : 3;
+		float unit = isZoomedIn() ? 18f : 13.25f;
 		
-		String tileWidthStyle = "width:" + unit + "%; border-width:1%; margin:"+(zoomedIn?1:0.5)+"%;";
+		String tileWidthStyle = "width:" + unit + "%; border-width:1%; margin:"+(isZoomedIn()?1:0.5)+"%;";
 		String tileMovementDisabledStyle = "border-color:#111;";
 		Vector2i playerPosition = Main.game.getPlayer().getLocation();
 		
@@ -2500,11 +2499,11 @@ public enum RenderingEngine {
 	}
 
 	public static boolean isZoomedIn() {
-		return zoomedIn;
+		return Main.getProperties().hasValue(PropertyValue.mapZoomedIn);
 	}
 
 	public static void setZoomedIn(boolean zoomedIn) {
-		RenderingEngine.zoomedIn = zoomedIn;
+		Main.getProperties().setValue(PropertyValue.mapZoomedIn, zoomedIn);
 	}
 
 	public static boolean isRenderedDisabledMap() {


### PR DESCRIPTION
Store minimap zoom level in the game properties.

Note: change the version upgrade check as appropriate.

Tested on 0.4.10 (with version upgrade check at 0.4.10).
`@phlarx`