### PR TITLE
Birthday to 1-31 days

### DIFF
--- a/src/com/lilithsthrone/game/character/npc/NPC.java
+++ b/src/com/lilithsthrone/game/character/npc/NPC.java
@@ -166,8 +166,8 @@ public abstract class NPC extends GameCharacter implements XMLSaving {
 			NPCGenerationFlag... generationFlags) {
 		super(nameTriplet, surname, description, level,
 				age<MINIMUM_AGE
-					?LocalDateTime.of(Main.game.getStartingDate().getYear()-age, birthMonth, (birthMonth==Month.FEBRUARY&&birthDay==29?28:birthDay), 12, 0)
-					:LocalDateTime.of(Main.game.getStartingDate().getYear()-(age-MINIMUM_AGE), birthMonth, (birthMonth==Month.FEBRUARY&&birthDay==29?28:birthDay), 12, 0),
+					?LocalDateTime.of(Main.game.getStartingDate().getYear()-age, birthMonth, Math.min(birthMonth.maxLength(), birthDay), 12, 0)// Why not random hour/minutes?
+					:LocalDateTime.of(Main.game.getStartingDate().getYear()-(age-MINIMUM_AGE), birthMonth, Math.min(birthMonth.maxLength(), birthDay), 12, 0),
 				startingGender, startingSubspecies, stage, inventory, worldLocation, startingPlace);
 		
 		List<NPCGenerationFlag> flags = Arrays.asList(generationFlags);

--- a/src/com/lilithsthrone/game/character/npc/dominion/Cultist.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/Cultist.java
@@ -68,7 +68,7 @@ public class Cultist extends NPC {
 	public Cultist(boolean isImported) {
 		super(isImported, null, null,
 				"",
-				Util.random.nextInt(30)+30, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(30)+30, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				15,
 				Gender.F_P_V_B_FUTANARI,
 				Subspecies.DEMON,

--- a/src/com/lilithsthrone/game/character/npc/dominion/DollFactorySuccubus.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DollFactorySuccubus.java
@@ -63,7 +63,7 @@ public class DollFactorySuccubus extends NPC {
 	public DollFactorySuccubus(boolean isImported) {
 		super(isImported, null, "Loviennemartuilani",
 				"",
-				Util.random.nextInt(50)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(28),
+				Util.random.nextInt(50)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				25,
 				Gender.F_V_B_FEMALE, Subspecies.DEMON, RaceStage.GREATER,
 				new CharacterInventory(false, 10), 

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionAlleywayAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionAlleywayAttacker.java
@@ -65,7 +65,7 @@ public class DominionAlleywayAttacker extends NPC {
 	 */
 	public DominionAlleywayAttacker(Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.DOMINION, PlaceType.DOMINION_BACK_ALLEYS, false,

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionClubNPC.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionClubNPC.java
@@ -40,7 +40,7 @@ public class DominionClubNPC extends NPC {
 	
 	public DominionClubNPC(Gender gender, AbstractSubspecies subspecies, RaceStage raceStage, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.EMPTY, PlaceType.GENERIC_CLUB_HOLDING_CELL, false);

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionExpressCentaur.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionExpressCentaur.java
@@ -60,7 +60,7 @@ public class DominionExpressCentaur extends NPC {
 	public DominionExpressCentaur(Gender gender, Colour collarColour, boolean isImported) {
 		super(isImported,
 				null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.DOMINION_EXPRESS, PlaceType.DOMINION_EXPRESS_STABLES, false);

--- a/src/com/lilithsthrone/game/character/npc/dominion/DominionSuccubusAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/DominionSuccubusAttacker.java
@@ -59,7 +59,7 @@ public class DominionSuccubusAttacker extends NPC {
 	
 	public DominionSuccubusAttacker(boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(50)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(50)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				5, Gender.getGenderFromUserPreferences(Femininity.FEMININE), Subspecies.DEMON, RaceStage.GREATER,
 				new CharacterInventory(false, 10), WorldType.DOMINION, PlaceType.DOMINION_BACK_ALLEYS, false);
 

--- a/src/com/lilithsthrone/game/character/npc/dominion/EnforcerPatrol.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/EnforcerPatrol.java
@@ -71,7 +71,7 @@ public class EnforcerPatrol extends NPC {
 	
 	public EnforcerPatrol(Occupation occupation, Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				5, gender, null, null,
 				new CharacterInventory(false, 10), WorldType.ENFORCER_HQ, PlaceType.ENFORCER_HQ_CELLS_OFFICE, false,
 				generationFlags);

--- a/src/com/lilithsthrone/game/character/npc/dominion/EnforcerWarehouseGuard.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/EnforcerWarehouseGuard.java
@@ -60,7 +60,7 @@ public class EnforcerWarehouseGuard extends NPC {
 	
 	public EnforcerWarehouseGuard(Occupation occupation, AbstractSubspecies subspecies, RaceStage raceStage, Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				5, gender, subspecies, raceStage,
 				new CharacterInventory(false, 10), WorldType.ENFORCER_WAREHOUSE, PlaceType.ENFORCER_WAREHOUSE_ENFORCER_GUARD_POST, false,
 				generationFlags);

--- a/src/com/lilithsthrone/game/character/npc/dominion/HarpyNestsAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/HarpyNestsAttacker.java
@@ -58,7 +58,7 @@ public class HarpyNestsAttacker extends NPC {
 	
 	public HarpyNestsAttacker(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				4,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.HARPY_NEST, PlaceType.HARPY_NESTS_WALKWAYS, false);

--- a/src/com/lilithsthrone/game/character/npc/dominion/ReindeerOverseer.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/ReindeerOverseer.java
@@ -60,7 +60,7 @@ public class ReindeerOverseer extends NPC {
 	
 	public ReindeerOverseer(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				10,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.DOMINION, PlaceType.DOMINION_STREET, false);

--- a/src/com/lilithsthrone/game/character/npc/dominion/SlaveInStocks.java
+++ b/src/com/lilithsthrone/game/character/npc/dominion/SlaveInStocks.java
@@ -52,7 +52,7 @@ public class SlaveInStocks extends NPC {
 	
 	public SlaveInStocks(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.SLAVER_ALLEY, PlaceType.SLAVER_ALLEY_PUBLIC_STOCKS, false);

--- a/src/com/lilithsthrone/game/character/npc/fields/ElisAlleywayAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/ElisAlleywayAttacker.java
@@ -60,7 +60,7 @@ public class ElisAlleywayAttacker extends NPC {
 	 */
 	public ElisAlleywayAttacker(Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/fields/EvelyxMilker.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/EvelyxMilker.java
@@ -64,7 +64,7 @@ public class EvelyxMilker extends NPC {
 
 	public EvelyxMilker(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.DOMINION, PlaceType.DOMINION_BACK_ALLEYS, false);

--- a/src/com/lilithsthrone/game/character/npc/fields/EvelyxSexualPartner.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/EvelyxSexualPartner.java
@@ -53,7 +53,7 @@ public class EvelyxSexualPartner extends NPC {
 
 	public EvelyxSexualPartner(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				25, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				25, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				10,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/fields/FieldsBandit.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/FieldsBandit.java
@@ -55,7 +55,7 @@ public class FieldsBandit extends NPC {
 	 */
 	public FieldsBandit(Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				5,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.EMPTY, PlaceType.GENERIC_HOLDING_CELL, false,

--- a/src/com/lilithsthrone/game/character/npc/fields/LunetteMelee.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/LunetteMelee.java
@@ -76,7 +76,7 @@ public class LunetteMelee extends NPC {
 	public LunetteMelee(List<String> namePrefixes, String name, boolean isImported) {
 		super(isImported,
 				null, null, "",
-				Util.random.nextInt(100)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(100)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				30,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/fields/LunetteRanged.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/LunetteRanged.java
@@ -76,7 +76,7 @@ public class LunetteRanged extends NPC {
 	public LunetteRanged(List<String> namePrefixes, String name, boolean isImported) {
 		super(isImported,
 				null, null, "",
-				Util.random.nextInt(100)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(100)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				30,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/fields/SillyModeLARPAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/fields/SillyModeLARPAttacker.java
@@ -65,7 +65,7 @@ public class SillyModeLARPAttacker extends NPC {
 	 */
 	public SillyModeLARPAttacker(Gender gender, boolean isImported, NPCGenerationFlag... generationFlags) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/misc/BasicDoll.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/BasicDoll.java
@@ -50,7 +50,7 @@ public class BasicDoll extends NPC {
 		super(isImported,
 				new NameTriplet("Doll"), "",
 				"",
-				18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(27),
+				18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				1,
 				null, null, null,
 				new CharacterInventory(false, 0),

--- a/src/com/lilithsthrone/game/character/npc/misc/BasicSlave.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/BasicSlave.java
@@ -50,7 +50,7 @@ public class BasicSlave extends NPC {
 		super(isImported,
 				new NameTriplet("Slave"), "",
 				"",
-				21, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(27),
+				21, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 0),

--- a/src/com/lilithsthrone/game/character/npc/misc/GenericSexualPartner.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/GenericSexualPartner.java
@@ -72,7 +72,7 @@ public class GenericSexualPartner extends NPC {
 	
 	public GenericSexualPartner(Gender gender, AbstractWorldType worldLocation, Vector2i location, boolean isImported, Predicate<AbstractSubspecies> subspeciesRemovalFilter) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/misc/ModdedCharacter.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/ModdedCharacter.java
@@ -58,7 +58,7 @@ public class ModdedCharacter extends NPC {
 
 	public ModdedCharacter(Gender gender, AbstractWorldType worldLocation, Vector2i location, boolean isImported, Predicate<AbstractSubspecies> subspeciesRemovalFilter) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/misc/SlaveForSale.java
+++ b/src/com/lilithsthrone/game/character/npc/misc/SlaveForSale.java
@@ -54,7 +54,7 @@ public class SlaveForSale extends NPC {
 		super(isImported,
 				new NameTriplet("Slave"), "",
 				"",
-				21, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(27),
+				21, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				1,
 				null, null, null,
 				new CharacterInventory(false, 0),

--- a/src/com/lilithsthrone/game/character/npc/submission/BatCavernLurkerAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/BatCavernLurkerAttacker.java
@@ -52,7 +52,7 @@ public class BatCavernLurkerAttacker extends NPC {
 	
 	public BatCavernLurkerAttacker(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.BAT_CAVERNS, PlaceType.BAT_CAVERN_DARK, false);

--- a/src/com/lilithsthrone/game/character/npc/submission/BatCavernSlimeAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/BatCavernSlimeAttacker.java
@@ -49,7 +49,7 @@ public class BatCavernSlimeAttacker extends NPC {
 	
 	public BatCavernSlimeAttacker(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3, gender, Subspecies.HUMAN, RaceStage.HUMAN,
 				new CharacterInventory(false, 10), WorldType.BAT_CAVERNS, PlaceType.BAT_CAVERN_DARK, false);
 

--- a/src/com/lilithsthrone/game/character/npc/submission/GamblingDenPatron.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/GamblingDenPatron.java
@@ -62,7 +62,7 @@ public class GamblingDenPatron extends NPC {
 	
 	public GamblingDenPatron(Gender gender, DicePokerTable table, AbstractWorldType worldType, AbstractPlaceType placeType, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10),

--- a/src/com/lilithsthrone/game/character/npc/submission/ImpAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/ImpAttacker.java
@@ -81,7 +81,7 @@ public class ImpAttacker extends NPC {
 	
 	public ImpAttacker(AbstractSubspecies subspecies, Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3, gender, subspecies, RaceStage.GREATER,
 				new CharacterInventory(false, 10), WorldType.SUBMISSION, PlaceType.SUBMISSION_TUNNELS, false);
 		

--- a/src/com/lilithsthrone/game/character/npc/submission/RatGangMember.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/RatGangMember.java
@@ -64,7 +64,7 @@ public class RatGangMember extends NPC {
 	
 	public RatGangMember(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				5,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.RAT_WARRENS, PlaceType.RAT_WARRENS_VENGARS_HALL, false);

--- a/src/com/lilithsthrone/game/character/npc/submission/RatWarrensCaptive.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/RatWarrensCaptive.java
@@ -70,7 +70,7 @@ public class RatWarrensCaptive extends NPC {
 	
 	public RatWarrensCaptive(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				5,
 				gender, Subspecies.HUMAN, RaceStage.HUMAN,
 				new CharacterInventory(false, 10), WorldType.RAT_WARRENS, PlaceType.RAT_WARRENS_MILKING_ROOM, false);

--- a/src/com/lilithsthrone/game/character/npc/submission/RebelBaseInsaneSurvivor.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/RebelBaseInsaneSurvivor.java
@@ -71,7 +71,7 @@ public class RebelBaseInsaneSurvivor extends NPC {
     
     public RebelBaseInsaneSurvivor(Gender gender, boolean isImported) {
         super(isImported, null, null, "",
-				(Main.game.getDateNow().getYear() - RECRUITMENT_YEAR) + 18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				(Main.game.getDateNow().getYear() - RECRUITMENT_YEAR) + 18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				5,
 				gender, Subspecies.HUMAN, RaceStage.HUMAN,
 				new CharacterInventory(false, 10), WorldType.REBEL_BASE, PlaceType.REBEL_BASE_SLEEPING_AREA, false);

--- a/src/com/lilithsthrone/game/character/npc/submission/SubmissionAttacker.java
+++ b/src/com/lilithsthrone/game/character/npc/submission/SubmissionAttacker.java
@@ -66,7 +66,7 @@ public class SubmissionAttacker extends NPC {
 	 */
 	public SubmissionAttacker(Gender gender, boolean isImported) {
 		super(isImported, null, null, "",
-				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(25),
+				Util.random.nextInt(28)+18, Util.randomItemFrom(Month.values()), 1+Util.random.nextInt(30),
 				3,
 				null, null, null,
 				new CharacterInventory(false, 10), WorldType.SUBMISSION, PlaceType.SUBMISSION_TUNNELS, false);


### PR DESCRIPTION
Changed Birthday's for any NPC with random birthday to do 1-31 days, then clamping it to the birth month's day limit in NPC

- What is the purpose of the pull request?
Change birthday to be able to be any day of a month, I found it weird the days were never 29th/30th

- Give a brief description of what you changed or added.
Changed all 1+Util.random.nextInt(25) / 1+Util.random.nextInt(26) / 1+Util.random.nextInt(27) in birthday declarations for NPCs to 1+Util.random.nextInt(30), 
and in NPC.java changed (birthMonth == Month.FEBRUARY && birthDay==29?28:birthDay) to Math.min(birthMonth.maxLength(), birthDay)

- Are any new graphical assets required?
nada

- Has this change been tested? If so, mention the version number that the test was based on.
Yes, 0.4.11

- So we have a better idea of who you are, what is your Discord Handle?
@keldonslayer
