### PR TITLE
Made all references to age 18 use minimum age,

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<name>Lilith's Throne</name>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.release>11</maven.compiler.release>
+		<maven.compiler.release>8</maven.compiler.release>
 		<javafx.version>18.0.2</javafx.version>
 		<nashorn.version>15.4</nashorn.version>
 		<javafx.maven.plugin.version>0.0.8</javafx.maven.plugin.version>

--- a/src/com/lilithsthrone/game/Game.java
+++ b/src/com/lilithsthrone/game/Game.java
@@ -599,7 +599,7 @@ public class Game implements XMLSaving {
 						CharacterImportSetting.CLEAR_FAMILY_ID);
 				try {
 					if(((Element)((Element)((Element)characterElement.getElementsByTagName("character").item(0)).getElementsByTagName("core").item(0)).getElementsByTagName("id").item(0)).getAttribute("value").equals("PlayerCharacter")) {
-						importedSlave.setBirthday(importedSlave.getBirthday().plusYears(18)); // If the imported character is a player character, they need to have their age adjusted to fit with the fact that NPCs start at age 18
+						importedSlave.setBirthday(importedSlave.getBirthday().plusYears(GameCharacter.MINIMUM_AGE)); // If the imported character is a player character, they need to have their age adjusted to fit with the fact that NPCs start at age 18
 					}
 				} catch(Exception ex) {	
 				}
@@ -684,7 +684,7 @@ public class Game implements XMLSaving {
 						CharacterImportSetting.CLEAR_FAMILY_ID);
 				try {
 					if(((Element)((Element)((Element)characterElement.getElementsByTagName("character").item(0)).getElementsByTagName("core").item(0)).getElementsByTagName("id").item(0)).getAttribute("value").equals("PlayerCharacter")) {
-						importedLodger.setBirthday(importedLodger.getBirthday().plusYears(18)); // If the imported character is a player character, they need to have their age adjusted to fit with the fact that NPCs start at age 18
+						importedLodger.setBirthday(importedLodger.getBirthday().plusYears(GameCharacter.MINIMUM_AGE)); // If the imported character is a player character, they need to have their age adjusted to fit with the fact that NPCs start at age 18
 					}
 				} catch(Exception ex) {
 				}
@@ -731,7 +731,7 @@ public class Game implements XMLSaving {
 						CharacterImportSetting.CLEAR_FAMILY_ID);
 				try {
 					if(((Element)((Element)((Element)characterElement.getElementsByTagName("character").item(0)).getElementsByTagName("core").item(0)).getElementsByTagName("id").item(0)).getAttribute("value").equals("PlayerCharacter")) {
-						importedClubber.setBirthday(importedClubber.getBirthday().plusYears(18)); // If the imported character is a player character, they need to have their age adjusted to fit with the fact that NPCs start at age 18
+						importedClubber.setBirthday(importedClubber.getBirthday().plusYears(GameCharacter.MINIMUM_AGE)); // If the imported character is a player character, they need to have their age adjusted to fit with the fact that NPCs start at age 18
 					}
 				} catch(Exception ex) {
 				}

--- a/src/com/lilithsthrone/game/character/CharacterUtils.java
+++ b/src/com/lilithsthrone/game/character/CharacterUtils.java
@@ -2061,10 +2061,10 @@ public class CharacterUtils {
 			character.setConceptionDate(character.getBirthday().minusDays(15+Util.random.nextInt(30)));
 			
 			if(character.getRace()==Race.HARPY) {
-				character.setAgeAppearanceDifferenceToAppearAsAge(Math.min(character.getAgeValue(), 18+Util.random.nextInt(9)));
+				character.setAgeAppearanceDifferenceToAppearAsAge(Math.min(character.getAgeValue(), GameCharacter.MINIMUM_AGE+Util.random.nextInt(9)));
 			}
 			if(character.getSubspeciesOverride()!=null && character.getSubspeciesOverride().isDoesNotAge()) {
-				character.setAgeAppearanceAbsolute(Math.min(character.getAgeValue(), 18+Util.random.nextInt(19))); // Range of real age to 36
+				character.setAgeAppearanceAbsolute(Math.min(character.getAgeValue(), GameCharacter.MINIMUM_AGE+Util.random.nextInt(19))); // Range of real age to 36
 				//System.out.println("Override: "+character.getAgeAppearanceAbsolute()+", "+character.getAgeValue());
 			}
 		}
