### PR TITLE
Made speech colours more accessible to mods.

### DIFF
--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -4132,10 +4132,33 @@ public abstract class GameCharacter implements XMLSaving {
 		return null;
 	}
 	
+	/**
+	 * Returns a web hex string representing the colour of this character's speech text. To get the
+	 * underlying colour object instead, use getSpeechColourAsColour.
+	 * <p>
+	 * If a subclass needs to return a hex colour that is not derived from a Colour object, override
+	 * the getDefaultSpeechColour method instead of this one.
+	 * 
+	 * @return this character's speech colour seen in-game, as a web hex string
+	 */
 	public String getSpeechColour() {
 		if(speechColour!=null) {
 			return speechColour.toWebHexString();
 		}
+		return getDefaultSpeechColour();
+	}
+	
+	/**
+	 * Returns a web hex string representing the colour of this character's speech text if no
+	 * speechColour is defined. Unless overridden, the result is based on the character's femininity.
+	 * <p>
+	 * If a subclass needs to return a hex colour that is not derived from a Colour object, override
+	 * this method instead of getSpeechColour, so that the function of the speechColour variable
+	 * will be preserved.
+	 * 
+	 * @return this character's speech colour if no other is defined, as a web hex string
+	 */
+	protected String getDefaultSpeechColour() {
 		if(this.isPlayer()) {
 			switch(Femininity.valueOf(getFemininityValue())) {
 				case ANDROGYNOUS:
@@ -4166,8 +4189,24 @@ public abstract class GameCharacter implements XMLSaving {
 		return null;
 	}
 	
+	/**
+	 * Sets the Colour to be used for this character's speech text. Pass speechColour=null to revert
+	 * to using getDefaultSpeechColour instead.
+	 * 
+	 * @param speechColour the new Colour for this character's speech, or null for the default 
+	 */
 	public void setSpeechColour(Colour speechColour) {
 		this.speechColour = speechColour;
+	}
+	
+	/**
+	 * Returns the underlying Colour object for this character's speech colour, which will be null
+	 * when relying on getDefaultSpeechColour to define their speech colour.
+	 * 
+	 * @return this character's speech colour as a Colour object
+	 */
+	public Colour getSpeechColourAsColour() {
+		return speechColour;
 	}
 
 	public void updateAttributeListeners(boolean requiresStatusEffectUpdate) {

--- a/src/com/lilithsthrone/game/character/npc/dominion/Amber.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Amber.java
@@ -331,7 +331,7 @@ public class Amber extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#FFB38A";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/dominion/Brax.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Brax.java
@@ -412,7 +412,7 @@ public class Brax extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			if(this.isFeminine()) {
 				if(Main.game.getDialogueFlags().values.contains(DialogueFlagValue.bimbofiedBrax)) {

--- a/src/com/lilithsthrone/game/character/npc/dominion/Elle.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Elle.java
@@ -293,7 +293,7 @@ public class Elle extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#754a86";
 		}

--- a/src/com/lilithsthrone/game/character/npc/dominion/Felicia.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Felicia.java
@@ -220,7 +220,7 @@ public class Felicia extends NPC {
     }
     
 //    @Override
-//    public String getSpeechColour() {
+//    protected String getDefaultSpeechColour() {
 //            if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 //                    return "#e6e68a";
 //            }

--- a/src/com/lilithsthrone/game/character/npc/dominion/Hannah.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Hannah.java
@@ -294,7 +294,7 @@ public class Hannah extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#c484da";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/dominion/HarpyBimbo.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/HarpyBimbo.java
@@ -245,7 +245,7 @@ public class HarpyBimbo extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#D60AB8";
 			

--- a/src/com/lilithsthrone/game/character/npc/dominion/HarpyBimboCompanion.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/HarpyBimboCompanion.java
@@ -220,7 +220,7 @@ public class HarpyBimboCompanion extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#BE09A3";
 			

--- a/src/com/lilithsthrone/game/character/npc/dominion/HarpyDominant.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/HarpyDominant.java
@@ -231,7 +231,7 @@ public class HarpyDominant extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#C13350";
 			

--- a/src/com/lilithsthrone/game/character/npc/dominion/HarpyDominantCompanion.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/HarpyDominantCompanion.java
@@ -221,7 +221,7 @@ public class HarpyDominantCompanion extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#D72D33";
 			

--- a/src/com/lilithsthrone/game/character/npc/dominion/HarpyNympho.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/HarpyNympho.java
@@ -237,7 +237,7 @@ public class HarpyNympho extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#D60AB8";
 			

--- a/src/com/lilithsthrone/game/character/npc/dominion/HarpyNymphoCompanion.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/HarpyNymphoCompanion.java
@@ -211,7 +211,7 @@ public class HarpyNymphoCompanion extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#BE09A3";
 			

--- a/src/com/lilithsthrone/game/character/npc/dominion/Helena.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Helena.java
@@ -301,7 +301,7 @@ public class Helena extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#59005C";
 		} else {

--- a/src/com/lilithsthrone/game/character/npc/dominion/Lilaya.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Lilaya.java
@@ -407,7 +407,7 @@ public class Lilaya extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#ff66a3";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/dominion/Lovienne.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Lovienne.java
@@ -126,7 +126,7 @@ public class Lovienne extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		//TODO
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#71009E";

--- a/src/com/lilithsthrone/game/character/npc/dominion/Natalya.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Natalya.java
@@ -318,7 +318,7 @@ public class Natalya extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#e4a1e0";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/dominion/Nyan.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Nyan.java
@@ -574,9 +574,9 @@ public class Nyan extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
-			return super.getSpeechColour();
+			return super.getDefaultSpeechColour();
 		}
 		return "#ffc8e9";
 	}

--- a/src/com/lilithsthrone/game/character/npc/dominion/NyanMum.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/NyanMum.java
@@ -310,9 +310,9 @@ public class NyanMum extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
-			return super.getSpeechColour();
+			return super.getDefaultSpeechColour();
 		}
 		return "#caa1ea";
 	}

--- a/src/com/lilithsthrone/game/character/npc/dominion/Pazu.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Pazu.java
@@ -106,7 +106,7 @@ public class Pazu extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#7000FA";
 		} else {

--- a/src/com/lilithsthrone/game/character/npc/dominion/Saellatrix.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Saellatrix.java
@@ -376,7 +376,7 @@ public class Saellatrix extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#eb6a91";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/dominion/Scarlett.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Scarlett.java
@@ -309,7 +309,7 @@ public class Scarlett extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(this.hasVagina()) {
 			if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 				return "#fa2ca7";

--- a/src/com/lilithsthrone/game/character/npc/dominion/SupplierLeader.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/SupplierLeader.java
@@ -228,7 +228,7 @@ public class SupplierLeader extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#d2ab77";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/dominion/SupplierPartner.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/SupplierPartner.java
@@ -223,7 +223,7 @@ public class SupplierPartner extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#d2ba74";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/dominion/Vanessa.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Vanessa.java
@@ -263,7 +263,7 @@ public class Vanessa extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#E7CAE6";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/dominion/Wes.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Wes.java
@@ -283,7 +283,7 @@ public class Wes extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#ef9424";
 		}

--- a/src/com/lilithsthrone/game/character/npc/dominion/Zaranix.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Zaranix.java
@@ -236,7 +236,7 @@ public class Zaranix extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(this.isFeminine()) {
 			return "#EB82ED";
 		} else {

--- a/src/com/lilithsthrone/game/character/npc/dominion/ZaranixMaidKatherine.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/ZaranixMaidKatherine.java
@@ -270,7 +270,7 @@ public class ZaranixMaidKatherine extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#E48AFF";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/dominion/ZaranixMaidKelly.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/ZaranixMaidKelly.java
@@ -269,7 +269,7 @@ public class ZaranixMaidKelly extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#E48AFF";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Angelixx.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Angelixx.java
@@ -364,7 +364,7 @@ public class Angelixx extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.game.isLightTheme()) {
 			return PresetColour.BASE_YELLOW_LIGHT.toWebHexString();
 		}

--- a/src/com/lilithsthrone/game/character/npc/fields/Arion.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Arion.java
@@ -236,7 +236,7 @@ public class Arion extends NPC {
 	}
 	
 //	@Override
-//	public String getSpeechColour() {
+//	protected String getDefaultSpeechColour() {
 //		return "#e4a1e0";
 //	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Astrapi.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Astrapi.java
@@ -329,7 +329,7 @@ public class Astrapi extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.game.isLightTheme()) {
 			return "#918365";
 		}

