### PR TITLE
Exclude some characters from forced chastity effect

### DIFF
--- a/src/com/lilithsthrone/game/character/effects/StatusEffect.java
+++ b/src/com/lilithsthrone/game/character/effects/StatusEffect.java
@@ -82,6 +82,7 @@ import com.lilithsthrone.world.Weather;
 import com.lilithsthrone.world.WorldRegion;
 import com.lilithsthrone.world.WorldType;
 import com.lilithsthrone.world.places.PlaceType;
+import com.lilithsthrone.game.inventory.clothing.BlockedParts;
 
 /**
  * @since 0.1.0
@@ -7475,11 +7476,29 @@ public class StatusEffect {
 		}
 		@Override
 		public boolean isConditionsMet(GameCharacter target) {
+      boolean isFreeButtSlut = true;
+
+      if(target.hasFetish(Fetish.FETISH_ANAL_RECEIVING)) {
+        for(AbstractClothing c : target.getClothingCurrentlyEquipped()) {
+          if(c.getItemTags().contains(ItemTag.CHASTITY)) {
+            for(BlockedParts blockedParts : c.getBlockedPartsMap(target, c.getSlotEquippedTo())) {
+              if(blockedParts.blockedBodyParts.contains(CoverableArea.ANUS)) {
+                isFreeButtSlut = false;
+                break;
+              }
+            }
+          }
+        }
+      } else {
+        isFreeButtSlut = false;
+      }
+
 			return target.isWearingChastity()
 					&& !target.isDoll()
 					&& !target.hasStatusEffect(CHASTITY_2)
 					&& !target.hasStatusEffect(CHASTITY_3)
-					&& !target.hasStatusEffect(CHASTITY_4);
+					&& !target.hasStatusEffect(CHASTITY_4)
+          && !(isFreeButtSlut || target.hasFetish(Fetish.FETISH_DENIAL_SELF));
 		}
 		@Override
 		public int getApplicationLength(GameCharacter target) {
@@ -7571,11 +7590,29 @@ public class StatusEffect {
 		}
 		@Override
 		public boolean isConditionsMet(GameCharacter target) {
+      boolean isFreeButtSlut = true;
+
+      if(target.hasFetish(Fetish.FETISH_ANAL_RECEIVING)) {
+        for(AbstractClothing c : target.getClothingCurrentlyEquipped()) {
+          if(c.getItemTags().contains(ItemTag.CHASTITY)) {
+            for(BlockedParts blockedParts : c.getBlockedPartsMap(target, c.getSlotEquippedTo())) {
+              if(blockedParts.blockedBodyParts.contains(CoverableArea.ANUS)) {
+                isFreeButtSlut = false;
+                break;
+              }
+            }
+          }
+        }
+      } else {
+        isFreeButtSlut = false;
+      }
+
 			return target.isWearingChastity()
 					&& !target.isDoll()
 					&& !target.hasStatusEffect(CHASTITY_1)
 					&& !target.hasStatusEffect(CHASTITY_2)
-					&& !target.hasStatusEffect(CHASTITY_3);
+					&& !target.hasStatusEffect(CHASTITY_3)
+          && !(isFreeButtSlut || target.hasFetish(Fetish.FETISH_DENIAL_SELF));
 		}
 		@Override
 		public boolean isSexEffect() {


### PR DESCRIPTION
Forced chastity effect will now not be applied to a character if they are a butt slut and their chastity does not block the anus(i.e full chastity belts). Characters with the orgasm denial fetish are also excluded from the effect.

This is to represent the idea that some characters enjoy being locked in chastity.

Tested against dev v0.4.10.7

Discord: mightbefluffy