@@ -2299,7 +2299,7 @@ public class CharacterUtils {
 			if(character.hasFetish(Fetish.FETISH_PURE_VIRGIN)
 					&& character.getHistory()!=Occupation.NPC_PROSTITUTE
 					&& !character.hasPersonalityTrait(PersonalityTrait.LEWD)
-					&& (!character.getHistory().isLowlife() || character.getAgeValue()==18)) {
+					&& (!character.getHistory().isLowlife() || character.getAgeValue()==GameCharacter.MINIMUM_AGE)) {
 				character.setVaginaVirgin(true);
 				if(Math.random()<0.33f) {
 					character.addPersonalityTrait(PersonalityTrait.INNOCENT);

--- a/src/com/lilithsthrone/game/character/GameCharacter.java
+++ b/src/com/lilithsthrone/game/character/GameCharacter.java
@@ -320,7 +320,7 @@ public abstract class GameCharacter implements XMLSaving {
 	public static final int MAX_COMBAT_MOVES = 8;
 	public static final int DEFAULT_COMBAT_AP = 3;
 
-	public static final int MINIMUM_AGE = 18;
+	public static final int MINIMUM_AGE = 18;// Todo, unlock to non-final to allow setting between 18-25 for CYOA reasons
 	
 	public static final int DEFAULT_TIME_START_VALUE = -1;
 	
@@ -2839,18 +2839,18 @@ public abstract class GameCharacter implements XMLSaving {
 				character.setConceptionDate(LocalDateTime.of(year, month, day, 12, 0));
 				
 				if(Main.isVersionOlderThan(Game.loadingVersion, "0.3.7.4") && !character.isPlayer()) { // Birthdays prior to v0.3.7.4 are loaded based on conception date, as a bug introduced in v0.3.7.3 caused birthdays to regress by 18 years:
-					if(year+18<=Main.game.getDateNow().getYear()) {
-						character.setBirthday(LocalDateTime.of(year+18, character.getBirthMonth(), character.getDayOfBirth(), 12, 0));
-						character.setConceptionDate(LocalDateTime.of(year+18, character.getBirthMonth(), character.getDayOfBirth(), 12, 0).minusDays(15+Util.random.nextInt(30)));
+					if(year+GameCharacter.MINIMUM_AGE<=Main.game.getDateNow().getYear()) {
+						character.setBirthday(LocalDateTime.of(year+GameCharacter.MINIMUM_AGE, character.getBirthMonth(), character.getDayOfBirth(), 12, 0));
+						character.setConceptionDate(LocalDateTime.of(year+GameCharacter.MINIMUM_AGE, character.getBirthMonth(), character.getDayOfBirth(), 12, 0).minusDays(15+Util.random.nextInt(30)));
 					} else {
 						character.setBirthday(LocalDateTime.of(year, character.getBirthMonth(), character.getDayOfBirth(), 12, 0));
 					}
 					
 				} else if(Main.isVersionOlderThan(Game.loadingVersion, "0.3.7.7") && character.isPlayer()) { // Reverting the above change for player characters
 					int age = (int) ChronoUnit.YEARS.between(character.getBirthday(), Main.game.getDateNow());
-					if(age<18) {
-						character.setBirthday(LocalDateTime.of(character.getBirthday().getYear()-18, character.getBirthMonth(), character.getDayOfBirth(), 12, 0));
-						character.setConceptionDate(LocalDateTime.of(year-18, month, day, 12, 0));
+					if(age<GameCharacter.MINIMUM_AGE) {
+						character.setBirthday(LocalDateTime.of(character.getBirthday().getYear()-GameCharacter.MINIMUM_AGE, character.getBirthMonth(), character.getDayOfBirth(), 12, 0));
+						character.setConceptionDate(LocalDateTime.of(year-GameCharacter.MINIMUM_AGE, month, day, 12, 0));
 					}
 				}
 				
@@ -3799,7 +3799,7 @@ public abstract class GameCharacter implements XMLSaving {
 					infoScreenSB.append(UtilText.parse(this,
 							", which"
 							+ (!this.isPlayer()
-								?", due to the fact that everyone in this world starts out as being 18 from the date of their birth,"
+								?", due to the fact that everyone in this world starts out as being " + GameCharacter.MINIMUM_AGE + " from the date of their birth,"
 								:"")
 							+ " makes [npc.herHim] <span style='color:"+this.getAge().getColour().toWebHexString()+";'>"+Util.intToString(this.getAgeValue())+"</span> years old."));
 				}
@@ -4312,7 +4312,7 @@ public abstract class GameCharacter implements XMLSaving {
 		
 		// This is the same as the age setting in CharacterUtil.randomiseBody()
 		if(Main.game.isStarted() && startingSpeciesType.isDoesNotAge() && this.getAgeAppearanceAbsolute()==0) {
-			this.setAgeAppearanceAbsolute(Math.min(this.getAgeValue(), 18+Util.random.nextInt(19))); // Range of real age to 36
+			this.setAgeAppearanceAbsolute(Math.min(this.getAgeValue(), GameCharacter.MINIMUM_AGE+Util.random.nextInt(19))); // Range of real age to 36
 			//System.out.println("Setup: "+this.getAgeAppearanceAbsolute()+", "+this.getAgeValue());
 		}
 	}

--- a/src/com/lilithsthrone/game/character/npc/dominion/Cultist.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Cultist.java
@@ -99,7 +99,7 @@ public class Cultist extends NPC {
 
 			this.setHistory(Occupation.NPC_CULTIST);
 			
-			this.setAgeAppearanceAbsolute(18+Util.random.nextInt(10));
+			this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE+Util.random.nextInt(10));
 			
 			this.setVaginaVirgin(false);
 			this.setAssVirgin(false);
@@ -136,7 +136,7 @@ public class Cultist extends NPC {
 			this.setFetishDesire(Fetish.FETISH_PENIS_GIVING, FetishDesire.TWO_NEUTRAL);
 		}
 		if(Main.isVersionOlderThan(Game.loadingVersion, "0.2.11")) {
-			this.setAgeAppearanceAbsolute(18+Util.random.nextInt(10));
+			this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE+Util.random.nextInt(10));
 		}
 		if(Main.isVersionOlderThan(Game.loadingVersion, "0.3.3.6")) {
 			this.setLevel(15);

--- a/src/com/lilithsthrone/game/character/npc/dominion/DollFactorySuccubus.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DollFactorySuccubus.java
@@ -63,7 +63,7 @@ public class DollFactorySuccubus extends NPC {
 	public DollFactorySuccubus(boolean isImported) {
 		super(isImported, null, "Loviennemartuilani",
 				"",
-				Util.random.nextInt(50)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(28),
+				Util.random.nextInt(50)+GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(28),
 				25,
 				Gender.F_V_B_FEMALE, Subspecies.DEMON, RaceStage.GREATER,
 				new CharacterInventory(false, 10), 

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionAlleywayAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionAlleywayAttacker.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -65,7 +66,7 @@ public class DominionAlleywayAttacker extends NPC {
 	 */
 	public DominionAlleywayAttacker(Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.DOMINION, PlaceType.DOMINION_BACK_ALLEYS, false,

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionClubNPC.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionClubNPC.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.dominion;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -40,7 +41,7 @@ public class DominionClubNPC extends NPC {
 	
 	public DominionClubNPC(Gender gender, AbstractSubspecies subspecies, RaceStage raceStage, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.EMPTY, PlaceType.GENERIC_CLUB_HOLDING_CELL, false);

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionExpressCentaur.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionExpressCentaur.java
@@ -60,7 +60,7 @@ public class DominionExpressCentaur extends NPC {
 	public DominionExpressCentaur(Gender gender, Colour collarColour, boolean isImported) {
 		super(isImported,
 				null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.DOMINION_EXPRESS, PlaceType.DOMINION_EXPRESS_STABLES, false);

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionSuccubusAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionSuccubusAttacker.java
@@ -59,7 +59,7 @@ public class DominionSuccubusAttacker extends NPC {
 	
 	public DominionSuccubusAttacker(boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(50)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(50)+GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				5, Gender.getGenderFromUserPreferences(Femininity.FEMININE), Subspecies.DEMON, RaceStage.GREATER,
 				new CharacterInventory(false, 10), WorldType.DOMINION, PlaceType.DOMINION_BACK_ALLEYS, false);
 
@@ -89,7 +89,7 @@ public class DominionSuccubusAttacker extends NPC {
 
 			setSexualOrientation(SexualOrientation.AMBIPHILIC);
 			
-			this.setAgeAppearanceAbsolute(18+Util.random.nextInt(10));
+			this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE+Util.random.nextInt(10));
 			
 			this.setVaginaVirgin(false);
 			this.setAssVirgin(false);
@@ -140,7 +140,7 @@ public class DominionSuccubusAttacker extends NPC {
 			this.setFetishDesire(Fetish.FETISH_NON_CON_DOM, FetishDesire.TWO_NEUTRAL);
 		}
 		if(Main.isVersionOlderThan(Game.loadingVersion, "0.2.11")) {
-			this.setAgeAppearanceAbsolute(18+Util.random.nextInt(10));
+			this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE+Util.random.nextInt(10));
 		}
 	}
 

--- a/src/com/lilithsthrone/game/character/npc/dominion/EnforcerPatrol.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/EnforcerPatrol.java
@@ -71,7 +71,7 @@ public class EnforcerPatrol extends NPC {
 	
 	public EnforcerPatrol(Occupation occupation, Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				5, gender, null, null,
 				new CharacterInventory(false, 10), WorldType.ENFORCER_HQ, PlaceType.ENFORCER_HQ_CELLS_OFFICE, false,
 				generationFlags);

--- a/src/com/lilithsthrone/game/character/npc/dominion/EnforcerWarehouseGuard.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/EnforcerWarehouseGuard.java
@@ -60,7 +60,7 @@ public class EnforcerWarehouseGuard extends NPC {
 	
 	public EnforcerWarehouseGuard(Occupation occupation, AbstractSubspecies subspecies, RaceStage raceStage, Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				5, gender, subspecies, raceStage,
 				new CharacterInventory(false, 10), WorldType.ENFORCER_WAREHOUSE, PlaceType.ENFORCER_WAREHOUSE_ENFORCER_GUARD_POST, false,
 				generationFlags);

--- a/src/com/lilithsthrone/game/character/npc/dominion/HarpyNestsAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/HarpyNestsAttacker.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import com.lilithsthrone.game.character.body.valueEnums.Femininity;
 import com.lilithsthrone.game.character.fetishes.Fetish;
 
@@ -58,7 +59,7 @@ public class HarpyNestsAttacker extends NPC {
 	
 	public HarpyNestsAttacker(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				4,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.HARPY_NEST, PlaceType.HARPY_NESTS_WALKWAYS, false);

--- a/src/com/lilithsthrone/game/character/npc/dominion/ReindeerOverseer.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/ReindeerOverseer.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.dominion;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -60,7 +61,7 @@ public class ReindeerOverseer extends NPC {
 	
 	public ReindeerOverseer(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				10,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.DOMINION, PlaceType.DOMINION_STREET, false);

--- a/src/com/lilithsthrone/game/character/npc/dominion/SlaveInStocks.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/SlaveInStocks.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -52,7 +53,7 @@ public class SlaveInStocks extends NPC {
 	
 	public SlaveInStocks(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.SLAVER_ALLEY, PlaceType.SLAVER_ALLEY_PUBLIC_STOCKS, false);

--- a/src/com/lilithsthrone/game/character/npc/dominion/ZaranixMaidKatherine.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/ZaranixMaidKatherine.java
@@ -100,7 +100,7 @@ public class ZaranixMaidKatherine extends NPC {
 			resetBodyAfterVersion_2_10_5();
 		}
 		if(Main.isVersionOlderThan(Game.loadingVersion, "0.2.11")) {
-			this.setAgeAppearanceAbsolute(18);
+			this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE);
 		}
 		if(Main.isVersionOlderThan(Game.loadingVersion, "0.3.3.6")) {
 			this.resetPerksMap(true);
@@ -147,7 +147,7 @@ public class ZaranixMaidKatherine extends NPC {
 		
 		// Body:
 		// Add full body reset as this method is called after leaving Zaranix's house:
-		this.setAgeAppearanceAbsolute(18);
+		this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE);
 		this.setBody(Gender.F_P_V_B_FUTANARI, Subspecies.DEMON, RaceStage.GREATER, false);
 		this.setTailType(TailType.DEMON_COMMON);
 		this.setWingType(WingType.NONE);

--- a/src/com/lilithsthrone/game/character/npc/dominion/ZaranixMaidKelly.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/ZaranixMaidKelly.java
@@ -100,7 +100,7 @@ public class ZaranixMaidKelly extends NPC {
 			resetBodyAfterVersion_2_10_5();
 		}
 		if(Main.isVersionOlderThan(Game.loadingVersion, "0.2.11")) {
-			this.setAgeAppearanceAbsolute(18);
+			this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE);
 		}
 		if(Main.isVersionOlderThan(Game.loadingVersion, "0.3.3.6")) {
 			this.resetPerksMap(true);
@@ -146,7 +146,7 @@ public class ZaranixMaidKelly extends NPC {
 		
 		// Body:
 		// Add full body reset as this method is called after leaving Zaranix's house:
-		this.setAgeAppearanceAbsolute(18);
+		this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE);
 		this.setBody(Gender.F_P_V_B_FUTANARI, Subspecies.DEMON, RaceStage.GREATER, false);
 		this.setTailType(TailType.DEMON_COMMON);
 		this.setWingType(WingType.NONE);

--- a/src/com/lilithsthrone/game/character/npc/fields/Angelixx.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Angelixx.java
@@ -214,7 +214,7 @@ public class Angelixx extends NPC {
 		
 		
 		// Body:
-		this.setAgeAppearanceAbsolute(18);
+		this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE);
 		this.setTailType(TailType.NONE);
 		this.setWingType(WingType.DEMON_FEATHERED);
 		this.setWingSize(WingSize.ZERO_TINY.getValue());

--- a/src/com/lilithsthrone/game/character/npc/fields/ElisAlleywayAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/ElisAlleywayAttacker.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -60,7 +61,7 @@ public class ElisAlleywayAttacker extends NPC {
 	 */
 	public ElisAlleywayAttacker(Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/fields/Evelyx.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/Evelyx.java
@@ -192,7 +192,7 @@ public class Evelyx extends NPC {
 		
 		
 		// Body:
-		this.setAgeAppearanceAbsolute(18);
+		this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE);
 		this.setTailType(TailType.DEMON_COMMON);
 		this.setWingType(WingType.NONE);
 		this.setLegType(LegType.DEMON_HOOFED);

--- a/src/com/lilithsthrone/game/character/npc/fields/EvelyxMilker.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/EvelyxMilker.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -64,7 +65,7 @@ public class EvelyxMilker extends NPC {
 
 	public EvelyxMilker(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.DOMINION, PlaceType.DOMINION_BACK_ALLEYS, false);

--- a/src/com/lilithsthrone/game/character/npc/fields/FieldsBandit.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/FieldsBandit.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -55,7 +56,7 @@ public class FieldsBandit extends NPC {
 	 */
 	public FieldsBandit(Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				5,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.EMPTY, PlaceType.GENERIC_HOLDING_CELL, false,

--- a/src/com/lilithsthrone/game/character/npc/fields/LunetteMelee.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/LunetteMelee.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.fields;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -76,7 +77,7 @@ public class LunetteMelee extends NPC {
 	public LunetteMelee(List<String> namePrefixes, String name, boolean isImported) {
 		super(isImported,
 				null, null, "",
-				Util.random.nextInt(100)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(100)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				30,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/fields/LunetteRanged.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/LunetteRanged.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.fields;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -76,7 +77,7 @@ public class LunetteRanged extends NPC {
 	public LunetteRanged(List<String> namePrefixes, String name, boolean isImported) {
 		super(isImported,
 				null, null, "",
-				Util.random.nextInt(100)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(100)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				30,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/fields/SillyModeLARPAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/SillyModeLARPAttacker.java
@@ -65,7 +65,7 @@ public class SillyModeLARPAttacker extends NPC {
 	 */
 	public SillyModeLARPAttacker(Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/misc/BasicDoll.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/BasicDoll.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.misc;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -50,7 +51,7 @@ public class BasicDoll extends NPC {
 		super(isImported,
 				new NameTriplet("Doll"), "",
 				"",
-				18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(27),
+				GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(27),
 				1,
 				null, null, null,
 				new CharacterInventory(false, 0),

--- a/src/com/lilithsthrone/game/character/npc/misc/ClubberImport.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/ClubberImport.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.misc;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -35,7 +36,7 @@ public class ClubberImport extends NPC {
 	
 	public ClubberImport(boolean isImported) {
 		super(isImported, new NameTriplet("Clubber"), "", "-",
-				18, Month.JUNE, 10,
+				GameCharacter.MINIMUM_AGE, Month.JUNE, 10,
 				1, Gender.F_V_B_FEMALE, Subspecies.HUMAN, RaceStage.HUMAN,
 				new CharacterInventory(false, 0), WorldType.EMPTY, PlaceType.GENERIC_HOLDING_CELL, false);
 	}

--- a/src/com/lilithsthrone/game/character/npc/misc/Elemental.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/Elemental.java
@@ -75,7 +75,7 @@ public class Elemental extends NPC {
 	public Elemental(Gender gender, GameCharacter summoner, boolean isImported) {
 		super(isImported, null, null, "",
 				summoner==null
-					?18
+					?GameCharacter.MINIMUM_AGE
 					:summoner.getAgeValue(),
 				summoner==null
 					?Month.JANUARY

--- a/src/com/lilithsthrone/game/character/npc/misc/GenericSexualPartner.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/GenericSexualPartner.java
@@ -72,7 +72,7 @@ public class GenericSexualPartner extends NPC {
 	
 	public GenericSexualPartner(Gender gender, AbstractWorldType worldLocation, Vector2i location, boolean isImported, Predicate<AbstractSubspecies> subspeciesRemovalFilter) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/misc/LodgerImport.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/LodgerImport.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.misc;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -33,7 +34,7 @@ public class LodgerImport extends NPC {
 	
 	public LodgerImport(boolean isImported) {
 		super(isImported, new NameTriplet("Lodger"), "", "-",
-				18, Month.JUNE, 10,
+				GameCharacter.MINIMUM_AGE, Month.JUNE, 10,
 				1, Gender.F_V_B_FEMALE, Subspecies.HUMAN, RaceStage.HUMAN,
 				new CharacterInventory(false, 0), WorldType.EMPTY, PlaceType.GENERIC_HOLDING_CELL, false);
 	}

--- a/src/com/lilithsthrone/game/character/npc/misc/ModdedCharacter.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/ModdedCharacter.java
@@ -1,6 +1,7 @@
 package com.lilithsthrone.game.character.npc.misc;
 
 import com.lilithsthrone.game.character.CharacterImportSetting;
+import com.lilithsthrone.game.character.GameCharacter;
 import com.lilithsthrone.game.character.gender.Gender;
 import com.lilithsthrone.game.character.npc.NPC;
 import com.lilithsthrone.game.character.persona.Name;
@@ -58,7 +59,7 @@ public class ModdedCharacter extends NPC {
 
 	public ModdedCharacter(Gender gender, AbstractWorldType worldLocation, Vector2i location, boolean isImported, Predicate<AbstractSubspecies> subspeciesRemovalFilter) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/misc/NPCOffspring.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/NPCOffspring.java
@@ -46,7 +46,7 @@ public class NPCOffspring extends NPC {
 	
 	public NPCOffspring(boolean isImported) {
 		super(isImported, null, null, "",
-				18, Month.JUNE, 15,
+				GameCharacter.MINIMUM_AGE, Month.JUNE, 15,
 				3, Gender.F_V_B_FEMALE, Subspecies.DOG_MORPH, RaceStage.GREATER, new CharacterInventory(false, 10), WorldType.EMPTY, PlaceType.GENERIC_HOLDING_CELL, true);
 	}
 	

--- a/src/com/lilithsthrone/game/character/npc/misc/SlaveImport.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/SlaveImport.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.misc;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -36,7 +37,7 @@ public class SlaveImport extends NPC {
 	
 	public SlaveImport(boolean isImported) {
 		super(isImported, new NameTriplet("Slave"), "", "-",
-				18, Month.JUNE, 10,
+				GameCharacter.MINIMUM_AGE, Month.JUNE, 10,
 				1, Gender.F_V_B_FEMALE, Subspecies.HUMAN, RaceStage.HUMAN,
 				new CharacterInventory(false, 0), WorldType.EMPTY, PlaceType.GENERIC_HOLDING_CELL, false);
 	}

--- a/src/com/lilithsthrone/game/character/npc/submission/BatCavernLurkerAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/BatCavernLurkerAttacker.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -52,7 +53,7 @@ public class BatCavernLurkerAttacker extends NPC {
 	
 	public BatCavernLurkerAttacker(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.BAT_CAVERNS, PlaceType.BAT_CAVERN_DARK, false);

--- a/src/com/lilithsthrone/game/character/npc/submission/BatCavernSlimeAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/BatCavernSlimeAttacker.java
@@ -3,6 +3,7 @@ package com.lilithsthrone.game.character.npc.submission;
 import java.time.Month;
 import java.util.List;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -49,7 +50,7 @@ public class BatCavernSlimeAttacker extends NPC {
 	
 	public BatCavernSlimeAttacker(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3, gender, Subspecies.HUMAN, RaceStage.HUMAN,
 				new CharacterInventory(false, 10), WorldType.BAT_CAVERNS, PlaceType.BAT_CAVERN_DARK, false);
 

--- a/src/com/lilithsthrone/game/character/npc/submission/DarkSiren.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/DarkSiren.java
@@ -268,7 +268,7 @@ public class DarkSiren extends NPC {
 		
 		// Body:
 		this.setSubspeciesOverride(Subspecies.HALF_DEMON);
-		this.setAgeAppearanceAbsolute(18);
+		this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE);
 		this.setTailType(TailType.DEMON_COMMON);
 		this.setTailGirth(PenetrationGirth.FOUR_GIRTHY);
 		this.setWingType(WingType.DEMON_COMMON);

--- a/src/com/lilithsthrone/game/character/npc/submission/FortressFemalesLeader.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/FortressFemalesLeader.java
@@ -147,7 +147,7 @@ public class FortressFemalesLeader extends NPC {
 		
 		
 		// Body:
-		this.setAgeAppearanceAbsolute(18);
+		this.setAgeAppearanceAbsolute(GameCharacter.MINIMUM_AGE);
 		this.setTailType(TailType.DEMON_COMMON);
 		this.setWingType(WingType.DEMON_COMMON);
 		this.setLegType(LegType.DEMON_COMMON);

--- a/src/com/lilithsthrone/game/character/npc/submission/GamblingDenPatron.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/GamblingDenPatron.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -62,7 +63,7 @@ public class GamblingDenPatron extends NPC {
 	
 	public GamblingDenPatron(Gender gender, DicePokerTable table, AbstractWorldType worldType, AbstractPlaceType placeType, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/submission/ImpAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/ImpAttacker.java
@@ -81,7 +81,7 @@ public class ImpAttacker extends NPC {
 	
 	public ImpAttacker(AbstractSubspecies subspecies, Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3, gender, subspecies, RaceStage.GREATER,
 				new CharacterInventory(false, 10), WorldType.SUBMISSION, PlaceType.SUBMISSION_TUNNELS, false);
 		

--- a/src/com/lilithsthrone/game/character/npc/submission/RatGangMember.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/RatGangMember.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -64,7 +65,7 @@ public class RatGangMember extends NPC {
 	
 	public RatGangMember(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				5,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.RAT_WARRENS, PlaceType.RAT_WARRENS_VENGARS_HALL, false);

--- a/src/com/lilithsthrone/game/character/npc/submission/RatWarrensCaptive.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/RatWarrensCaptive.java
@@ -4,6 +4,7 @@ import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import com.lilithsthrone.game.character.body.valueEnums.*;
 import com.lilithsthrone.game.character.effects.Perk;
 import com.lilithsthrone.game.character.effects.PerkCategory;
@@ -70,7 +71,7 @@ public class RatWarrensCaptive extends NPC {
 	
 	public RatWarrensCaptive(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				5,
 				gender, Subspecies.HUMAN, RaceStage.HUMAN,
 				new CharacterInventory(false, 10), WorldType.RAT_WARRENS, PlaceType.RAT_WARRENS_MILKING_ROOM, false);

--- a/src/com/lilithsthrone/game/character/npc/submission/RebelBaseInsaneSurvivor.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/RebelBaseInsaneSurvivor.java
@@ -71,7 +71,7 @@ public class RebelBaseInsaneSurvivor extends NPC {
     
     public RebelBaseInsaneSurvivor(Gender gender, boolean isImported) {
         super(isImported, null, null, "",
-				(Main.game.getDateNow().getYear() - RECRUITMENT_YEAR) + 18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				(Main.game.getDateNow().getYear() - RECRUITMENT_YEAR) + GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				5,
 				gender, Subspecies.HUMAN, RaceStage.HUMAN,
 				new CharacterInventory(false, 10), WorldType.REBEL_BASE, PlaceType.REBEL_BASE_SLEEPING_AREA, false);

--- a/src/com/lilithsthrone/game/character/npc/submission/SubmissionAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/SubmissionAttacker.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.lilithsthrone.game.character.GameCharacter;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -66,7 +67,7 @@ public class SubmissionAttacker extends NPC {
 	 */
 	public SubmissionAttacker(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+ GameCharacter.MINIMUM_AGE, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.SUBMISSION, PlaceType.SUBMISSION_TUNNELS, false);

--- a/src/com/lilithsthrone/game/dialogue/story/CharacterCreation.java
+++ b/src/com/lilithsthrone/game/dialogue/story/CharacterCreation.java
@@ -1852,7 +1852,7 @@ public class CharacterCreation {
 		
 		Main.game.getNpc(Lilaya.class).setSkinCovering(new Covering(BodyCoveringType.HUMAN, Main.game.getPlayer().getCovering(BodyCoveringType.HUMAN).getPrimaryColour()), true);
 
-		Main.game.getNpc(Lilaya.class).setBirthday(LocalDateTime.of(Main.game.getPlayer().getBirthday().getYear()-22+18, Main.game.getNpc(Lilaya.class).getBirthMonth(), Main.game.getNpc(Lilaya.class).getDayOfBirth(), 12, 0));
+		Main.game.getNpc(Lilaya.class).setBirthday(LocalDateTime.of(Main.game.getPlayer().getBirthday().getYear()-22+GameCharacter.MINIMUM_AGE, Main.game.getNpc(Lilaya.class).getBirthMonth(), Main.game.getNpc(Lilaya.class).getDayOfBirth(), 12, 0));
 		
 		Main.game.clearTextStartStringBuilder();
 		Main.game.clearTextEndStringBuilder();

--- a/src/com/lilithsthrone/game/dialogue/utils/CharacterModificationUtils.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/CharacterModificationUtils.java
@@ -435,8 +435,8 @@ public class CharacterModificationUtils {
 			BodyChanging.getTarget().setBirthday(BodyChanging.getTarget().getBirthday().plusYears(age-(CharacterModificationUtils.MAX_AGE_NPC-GameCharacter.MINIMUM_AGE)));
 		}
 		
-		if(BodyChanging.getTarget().isPlayer() && age<18) {
-			BodyChanging.getTarget().setBirthday(BodyChanging.getTarget().getBirthday().minusYears(18-age));
+		if(BodyChanging.getTarget().isPlayer() && age<GameCharacter.MINIMUM_AGE) {
+			BodyChanging.getTarget().setBirthday(BodyChanging.getTarget().getBirthday().minusYears(GameCharacter.MINIMUM_AGE-age));
 		}
 		
 		if(age<0) {
@@ -470,7 +470,7 @@ public class CharacterModificationUtils {
 				contentSB.append("<div class='container-full-width' style='width:calc(33.3% - 16px);'>");
 					contentSB.append(applyDateWrapper("Age", "AGE", "", "",
 							String.valueOf(BodyChanging.getTarget().getAgeValue()),
-							BodyChanging.getTarget().getAgeValue()<=18,
+							BodyChanging.getTarget().getAgeValue()<=GameCharacter.MINIMUM_AGE,
 							BodyChanging.getTarget().isPlayer()
 								?BodyChanging.getTarget().getAgeValue()>=MAX_AGE_PLAYER
 								:BodyChanging.getTarget().getAgeValue()>=MAX_AGE_NPC));
@@ -514,7 +514,7 @@ public class CharacterModificationUtils {
 		contentSB.append("<div class='container-half-width'>");
 			contentSB.append(applyDateWrapper("Age", "AGE", "", "",
 					String.valueOf(BodyChanging.getTarget().getAgeValue()),
-					BodyChanging.getTarget().getAgeValue()<=18,
+					BodyChanging.getTarget().getAgeValue()<=GameCharacter.MINIMUM_AGE,
 					BodyChanging.getTarget().isPlayer()
 						?BodyChanging.getTarget().getAgeValue()>=MAX_AGE_PLAYER
 						:BodyChanging.getTarget().getAgeValue()>=MAX_AGE_NPC));
@@ -1022,7 +1022,7 @@ public class CharacterModificationUtils {
 		return applyFullVariableWrapper(
 				"Age Appearance",
 				UtilText.parse(BodyChanging.getTarget(),
-						"Change how old [npc.name] [npc.verb(appear)] to be. [npc.She] [npc.is] limited to looking as young as 18, or up to "
+						"Change how old [npc.name] [npc.verb(appear)] to be. [npc.She] [npc.is] limited to looking as young as " + GameCharacter.MINIMUM_AGE + ", or up to "
 						+ Util.intToString(BodyChanging.getTarget().getAgeDifferenceUpperLimit())
 						+ " years older than [npc.her] real age."
 						+ "<br/><i>This is purely a cosmetic change, and doesn't affect any in-game choices.</i>"),
@@ -1030,7 +1030,7 @@ public class CharacterModificationUtils {
 				"1",
 				"5",
 				String.valueOf(BodyChanging.getTarget().getAppearsAsAgeValue()),
-				BodyChanging.getTarget().getAppearsAsAgeValue()<=18,
+				BodyChanging.getTarget().getAppearsAsAgeValue()<=GameCharacter.MINIMUM_AGE,
 				BodyChanging.getTarget().getAppearsAsAgeValue()>=(BodyChanging.getTarget().getAgeValue()+BodyChanging.getTarget().getAgeDifferenceUpperLimit()))
 				
 				+ applyWrapper("Birthday",

--- a/src/com/lilithsthrone/game/dialogue/utils/MiscDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/MiscDialogue.java
@@ -780,7 +780,9 @@ public class MiscDialogue {
 
 			if(Main.getProperties().hasValue(PropertyValue.ageContent)) {
 				sb.append(startWrapper("Age Appearance"));
-					sb.append(applyWrapperDiscounted("18", "Our default model has the appearance of an 18 year old.", PresetColour.AGE_TEENS, "DOLL_AGE_0", "Select", ageOption==0, getAgeCost(0), true));
+					sb.append(applyWrapperDiscounted("" + GameCharacter.MINIMUM_AGE, "Our default model has the appearance of an " + GameCharacter.MINIMUM_AGE + " year old.",
+							PresetColour.AGE_TEENS, "DOLL_AGE_0", "Select",
+							ageOption==0, getAgeCost(0), true));
 					sb.append(applyWrapperDiscounted("20's", "We're able to age your doll a little if you like.", PresetColour.AGE_TWENTIES, "DOLL_AGE_1", "Select", ageOption==1, getAgeCost(1), true));
 					sb.append(applyWrapperDiscounted("30's", "Or we can double their age from the default, if you prefer.", PresetColour.AGE_THIRTIES, "DOLL_AGE_2", "Select", ageOption==2, getAgeCost(2), true));
 					sb.append(applyWrapperDiscounted("40's", "Want your doll to look like a MILF? We can do that too.", PresetColour.AGE_FORTIES, "DOLL_AGE_3", "Select", ageOption==3, getAgeCost(3), true));

--- a/src/com/lilithsthrone/main/Main.java
+++ b/src/com/lilithsthrone/main/Main.java
@@ -25,6 +25,7 @@ import com.lilithsthrone.game.Game;
 import com.lilithsthrone.game.Properties;
 import com.lilithsthrone.game.PropertyValue;
 import com.lilithsthrone.game.character.CharacterImportSetting;
+import com.lilithsthrone.game.character.GameCharacter;
 import com.lilithsthrone.game.character.PlayerCharacter;
 import com.lilithsthrone.game.character.body.valueEnums.Femininity;
 import com.lilithsthrone.game.character.gender.Gender;
@@ -120,7 +121,7 @@ public class Main extends Application {
 			+ " All of the characters that appear in this story are fictional entities who have given their consent to appear and act in this story."
 			+ " If you find yourself concerned for the characters in the story then please be reassured that they are all consenting adults who are speaking lines from a script."
 			+ " None of the characters portrayed within this game were or are being harmed in any way during the construction or execution of this game."
-			+ " Every character in the game is at least 18 years of age (or is magically the legal age needed to appear in erotic literature in whatever country you are playing this)."
+			+ " Every character in the game is at least " + GameCharacter.MINIMUM_AGE + " years of age (or is magically the legal age needed to appear in erotic literature in whatever country you are playing this)."
 			+  " No character in this game is blood-related to any other; once again, they are simply speaking lines from a script.<br/><br/>"
 
 			+ "By agreeing to this disclaimer and playing this game you agree to be exposed to graphic sexual and adult content that is presented as part of the game's fictional universe."


### PR DESCRIPTION
- What is the purpose of the pull request?
Made all references to age 18 use minimum age, to prep for allowing minimum age to be adjustable from 18-25 to comply with certain countries having age of majority higher than 18. A future push when Sliders are merged, will be allowing Minimum age to be adjusted to 18-25, and adding a disclaimer for "If the age of majority is not 18 please set it in the settings to comply with your local laws"

- Give a brief description of what you changed or added.
Made all references to age 18 use GameCharacter.MINIMUM_AGE.

- Are any new graphical assets required?
None

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.3.4

- So we have a better idea of who you are, what is your Discord Handle?
@keldonslayer

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
Already doneso