--- a/src/com/lilithsthrone/game/character/npc/fields/Aurokaris.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Aurokaris.java
@@ -266,7 +266,7 @@ public class Aurokaris extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return PresetColour.BASE_PERIWINKLE.toWebHexString();
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Belle.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Belle.java
@@ -256,7 +256,7 @@ public class Belle extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return PresetColour.BASE_PINK_SALMON.toWebHexString();
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Ceridwen.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Ceridwen.java
@@ -213,7 +213,7 @@ public class Ceridwen extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return PresetColour.BASE_PINK_SALMON.toWebHexString();
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Daphne.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Daphne.java
@@ -242,7 +242,7 @@ public class Daphne extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return PresetColour.BASE_PINK_LIGHT.toWebHexString();
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Eisek.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Eisek.java
@@ -309,7 +309,7 @@ public class Eisek extends NPC {
     }
     
     @Override
-    public String getSpeechColour() {
+    protected String getDefaultSpeechColour() {
     	if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
         	return "#55a2d5";
         }

--- a/src/com/lilithsthrone/game/character/npc/fields/Fae.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Fae.java
@@ -270,7 +270,7 @@ public class Fae extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#ff99cb";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Farah.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Farah.java
@@ -235,7 +235,7 @@ public class Farah extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return PresetColour.BASE_PINK.toWebHexString();
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Ghost.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Ghost.java
@@ -261,7 +261,7 @@ public class Ghost extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.game.isLightTheme()) {
 			return "#48372b";
 		}

