### PR TITLE
Add support for chastity items with an attached dildo

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -30248,20 +30248,41 @@ public abstract class GameCharacter implements XMLSaving {
 			return null;
 		}
 		
-		if(body.getPenis().getType()==PenisType.NONE) {
-			for(AbstractClothing c : this.getClothingCurrentlyEquipped()) {
-				if(c.getItemTags().contains(ItemTag.DILDO_OTHER)) {
-					return new Penis(
-							PenisType.DILDO,
-							c.getClothingType().getPenetrationOtherLength(),
-							false,
-							c.getClothingType().getPenetrationOtherGirth(),
-							TesticleSize.ZERO_VESTIGIAL.getValue(),
-							0,
-							2);
-				}
-			}
-		}
+    for(AbstractClothing c : this.getClothingCurrentlyEquipped()) {
+      boolean isDildo    = false;
+      boolean isChastity = false;
+      boolean doesBlock  = false;
+
+      for(ItemTag itemTag : c.getItemTags()) {
+        switch(itemTag) {
+          case DILDO_OTHER:
+            isDildo = true;
+            break;
+
+          case CHASTITY:
+            isChastity = true;
+            break;
+
+          case PREVENTS_ERECTION_PHYSICAL:
+            doesBlock = true;
+            break;
+
+          default:
+            break;
+        }
+      }
+
+      if(isDildo && (body.getPenis().getType() == PenisType.NONE || (isChastity && doesBlock))) {
+        return new Penis(
+            PenisType.DILDO,
+            c.getClothingType().getPenetrationOtherLength(),
+            false,
+            c.getClothingType().getPenetrationOtherGirth(),
+            TesticleSize.ZERO_VESTIGIAL.getValue(),
+            0,
+            2);
+      }
+    }
 		
 		return body.getPenis();
 	}


### PR DESCRIPTION
Tried to mod in a chastity cage with a dildo and found that the game logic will pick the characters penis. Changed __getCurrentPenis__ to always check clothing for a dildo. And now the dildo is selected.

I don't know what else needs to be changed to further support this. If this is something that sounds interesting to put in the game, I'm willing to make the needed code changes.

Discord: mightbefluffy 