### PR TITLE
Added a replacement error logger, for de-duplicating stack traces

### DIFF
--- a/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
+++ b/src/com/lilithsthrone/game/dialogue/utils/OptionsDialogue.java
@@ -37,6 +37,7 @@ import com.lilithsthrone.game.character.race.Subspecies;
 import com.lilithsthrone.game.character.race.SubspeciesPreference;
 import com.lilithsthrone.game.dialogue.DialogueNode;
 import com.lilithsthrone.game.dialogue.DialogueNodeType;
+import com.lilithsthrone.game.dialogue.places.dominion.lilayashome.Library;
 import com.lilithsthrone.game.dialogue.responses.Response;
 import com.lilithsthrone.game.dialogue.responses.ResponseEffectsOnly;
 import com.lilithsthrone.game.dialogue.story.CharacterCreation;
@@ -52,6 +53,7 @@ import com.lilithsthrone.rendering.ArtistWebsite;
 import com.lilithsthrone.rendering.Artwork;
 import com.lilithsthrone.rendering.SVGImages;
 import com.lilithsthrone.utils.CreditsSlot;
+import com.lilithsthrone.utils.ErrorStream;
 import com.lilithsthrone.utils.Units;
 import com.lilithsthrone.utils.Util;
 import com.lilithsthrone.utils.colours.Colour;
