### PR TITLE
Enhancement: Produce an error message when a world map contains invalid colors

### DIFF
--- a/src/com/lilithsthrone/world/Generation.java
+++ b/src/com/lilithsthrone/world/Generation.java
@@ -11,6 +11,7 @@ import javax.imageio.ImageIO;
 import com.lilithsthrone.main.Main;
 import com.lilithsthrone.utils.Vector2i;
 import com.lilithsthrone.world.places.GenericPlace;
+import com.lilithsthrone.world.places.PlaceType;
 import javafx.concurrent.Task;
 
 /**
@@ -83,7 +84,15 @@ public class Generation extends Task<Boolean> {
 				
 				for(int w = 0 ; w < img.getWidth(); w++) {
 					for(int h = 0 ; h < img.getHeight(); h++) {
-						grid[w][img.getHeight()-1-h].setPlace(new GenericPlace(worldType.getPlacesMap().get(new Color(img.getRGB(w, h)))), true);
+						Color pixelColour = new Color(img.getRGB(w, h) | 0xff000000); // enforce no transparency by ignoring the alpha channel
+						if(worldType.getPlacesMap().containsKey(pixelColour)) {
+							grid[w][img.getHeight() - 1 - h].setPlace(new GenericPlace(worldType.getPlacesMap().get(pixelColour)), true);
+						} else {
+							String webHex = String.format("#%06x", pixelColour.getRGB() & 0x00ffffff); // format color without the alpha channel (to match the xml)
+							System.err.println("Error: Colour " + webHex + " for pixel at (x=" + w + ",y=" + h + ") "
+									+ "does not match any place type defined in " + worldType.getFileLocation() + "!");
+							grid[w][img.getHeight() - 1 - h].setPlace(new GenericPlace(PlaceType.GENERIC_IMPASSABLE), true);
+						}
 					}
 				}
 


### PR DESCRIPTION
\- Produce an error message when a world map contains invalid colors
\- The cell at that location will be set to `GENERIC_IMPASSABLE`
\- Also ignores the alpha channel for the comparison (this should be irrelevant in most cases, so it's a just-in-case thing)

There are other options for what to do in this situation:
a. Throw an exception (and catch it) preventing the world loading at all. Might be good for mods, but I think it'd be bad for vanilla maps.
b. Attempt to find the 'nearest' valid color instead. Possible, but I think that would be counterproductive since this code has no bearing on compatibility with older saves / mods, except in ways that are shared with starting a new game.
c. Set the invalid cell to a new `GENERIC_ERROR` place type that functions like `GENERIC_IMPASSABLE`, but appears different so that the error is more visible.

I think either the proposed solution in this PR is the best, or option c.

Example error message (I added a bad pixel to Elis near the east exit):
```
Error: Pixel colour #00a2e8 at (x=19,y=16) does not match any place type defined in E:\DevSrc\liliths-throne-public\classes\artifacts\LilithsThrone_jar\res\maps\innoxia\fields\elis\town\map.png!
```

Recent relevant discord discussion in #mod-discussion: https://discord.com/channels/302617912949211136/446038411791433729/1383445667984179220

No graphical asset changes required, tested on `0.4.10.10` and `0.4.11`.
Discord: `@phlarx` (Cognitive Mist)