--- a/src/com/lilithsthrone/game/character/npc/fields/Hale.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Hale.java
@@ -230,7 +230,7 @@ public class Hale extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#d1c084";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Hammer.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Hammer.java
@@ -261,7 +261,7 @@ public class Hammer extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.game.isLightTheme()) {
 			return "#3b3e4e";
 		}

--- a/src/com/lilithsthrone/game/character/npc/fields/HeadlessHorseman.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/HeadlessHorseman.java
@@ -232,7 +232,7 @@ public class HeadlessHorseman extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return PresetColour.BASE_RED.toWebHexString();
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Heather.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Heather.java
@@ -294,7 +294,7 @@ public class Heather extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#d6a5e6";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Imsu.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Imsu.java
@@ -229,7 +229,7 @@ public class Imsu extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#d18484";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Jess.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Jess.java
@@ -255,7 +255,7 @@ public class Jess extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.game.isLightTheme()) {
 			return "#cb3138";
 		}

--- a/src/com/lilithsthrone/game/character/npc/fields/Kazik.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Kazik.java
@@ -259,7 +259,7 @@ public class Kazik extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#94b0ff";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Kheiron.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Kheiron.java
@@ -245,7 +245,7 @@ public class Kheiron extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.game.isLightTheme()) {
 			return "#2b4a8a";
 		}

--- a/src/com/lilithsthrone/game/character/npc/fields/Lunette.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Lunette.java
@@ -125,7 +125,7 @@ public class Lunette extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		//TODO
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#71009E";

--- a/src/com/lilithsthrone/game/character/npc/fields/Lunexis.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Lunexis.java
@@ -351,7 +351,7 @@ public class Lunexis extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return PresetColour.BASE_RED.toWebHexString();
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Minotallys.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Minotallys.java
@@ -340,7 +340,7 @@ public class Minotallys extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(this.getTorsoType().getRace()==Race.DEMON) {
 			if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 				return "#872f91";

--- a/src/com/lilithsthrone/game/character/npc/fields/Monica.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Monica.java
@@ -379,7 +379,7 @@ public class Monica extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#ffb8a3";
 	}
 

