### PR TITLE
Fix Eisek (and probably other NPCs) showing up as winged dragon-boy

### DIFF
--- a/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipInformationEventListener.java
+++ b/src/com/lilithsthrone/controller/eventListeners/tooltips/TooltipInformationEventListener.java
@@ -901,7 +901,6 @@ public class TooltipInformationEventListener implements EventListener {
 
 					Main.mainController.setTooltipSize(dimensions[0], dimensions[1]);
 					
-					boolean showWinged = (owner.hasWings() || owner.isArmWings()) && !owner.getFleshSubspecies().isWinged();
 					tooltipSB.setLength(0);
 					tooltipSB.append("<div class='title' style='color:" + owner.getRace().getColour().toWebHexString() + ";'>"
 							+(owner.getRaceStage().getName()!=""
@@ -909,8 +908,8 @@ public class TooltipInformationEventListener implements EventListener {
 								:"")
 							+ "<b style='color:"+owner.getSubspecies().getColour(owner).toWebHexString()+";'>"
 								+ (owner.isFeminine()
-										?Util.capitaliseSentence((showWinged ? "winged " : "") + owner.getSubspecies().getSingularFemaleName(owner.getBody()))
-										:Util.capitaliseSentence((showWinged ? "winged " : "") + owner.getSubspecies().getSingularMaleName(owner.getBody())))
+										?Util.capitaliseSentence((owner.showWinged() ? "winged " : "") + owner.getSubspecies().getSingularFemaleName(owner.getBody()))
+										:Util.capitaliseSentence((owner.showWinged() ? "winged " : "") + owner.getSubspecies().getSingularMaleName(owner.getBody())))
 							+ "</b>"
 							+ "</div>");
 					

--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -3987,6 +3987,11 @@ public abstract class GameCharacter implements XMLSaving {
 		setArtworkIndex(this.artworkIndex + increment);
 	}
 	
+	public boolean showWinged() {
+		AbstractSubspecies subspecies = getBodyMaterial() == BodyMaterial.FLESH ? getSubspecies() : getFleshSubspecies();
+		return (hasWings() || isArmWings()) && !subspecies.isWinged();
+	}
+	
 	public String getName(String determiner) {
 		char firstChar = getName(true).charAt(0);
 		if (Character.isUpperCase(firstChar) || !Character.isAlphabetic(firstChar) || determiner.isEmpty()) { //|| getName().equals(this.getGenericName())
@@ -3996,8 +4001,7 @@ public abstract class GameCharacter implements XMLSaving {
 			return getName(true);
 			
 		} else {
-			boolean showWinged = (hasWings() || isArmWings()) && !getFleshSubspecies().isWinged();
-			String nameText = (showWinged ? "winged " : "") + getName(true);
+			String nameText = (showWinged() ? "winged " : "") + getName(true);
 			if(this.isUnique()) {
 				determiner = "the";
 			}

--- a/src/com/lilithsthrone/game/dialogue/companions/OccupantManagementDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/companions/OccupantManagementDialogue.java
@@ -1306,15 +1306,13 @@ public class OccupantManagementDialogue {
 	}
 	
 	private static String getSlaveryEntry(boolean slaveOwned, GenericPlace place, NPC slave, AffectionLevel affection, float affectionChange, ObedienceLevel obedience, float obedienceChange, boolean alternateBackground) {
-		boolean showWinged = (slave.hasWings() || slave.isArmWings()) && !slave.getFleshSubspecies().isWinged();
-		
 		miscDialogueSB.setLength(0);
 		miscDialogueSB.append(
 				"<div class='container-full-width inner' style='margin-bottom:0;"+(alternateBackground?"background:"+PresetColour.BACKGROUND_ALT.toWebHexString()+";'":"'")+"'>"
 						+ "<div style='width:20%; float:left; margin:0; padding:0;'>"
 							+ "<b style='color:"+slave.getFemininity().getColour().toWebHexString()+";'>"+slave.getName(true)+"</b><br/>"
 							+ "<span style='color:"+slave.getRace().getColour().toWebHexString()+";'>"
-								+Util.capitaliseSentence((showWinged?"winged ":"")+(slave.isFeminine()?slave.getSubspecies().getSingularFemaleName(slave.getBody()):slave.getSubspecies().getSingularMaleName(slave.getBody())))+"</span><br/>"
+								+Util.capitaliseSentence((slave.showWinged()?"winged ":"")+(slave.isFeminine()?slave.getSubspecies().getSingularFemaleName(slave.getBody()):slave.getSubspecies().getSingularMaleName(slave.getBody())))+"</span><br/>"
 							+ "<span style='color:"+slave.getFemininity().getColour().toWebHexString()+";'>"+Util.capitaliseSentence(slave.getGender().getName())+"</span>"
 						+ "</div>"
 						+ "<div style='width:20%; float:left; margin:0; padding:0;'>"
@@ -1419,15 +1417,13 @@ public class OccupantManagementDialogue {
 	}
 	
 	private static String getOccupantEntry(GenericPlace place, NPC occupant, AffectionLevel affection, float affectionChange, ObedienceLevel obedience, float obedienceChange, boolean alternateBackground) {
-		boolean showWinged = (occupant.hasWings() || occupant.isArmWings()) && !occupant.getFleshSubspecies().isWinged();
-
 		miscDialogueSB.setLength(0);
 		miscDialogueSB.append(
 				"<div class='container-full-width inner' style='margin-bottom:0;"+(alternateBackground?"background:"+PresetColour.BACKGROUND_ALT.toWebHexString()+";'":"'")+"'>"
 						+ "<div style='width:20%; float:left; margin:0; padding:0;'>"
 							+ "<b style='color:"+occupant.getFemininity().getColour().toWebHexString()+";'>"+occupant.getName(true)+"</b><br/>"
 							+ "<span style='color:"+occupant.getRace().getColour().toWebHexString()+";'>"
-								+Util.capitaliseSentence((showWinged?"winged ":"")+(occupant.isFeminine()?occupant.getSubspecies().getSingularFemaleName(occupant.getBody()):occupant.getSubspecies().getSingularMaleName(occupant.getBody())))+"</span><br/>"
+								+Util.capitaliseSentence((occupant.showWinged()?"winged ":"")+(occupant.isFeminine()?occupant.getSubspecies().getSingularFemaleName(occupant.getBody()):occupant.getSubspecies().getSingularMaleName(occupant.getBody())))+"</span><br/>"
 							+ "<span style='color:"+occupant.getFemininity().getColour().toWebHexString()+";'>"+Util.capitaliseSentence(occupant.getGender().getName())+"</span>"
 						+ "</div>"
 						+ "<div style='width:20%; float:left; margin:0; padding:0;'>"


### PR DESCRIPTION
- What is the purpose of the pull request?
  Fixed Eisek (and probably other named NPCs) showing up as 'The **winged** dragon-boy'.

- Give a brief description of what you changed or added.
  Eisek (and probably other NPCs) showed up as 'The winged dragon-boy' because getFleshSubspecies() always returned 'HUMAN' for him for whatever reason. I've adjusted the code to only check for getFleshsubspecies() if the BodyMaterial is not flesh and for getSubspecies() otherwise.

  Did a few tests with Eisek, my occupants and some slimes including the ones in the Slime Queen's Tower and everything works as intended so far.

- Are any new graphical assets required?
  No

- Has this change been tested? If so, mention the version number that the test was based on.
  Yes, 0.4.10.7 Alpha

- So we have a better idea of who you are, what is your Discord Handle?
  `Stadler#3007`