@@ -99,7 +101,7 @@ public class OptionsDialogue {
 					.append(" [style.italicsMinorBad(<b>Note:</b> Intrusive age verification is being rolled out on blogspot, so I will likely create a new blog soon.)]</p>")
 					.append("<p style='text-align:center'><b>Please use either my blog or github to get the latest official version of Lilith's Throne!</b></p>")
 					.append("<p style='text-align:center'><i>Copy over the contents of your 'data' folder to use your old saves in this version!</i></p>");
-			
+			sb.append((ErrorStream.newErrorLog ? "<p style='text-align:center;color:#F44';>You have a new error log file in /data/ </p>" : ""));
 			sb.append(getJavaVersionInformation());
 			
 			if(Toolkit.getDefaultToolkit().getScreenSize().getHeight()<800) {

--- a/src/com/lilithsthrone/main/Main.java
+++ b/src/com/lilithsthrone/main/Main.java
@@ -35,12 +35,14 @@ import com.lilithsthrone.game.character.race.Subspecies;
 import com.lilithsthrone.game.combat.Combat;
 import com.lilithsthrone.game.dialogue.DialogueNode;
 import com.lilithsthrone.game.dialogue.DialogueNodeType;
+import com.lilithsthrone.game.dialogue.places.dominion.lilayashome.Library;
 import com.lilithsthrone.game.dialogue.responses.Response;
 import com.lilithsthrone.game.dialogue.story.CharacterCreation;
 import com.lilithsthrone.game.dialogue.utils.MapTravelType;
 import com.lilithsthrone.game.dialogue.utils.OptionsDialogue;
 import com.lilithsthrone.game.sex.Sex;
 import com.lilithsthrone.utils.CreditsSlot;
+import com.lilithsthrone.utils.ErrorStream;
 import com.lilithsthrone.utils.Util;
 import com.lilithsthrone.utils.colours.PresetColour;
 import com.lilithsthrone.world.Generation;
@@ -680,33 +682,30 @@ public class Main extends Application {
 		
 		// Open error log
 		if(!DEBUG) {
+			File errorLog = new File("data/error.log");
+			if (errorLog.exists() && ErrorStream.getLogLengthSafe(errorLog) > ErrorStream.ERR_LOG_INFO_LENGTH) {
+				ErrorStream.newErrorLog = true;
+				errorLog.renameTo(new File("data/error_log_" + errorLog.lastModified() + ".log"));
+			}
 			System.out.println("Printing to error.log");
 			try {
-				PrintStream stream = new PrintStream("data/error.log");
+				ErrorStream stream = new ErrorStream("data/error.log");
 				System.setErr(stream);
-				System.err.println("Game Version: "+VERSION_NUMBER+" ("+System.getProperty("build.type", "jar")+")");
-				System.err.println("Java: "+System.getProperty("java.version")+" ("+System.getProperty("java.vendor")+")");
-				System.err.println("OS: "+System.getProperty("os.name")+" ("+System.getProperty("os.arch")+")");
-				if (new File("res/mods").exists()) {
-					System.err.print("Mod folders present: ");
-					int i=0;
-					for(File f : new File("res/mods").listFiles()) {
-						if(f.isDirectory()) {
-							if(i>0) {
-								System.err.print(", ");
-							}
-							System.err.print(f.getName());
-						}
-						i++;
-					}
-					System.err.println();
-				}
-				
-				
-//				System.err.println("OS: "+System.getProperty("os.name"));
-				
+				stream.printData();
 			} catch (FileNotFoundException e) {
-				e.printStackTrace();
+				Alert a = new Alert(AlertType.ERROR,
+						"Unable to create or modify error.log ("+ (new File("./data/error.log")).getAbsolutePath()+")."
+								+ "\nMake sure that data exists, and that the file has write permissions."
+								+ "\n(Please do not extract the game into protected folders [C:\\, Desktop, OneDrive, etc...])"
+								+ "\nContinue?",
+						ButtonType.YES, ButtonType.NO);
+				System.err.println("Failed to create/modify error.log");
+				a.showAndWait().ifPresent(response -> {
+					if (response == ButtonType.NO) {
+						System.exit(1);
+					}
+				});
+
 			}
 		}
 		// Load properties:

--- a/src/com/lilithsthrone/utils/ErrorStream.java
+++ b/src/com/lilithsthrone/utils/ErrorStream.java
@@ -1,0 +1,114 @@
+package com.lilithsthrone.utils;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Objects;
+
+import static com.lilithsthrone.main.Main.VERSION_NUMBER;
+
+public class ErrorStream extends PrintStream {
+    /* this is a size assumption on average size + mod folders */
+    public static int ERR_LOG_INFO_LENGTH = 22;
+    public static boolean newErrorLog = false;
+    private static final ArrayList<String> KNOWN_ISSUES = new ArrayList<>();// this allows us to track what errors we've seen, to skip duplicate reports
+    public static int informationLines = 1;
+    public static boolean skipNextNL = false;
+
+    public ErrorStream(String fileName) throws FileNotFoundException {
+        super(fileName);
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len) {
+        String str = new String(buf, StandardCharsets.UTF_8); // Enables magic
+        if (str.startsWith("|") || str.startsWith("=")) informationLines++;
+        if (KNOWN_ISSUES.contains(str) && !str.startsWith("=")) return; // don't break my neat box
+        if (!str.equals(System.lineSeparator()))
+            KNOWN_ISSUES.add(str);
+        if (str.contains("WARNING: Unsupported JavaFX configuration") ||// HAHA We don't care! Java 9+ warning
+                str.trim().startsWith("at com.sun.") ||
+                str.trim().startsWith("at javafx.") || // added these to make the logs more readable,
+                str.trim().startsWith("at java.") ||
+                str.trim().startsWith("at org.openjdk.") ||
+                str.trim().startsWith("at jdk.dynalink")) {
+            skipNextNL = true;
+            return; //we don't care where in java the issue visited, only where in code path it happened.
+        }
+        if (skipNextNL) {
+            skipNextNL = false;
+            return;
+        }
+        super.write(buf, off, len);// The important line.
+    }
+
+    public void printData() {
+//        System.err.print("=".repeat(64) + System.lineSeparator());
+        System.err.print(repeatString("=", 64) + System.lineSeparator());
+        printInformationLine("Game Version : " + VERSION_NUMBER);
+        printInformationLine("Java : " + System.getProperty("java.version") + " [" + System.getProperty("sun.arch.data.model") + "-bit] (" + System.getProperty("java.vendor") + ")");
+        printInformationLine("OS : " + System.getProperty("os.name") + " (" + System.getProperty("os.arch") + ")");
+        if (new File("res/mods").exists()) {
+            StringBuilder mods = new StringBuilder();
+            int i = 0;
+            for (File f : Objects.requireNonNull(new File("res/mods").listFiles())) {
+                if (f.isDirectory()) {
+                    if (i > 0) {
+                        mods.append(", ");
+                    }
+                    mods.append(f.getName());
+                }
+                i++;
+            }
+            String info = "Mod folders present: " + mods;
+            if (info.length() > 60) {
+                String[] infArr = mods.toString().split(", ");
+                StringBuilder tInfo = new StringBuilder();
+                printInformationLine("Mod folders present");
+                for (int j = 0; j < infArr.length; j++) {
+                    if ((tInfo + (j == 0 ? "" : ", ") + infArr[j]).length() < 60) {
+                        tInfo.append(j == 0 ? "" : ", ").append(infArr[j]);
+                    } else {
+                        printInformationLine(tInfo.toString());
+                        tInfo.setLength(0);
+                    }
+                }
+                printInformationLine(tInfo.toString());
+            } else {
+                printInformationLine(info);
+            }
+        }
+        printInformationLine("Send this log file in a report on github");
+//        System.err.print("=".repeat(64) + System.lineSeparator());
+        System.err.print(repeatString("=", 64) + System.lineSeparator());
+        // This is saved in a file on my build, but as this isn't mine, I'm just making an assumption on average info size
+//        ERR_LOG_INFO_LENGTH = informationLines;// so we don't make backups of logs that are not longer than information chunk
+    }
+
+    public void printInformationLine(String information) {
+        int l = 62 - information.length();
+        System.err.print("|" + repeatString(" ", (int) (l / 2f)) + information + repeatString(" ", Math.round(l / 2f)) + "|" + System.lineSeparator());
+    }
+
+    private static String repeatString(String in, int count) {
+        String out = "";
+        for (int i = 0; i < count; i++) {
+            out += in;
+        }
+        return out;
+    }
+
+    public static long getLogLengthSafe(File errorLog) {
+        long len = 0;
+        if (!errorLog.exists()) return len;
+        try { len = getLogLength(errorLog); } catch (IOException ignored) { }
+        return len;
+    }
+
+    private static long getLogLength(File errorLog) throws IOException {
+        BufferedReader br = new BufferedReader(new FileReader(errorLog));
+        long length = br.lines().count();
+        br.close();
+        return length;
+    }
+}

--- a/src/com/lilithsthrone/utils/ErrorStream.java
+++ b/src/com/lilithsthrone/utils/ErrorStream.java
@@ -13,7 +13,6 @@ public class ErrorStream extends PrintStream {
     public static boolean newErrorLog = false;
     private static final ArrayList<String> KNOWN_ISSUES = new ArrayList<>();// this allows us to track what errors we've seen, to skip duplicate reports
     public static int informationLines = 1;
-    public static boolean skipNextNL = false;
 
     public ErrorStream(String fileName) throws FileNotFoundException {
         super(fileName);
@@ -26,19 +25,7 @@ public class ErrorStream extends PrintStream {
         if (KNOWN_ISSUES.contains(str) && !str.startsWith("=")) return; // don't break my neat box
         if (!str.equals(System.lineSeparator()))
             KNOWN_ISSUES.add(str);
-        if (str.contains("WARNING: Unsupported JavaFX configuration") ||// HAHA We don't care! Java 9+ warning
-                str.trim().startsWith("at com.sun.") ||
-                str.trim().startsWith("at javafx.") || // added these to make the logs more readable,
-                str.trim().startsWith("at java.") ||
-                str.trim().startsWith("at org.openjdk.") ||
-                str.trim().startsWith("at jdk.dynalink")) {
-            skipNextNL = true;
-            return; //we don't care where in java the issue visited, only where in code path it happened.
-        }
-        if (skipNextNL) {
-            skipNextNL = false;
-            return;
-        }
+        if (str.contains("WARNING: Unsupported JavaFX configuration")) return; // HAHA We don't care!
         super.write(buf, off, len);// The important line.
     }
 


### PR DESCRIPTION
### Things to include in a large Pull Request: ###

- What is the purpose of the pull request?
The intent is to replace the existing error logging, with one that tracks reports it's seen in the current run, so if something occurs multiple times, it only reports once in the file, to prevent log files that go upwards of 20GB (I've received one of those)
It also skips over native java code in the stack, since you only need to know where in the code you manage broke and why, not the remaining stack trace up to some sun.java start function

- Give a brief description of what you changed or added.
Added ErrorStream handler with an overwritten write function to skip seen errors from being logged, and prettify the error log info section, and added a warning on the home page for "a new error log was saved in /data/" when one is generated from a previous run.

- Are any new graphical assets required?
No

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.4.2+

- So we have a better idea of who you are, what is your Discord Handle?
@keldonslayer

- If you want quick feedback, you can use @Innoxia, or jump on the Lilith's Throne discord and send Innoxia a PM.
Will do

Said 20GB error log
<img width="1051" height="171" alt="image" src="https://github.com/user-attachments/assets/44b1f35e-f039-48ab-a878-6cac764864f3" />


Error backup warning
<img width="361" height="123" alt="image" src="https://github.com/user-attachments/assets/ca455e6d-ed49-441e-a9d5-0e3f886c126b" />