--- a/src/com/lilithsthrone/game/character/npc/fields/Moreno.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Moreno.java
@@ -207,7 +207,7 @@ public class Moreno extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#808fff";
 	}
 

--- a/src/com/lilithsthrone/game/character/npc/fields/Nir.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Nir.java
@@ -307,7 +307,7 @@ public class Nir extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.game.isLightTheme()) {
 			return "#2f2b27";
 		}

--- a/src/com/lilithsthrone/game/character/npc/fields/Nizhoni.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Nizhoni.java
@@ -245,7 +245,7 @@ public class Nizhoni extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#ff997a";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Oglix.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Oglix.java
@@ -310,7 +310,7 @@ public class Oglix extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return PresetColour.BASE_GREEN.toWebHexString();
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Silvia.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Silvia.java
@@ -257,7 +257,7 @@ public class Silvia extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#ffb3ff";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Sleip.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Sleip.java
@@ -340,7 +340,7 @@ public class Sleip extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.game.isLightTheme()) {
 			return "#242120";
 		}

--- a/src/com/lilithsthrone/game/character/npc/fields/Sterope.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Sterope.java
@@ -362,7 +362,7 @@ public class Sterope extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#f282f7";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Ursa.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Ursa.java
@@ -243,7 +243,7 @@ public class Ursa extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return PresetColour.BASE_BROWN.toWebHexString();
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Vronti.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Vronti.java
@@ -263,7 +263,7 @@ public class Vronti extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.game.isLightTheme()) {
 			return "#1c5583";
 		}

--- a/src/com/lilithsthrone/game/character/npc/fields/Yui.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Yui.java
@@ -290,7 +290,7 @@ public class Yui extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#ff799b";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/fields/Ziva.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Ziva.java
@@ -238,7 +238,7 @@ public class Ziva extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return "#ee4078";
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/misc/PrologueFemale.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/PrologueFemale.java
@@ -228,7 +228,7 @@ public class PrologueFemale extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#D60092";
 			

--- a/src/com/lilithsthrone/game/character/npc/misc/PrologueMale.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/PrologueMale.java
@@ -208,7 +208,7 @@ public class PrologueMale extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#2D3795";
 			

--- a/src/com/lilithsthrone/game/character/npc/submission/DarkSiren.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/DarkSiren.java
@@ -405,7 +405,7 @@ public class DarkSiren extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#7E0094";
 		}//

--- a/src/com/lilithsthrone/game/character/npc/submission/HazmatRat.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/HazmatRat.java
@@ -198,7 +198,7 @@ public class HazmatRat extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		return PresetColour.BASE_GREEN_LIME.toWebHexString();
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/submission/Lyssieth.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/Lyssieth.java
@@ -332,7 +332,7 @@ public class Lyssieth extends NPC {
 	}
 	
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(Main.getProperties().hasValue(PropertyValue.lightTheme)) {
 			return "#71009E";
 		}

--- a/src/com/lilithsthrone/game/character/npc/submission/Murk.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/Murk.java
@@ -395,7 +395,7 @@ public class Murk extends NPC {
 	}
 
 	@Override
-	public String getSpeechColour() {
+	protected String getDefaultSpeechColour() {
 		if(this.isFeminine()) {
 			return PresetColour.BASE_TAN.toWebHexString();
 		}


### PR DESCRIPTION
<b>Please only submit Pull Requests to the dev branch!</b>

### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
Improve public access to character speech colours for mods. This will make my Speech Clinic mod a little bit cleaner and allow it to work on unique NPCs.

- Give a brief description of what you changed or added.
  - Added a getSpeechColourAsColour as a public getter for speechColour, since getSpeechColour is already used to get the hex string.
  - Split getSpeechColour into getDefaultSpeechColour to enable use of the speechColour variable on unique NPCs.
  - Changed NPC subclasses to override getDefaultSpeechColour instead of getSpeechColour directly.

- Are any new graphical assets required?
No.

- Has this change been tested? If so, mention the version number that the test was based on.
Testing was based on Lilith's Throne 0.4.11.3 and Java 1.8.0_172.

- So we have a better idea of who you are, what is your Discord Handle?
stormystar